### PR TITLE
Ignore formatting on GitHub markdown.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 ## Checklist
 
-- [ ] The PR conforms to DataHub's
-      [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly
-      [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
+- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
 - [ ] Links to related issues (if applicable)
 - [ ] Tests for the changes have been added/updated (if applicable)
 - [ ] Docs related to the changes have been added/updated (if applicable)

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ subprojects { sp ->
 spotless {
   format 'md', {
     target '**/*.md'
-    targetExclude '.github' // GitHub renders these documents differently...
+    targetExclude '.github/**' // GitHub renders these documents differently...
     prettier().config([printWidth: 120, proseWrap: 'always'])
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -149,10 +149,9 @@ subprojects { sp ->
 }
 
 spotless {
-  // TODO Format Java
-
   format 'md', {
     target '**/*.md'
+    targetExclude '.github' // GitHub renders these documents differently...
     prettier().config([printWidth: 120, proseWrap: 'always'])
   }
 }


### PR DESCRIPTION
It is rendered too differently from the rest of markdown for spotless to handle it. Whitespace is respected, which most markdown renderers don't do.

See below for how formatting is bad:

## Checklist

- [ ] The PR conforms to DataHub's
      [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly
      [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
