### PR TITLE
fix: apply checkstyle JavaDoc checks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects { sp ->
     checkstyle {
       configDirectory = file("${project.rootDir}/gradle/checkstyle")
       sourceSets = [ getProject().sourceSets.main, getProject().sourceSets.test ]
-      toolVersion = "8.0"
+      toolVersion = "8.35"
       maxWarnings = 0
       ignoreFailures = false
     }

--- a/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
+++ b/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
@@ -171,7 +171,7 @@ public class Neo4jUtil {
   /**
    * Converts path segment (field:value map) list of {@link RecordTemplate}s of nodes and edges.
    *
-   * @param segment The segment of a path containing nodes & edges
+   * @param segment the segment of a path containing nodes and edges
    */
   @Nonnull
   public static List<RecordTemplate> pathSegmentToRecordList(@Nonnull Path.Segment segment) {

--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -10,10 +10,17 @@ LinkedIn Java style.
   <property name="severity" value="warning"/>
   <property name="fileExtensions" value="java"/>
 
+  <!-- LENGTHS -->
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="160"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
   <module name="TreeWalker">
     <property name="tabWidth" value="2"/>
     <module name="SuppressWarningsHolder"/>
-    <module name="FileContentsHolder"/>
 
     <!-- ANNOTATIONS -->
 
@@ -95,8 +102,44 @@ LinkedIn Java style.
     <!-- JAVADOC COMMENTS -->
 
     <!-- If you have a Javadoc comment, make sure it is properly formed -->
-    <module name="JavadocStyle">
-      <property name="checkFirstSentence" value="false"/>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+                value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+    </module>
+    <module name="JavadocParagraph"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
+    <module name="JavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+    </module>
+    <!--    TODO enable missing doc checks -->
+    <!--    <module name="MissingJavadocMethod">-->
+    <!--      <property name="scope" value="public"/>-->
+    <!--      <property name="minLineCount" value="2"/>-->
+    <!--      <property name="allowedAnnotations" value="Override, Test"/>-->
+    <!--      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,-->
+    <!--                                   COMPACT_CTOR_DEF"/>-->
+    <!--    </module>-->
+    <!--    <module name="MissingJavadocType">-->
+    <!--      <property name="scope" value="public"/>-->
+    <!--    </module>-->
+    <module name="JavadocType">
+      <property name="allowMissingParamTags" value="true"/>
+    </module>
+    <module name="SingleLineJavadoc">
+      <property name="ignoreInlineTags" value="false"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
     </module>
 
     <!-- NAMING CONVENTIONS -->
@@ -135,14 +178,6 @@ LinkedIn Java style.
     <!-- Type names must be camel case starting with an uppercase letter -->
     <module name="TypeName"/>
 
-    <!-- LENGTHS -->
-
-    <!-- Desired line length is 120 but allow some overrun beyond that -->
-    <module name="LineLength">
-      <property name="max" value="160"/>
-      <message key="maxLineLen" value="Line is longer than {0,number,integer} characters (found {1,number,integer}). Try to keep lines under 120 characters."/>
-    </module>
-
     <!-- WHITESPACE -->
 
     <module name="GenericWhitespace"/>
@@ -164,6 +199,11 @@ LinkedIn Java style.
       <property name="format" value="[\s]+arg[\d]+[,\)]"/>
       <property name="message" value="Replace argN with a meaningful parameter name"/>
     </module>
+
+    <!-- Allow Checkstyle warnings to be suppressed using trailing comments -->
+    <module name="SuppressWithNearbyCommentFilter"/>
+    <!-- Allow Checkstyle warnings to be suppressed using block comments -->
+    <module name="SuppressionCommentFilter"/>
   </module>
 
   <!-- Do not allow tab characters in source files -->
@@ -189,10 +229,6 @@ LinkedIn Java style.
   <module name="SuppressionFilter">
     <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
-  <!-- Allow Checkstyle warnings to be suppressed using trailing comments -->
-  <module name="SuppressWithNearbyCommentFilter"/>
-  <!-- Allow Checkstyle warnings to be suppressed using block comments -->
-  <module name="SuppressionCommentFilter"/>
   <!-- Allow SuppressWarnings annotation to suppress Checkstyle issues -->
   <module name="SuppressWarningsFilter"/>
 </module>

--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -22,6 +22,7 @@ javadoc {
   exclude 'com/linkedin/metadata/query/**'
 
   // We don't care about most of these warnings; we're fine with no @return or missing @param if they don't add value.
+  // We'll check the things we care about in checkstyle.
   javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 }
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -150,7 +150,7 @@ public abstract class BaseEntityResource<
   }
 
   /**
-   * Similar to {@link #get(KEY, String[])} but for multiple entities.
+   * Similar to {@link #get(Object, String[])} but for multiple entities.
    */
   @RestMethod.BatchGet
   @Nonnull

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntityResource.java
@@ -64,7 +64,7 @@ public abstract class BaseSingleAspectEntityResource<
   }
 
   /**
-   * Takes a partial entity created by {@link #createPartialEntityFromAspect(ASPECT)} and the urn and
+   * Takes a partial entity created by {@link #createPartialEntityFromAspect(RecordTemplate)} and the urn and
    * creates the complete entity value.
    *
    * @param partialEntity the partial entity.

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntityVersionedSubResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntityVersionedSubResource.java
@@ -68,7 +68,7 @@ public abstract class BaseSingleAspectEntityVersionedSubResource<
   protected abstract URN getUrn(@Nonnull PathKeys entityPathKeys);
 
   /**
-   * Takes a partial entity created by {@link #createPartialEntityFromAspect(ASPECT)} and the urn and
+   * Takes a partial entity created by {@link #createPartialEntityFromAspect(RecordTemplate)} and the urn and
    * creates the complete entity value.
    *
    * @param partialEntity the partial entity.

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntityResource.java
@@ -58,7 +58,7 @@ public abstract class BaseSingleAspectSearchableEntityResource<
   }
 
   /**
-   * Takes a partial entity created by {@link #createPartialEntityFromAspect(ASPECT)} and the urn and
+   * Takes a partial entity created by {@link #createPartialEntityFromAspect(RecordTemplate)} and the urn and
    * creates the complete entity value.
    *
    * @param partialEntity the partial entity.


### PR DESCRIPTION
This should ensure our javadoc is actually valid HTML, and adheres to a slightly stricter style (taken from Google's).

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
