### PR TITLE
fix: enable javadoc warnings

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -386,7 +386,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   public abstract List<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize);
 
   /**
-   * Similar to {@link #listUrns(IndexFilter, URN, int)}. This is to get all urns with type URN.
+   * Similar to {@link #listUrns(IndexFilter, Urn, int)}. This is to get all urns with type URN.
    */
   @Nonnull
   public List<URN> listUrns(@Nonnull Class<URN> urnClazz, @Nullable URN lastUrn, int pageSize) {
@@ -468,7 +468,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull Class<ASPECT> aspectClass);
 
   /**
-   * Saves an aspect for an entity with specific version & {@link AuditStamp}.
+   * Saves an aspect for an entity with specific version and {@link AuditStamp}.
    *
    * @param urn {@link Urn} for the entity
    * @param value the aspect to save

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/internal/BaseGraphWriterDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/internal/BaseGraphWriterDAO.java
@@ -26,7 +26,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param entity the entity to be persisted
    * @param <ENTITY> entity type. Must be a type defined in com.linkedin.metadata.entity.
-   * @throws Exception
    */
   public <ENTITY extends RecordTemplate> void addEntity(@Nonnull ENTITY entity) throws Exception {
     addEntities(Collections.singletonList(entity));
@@ -37,7 +36,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param entities the list of entities to be persisted
    * @param <ENTITY> entity type. Must be a type defined in com.linkedin.metadata.entity.
-   * @throws Exception
    */
   public abstract <ENTITY extends RecordTemplate> void addEntities(@Nonnull List<ENTITY> entities) throws Exception;
 
@@ -46,7 +44,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param urn the URN of the entity to be removed
    * @param <URN> URN type of the entity
-   * @throws Exception
    */
   public <URN extends Urn> void removeEntity(@Nonnull URN urn) throws Exception {
     removeEntities(Collections.singletonList(urn));
@@ -57,7 +54,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param urns the URNs of the entities to be removed
    * @param <URN> URN type of the entity
-   * @throws Exception
    */
   public abstract <URN extends Urn> void removeEntities(@Nonnull List<URN> urns) throws Exception;
 
@@ -66,7 +62,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param relationship the relationship to be persisted
    * @param <RELATIONSHIP> relationship type. Must be a type defined in com.linkedin.metadata.relationship.
-   * @throws Exception
    */
   public <RELATIONSHIP extends RecordTemplate> void addRelationship(@Nonnull RELATIONSHIP relationship)
       throws Exception {
@@ -79,7 +74,6 @@ public abstract class BaseGraphWriterDAO {
    * @param relationship the relationship to be persisted
    * @param removalOption whether to remove existing relationship of the same type
    * @param <RELATIONSHIP> relationship type. Must be a type defined in com.linkedin.metadata.relationship.
-   * @throws Exception
    */
   public <RELATIONSHIP extends RecordTemplate> void addRelationship(@Nonnull RELATIONSHIP relationship,
       @Nonnull RemovalOption removalOption) throws Exception {
@@ -91,7 +85,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param relationships the list of relationships to be persisted
    * @param <RELATIONSHIP> relationship type. Must be a type defined in com.linkedin.metadata.relationship.
-   * @throws Exception
    */
   public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships)
       throws Exception {
@@ -104,7 +97,6 @@ public abstract class BaseGraphWriterDAO {
    * @param relationships the list of relationships to be persisted
    * @param removalOption whether to remove existing relationship of the same type
    * @param <RELATIONSHIP> relationship type. Must be a type defined in com.linkedin.metadata.relationship.
-   * @throws Exception
    */
   public abstract <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
       @Nonnull RemovalOption removalOption) throws Exception;
@@ -114,7 +106,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param relationship the relationship to be removed
    * @param <RELATIONSHIP> relationship type. Must be a type defined in com.linkedin.metadata.relationship.
-   * @throws Exception
    */
   public <RELATIONSHIP extends RecordTemplate> void removeRelationship(@Nonnull RELATIONSHIP relationship)
       throws Exception {
@@ -126,7 +117,6 @@ public abstract class BaseGraphWriterDAO {
    *
    * @param relationships the list of relationships to be removed
    * @param <RELATIONSHIP> relationship type. Must be a type defined in com.linkedin.metadata.relationship.
-   * @throws Exception
    */
   public abstract <RELATIONSHIP extends RecordTemplate> void removeRelationships(
       @Nonnull List<RELATIONSHIP> relationships) throws Exception;

--- a/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jQueryDAO.java
+++ b/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jQueryDAO.java
@@ -64,7 +64,6 @@ public class Neo4jQueryDAO extends BaseQueryDAO {
    * Similar to other free form APIs, such as findEntities, findRelationships, findMixedTypesEntities, etc.
    * findPaths should be used when there is a specific need to query the graph DB and no existing APIs could be used.
    *
-   * @param queryStatement
    * @return A list of paths, each of which should be [Node1, Edge1, Node2, Edge2, ....]
    */
   @Nonnull

--- a/gradle/java-publishing.gradle
+++ b/gradle/java-publishing.gradle
@@ -21,9 +21,9 @@ javadoc {
   // TODO Don't generate javadoc for some PDL Java files for now. https://github.com/linkedin/rest.li/issues/432
   exclude 'com/linkedin/metadata/query/**'
 
-  // We don't care about most of these warnings; we're fine with no @return or missing @param if they don't add value.
-  // We'll check the things we care about in checkstyle.
-  javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+  // We don't care about missing warnings; we're fine with no @return or missing @param if they don't add value.
+  options.addStringOption('Xdoclint:all,-missing', '-quiet')
+  options.addStringOption('Xwerror', '-quiet')
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
My previous RB for this I thought fixed it via checkstyle, but it did not. We need both checks, turns out.

I've turned on all warnings except missing warnings, we don't care about missing @tags if they don't add value.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
