### PR TITLE
feat: Make max aggregation bucket size configurable

### DIFF
--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
@@ -63,6 +63,7 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
   private BaseSearchConfig<DOCUMENT> _config;
   private BaseESAutoCompleteQuery _autoCompleteQueryForLowCardFields;
   private BaseESAutoCompleteQuery _autoCompleteQueryForHighCardFields;
+  private int _maxTermBucketSize = DEFAULT_TERM_BUCKETS_SIZE_100;
 
   // TODO: Currently takes elastic search client, in future, can take other clients such as galene
   // TODO: take params and settings needed to create the client
@@ -255,7 +256,7 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
       @Nullable Filter filter) {
     Set<String> facetFields = _config.getFacetFields();
     for (String facet : facetFields) {
-      AggregationBuilder aggBuilder = AggregationBuilders.terms(facet).field(facet).size(DEFAULT_TERM_BUCKETS_SIZE_100);
+      AggregationBuilder aggBuilder = AggregationBuilders.terms(facet).field(facet).size(_maxTermBucketSize);
       Optional.ofNullable(filter).map(Filter::getCriteria).ifPresent(criteria -> {
         for (Criterion criterion : criteria) {
           if (!facetFields.contains(criterion.getField()) || criterion.getField().equals(facet)) {
@@ -446,5 +447,17 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
     } catch (URISyntaxException e) {
       throw new RuntimeException("Invalid urn in search document " + e);
     }
+  }
+
+  /**
+   * Sets max term bucket size in the aggregation results.
+   *
+   * <p>The default value might not always be good enough when aggregation happens on a high cardinality field.
+   * Using a high default instead is also not ideal because of potential query performance degradation.
+   * Instead, entities which have a rare use case of aggregating over high cardinality fields can use this method
+   * to configure the aggregation behavior.
+   */
+  public void setMaxTermBucketSize(int maxTermBucketSize) {
+    _maxTermBucketSize = maxTermBucketSize;
   }
 }

--- a/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
+++ b/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -212,6 +213,25 @@ public class ESSearchDAOTest {
     String preference = "urn:li:servicePrincipal:appName";
     SearchRequest searchRequest = _searchDAO.constructSearchQuery(input, filter, null, preference, 0, 10);
     assertEquals(searchRequest.preference(), preference);
+  }
+
+  @Test
+  public void testDefaultMaxTermBucketSize() {
+    String facetFieldName = "value";
+    Filter filter = QueryUtils.newFilter(Collections.singletonMap(facetFieldName, "dummy"));
+    SearchRequest searchRequest = _searchDAO.constructSearchQuery("dummy", filter, null, null, 0, 10);
+    assertEquals(searchRequest.source().aggregations().getAggregatorFactories().iterator().next(),
+        AggregationBuilders.terms(facetFieldName).field(facetFieldName).size(100));
+  }
+
+  @Test
+  public void testSetMaxTermBucketSize() {
+    String facetFieldName = "value";
+    Filter filter = QueryUtils.newFilter(Collections.singletonMap(facetFieldName, "dummy"));
+    _searchDAO.setMaxTermBucketSize(5);
+    SearchRequest searchRequest = _searchDAO.constructSearchQuery("dummy", filter, null, null, 0, 10);
+    assertEquals(searchRequest.source().aggregations().getAggregatorFactories().iterator().next(),
+        AggregationBuilders.terms(facetFieldName).field(facetFieldName).size(5));
   }
 
   private static SearchHit makeSearchHit(int id) {

--- a/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
+++ b/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
@@ -2,7 +2,6 @@ package com.linkedin.metadata.dao.search;
 
 import com.linkedin.testing.EntityDocument;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -10,7 +9,7 @@ public class TestSearchConfig extends BaseSearchConfig<EntityDocument> {
   @Override
   @Nonnull
   public Set<String> getFacetFields() {
-    return Collections.unmodifiableSet(new HashSet<>());
+    return Collections.singleton("value");
   }
 
   @Override

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
@@ -55,13 +55,13 @@ import static com.linkedin.metadata.dao.utils.SearchUtils.*;
 @Slf4j
 public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<DOCUMENT> {
 
-  private static final Integer DEFAULT_TERM_BUCKETS_SIZE_100 = 100;
   private static final String URN_FIELD = "urn";
 
   private RestHighLevelClient _client;
   private BaseSearchConfig<DOCUMENT> _config;
   private BaseESAutoCompleteQuery _autoCompleteQueryForLowCardFields;
   private BaseESAutoCompleteQuery _autoCompleteQueryForHighCardFields;
+  private int _maxTermBucketSize = 100;
 
   // TODO: Currently takes elastic search client, in future, can take other clients such as galene
   // TODO: take params and settings needed to create the client
@@ -254,7 +254,7 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
       @Nullable Filter filter) {
     Set<String> facetFields = _config.getFacetFields();
     for (String facet : facetFields) {
-      AggregationBuilder aggBuilder = AggregationBuilders.terms(facet).field(facet).size(DEFAULT_TERM_BUCKETS_SIZE_100);
+      AggregationBuilder aggBuilder = AggregationBuilders.terms(facet).field(facet).size(_maxTermBucketSize);
       Optional.ofNullable(filter).map(Filter::getCriteria).ifPresent(criteria -> {
         for (Criterion criterion : criteria) {
           if (!facetFields.contains(criterion.getField()) || criterion.getField().equals(facet)) {
@@ -445,5 +445,17 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
     } catch (URISyntaxException e) {
       throw new RuntimeException("Invalid urn in search document " + e);
     }
+  }
+
+  /**
+   * Sets max term bucket size in the aggregation results.
+   *
+   * <p>The default value might not always be good enough when aggregation happens on a high cardinality field.
+   * Using a high default instead is also not ideal because of potential query performance degradation.
+   * Instead, entities which have a rare use case of aggregating over high cardinality fields can use this method
+   * to configure the aggregation behavior.
+   */
+  public void setMaxTermBucketSize(int maxTermBucketSize) {
+    _maxTermBucketSize = maxTermBucketSize;
   }
 }

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
@@ -55,13 +55,14 @@ import static com.linkedin.metadata.dao.utils.SearchUtils.*;
 @Slf4j
 public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<DOCUMENT> {
 
+  private static final Integer DEFAULT_TERM_BUCKETS_SIZE_100 = 100;
   private static final String URN_FIELD = "urn";
 
   private RestHighLevelClient _client;
   private BaseSearchConfig<DOCUMENT> _config;
   private BaseESAutoCompleteQuery _autoCompleteQueryForLowCardFields;
   private BaseESAutoCompleteQuery _autoCompleteQueryForHighCardFields;
-  private int _maxTermBucketSize = 100;
+  private int _maxTermBucketSize = DEFAULT_TERM_BUCKETS_SIZE_100;
 
   // TODO: Currently takes elastic search client, in future, can take other clients such as galene
   // TODO: take params and settings needed to create the client

--- a/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
+++ b/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
@@ -214,18 +214,20 @@ public class ESSearchDAOTest {
   }
 
   @Test
-  public void testSetMaxTermBucketSize() {
+  public void testDefaultMaxTermBucketSize() {
     String facetFieldName = "value";
     Filter filter = QueryUtils.newFilter(Collections.singletonMap(facetFieldName, "dummy"));
-
-    // Default max term bucket size
     SearchRequest searchRequest = _searchDAO.constructSearchQuery("dummy", filter, null, null, 0, 10);
     assertEquals(searchRequest.source().aggregations().getAggregatorFactories().get(0),
         AggregationBuilders.terms(facetFieldName).field(facetFieldName).size(100));
+  }
 
-    // Modified max term bucket size
+  @Test
+  public void testSetMaxTermBucketSize() {
+    String facetFieldName = "value";
+    Filter filter = QueryUtils.newFilter(Collections.singletonMap(facetFieldName, "dummy"));
     _searchDAO.setMaxTermBucketSize(5);
-    searchRequest = _searchDAO.constructSearchQuery("dummy", filter, null, null, 0, 10);
+    SearchRequest searchRequest = _searchDAO.constructSearchQuery("dummy", filter, null, null, 0, 10);
     assertEquals(searchRequest.source().aggregations().getAggregatorFactories().get(0),
         AggregationBuilders.terms(facetFieldName).field(facetFieldName).size(5));
   }

--- a/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
+++ b/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -210,6 +211,23 @@ public class ESSearchDAOTest {
     String preference = "urn:li:servicePrincipal:appName";
     SearchRequest searchRequest = _searchDAO.constructSearchQuery(input, filter, null, preference, 0, 10);
     assertEquals(searchRequest.preference(), preference);
+  }
+
+  @Test
+  public void testSetMaxTermBucketSize() {
+    String facetFieldName = "value";
+    Filter filter = QueryUtils.newFilter(Collections.singletonMap(facetFieldName, "dummy"));
+
+    // Default max term bucket size
+    SearchRequest searchRequest = _searchDAO.constructSearchQuery("dummy", filter, null, null, 0, 10);
+    assertEquals(searchRequest.source().aggregations().getAggregatorFactories().get(0),
+        AggregationBuilders.terms(facetFieldName).field(facetFieldName).size(100));
+
+    // Modified max term bucket size
+    _searchDAO.setMaxTermBucketSize(5);
+    searchRequest = _searchDAO.constructSearchQuery("dummy", filter, null, null, 0, 10);
+    assertEquals(searchRequest.source().aggregations().getAggregatorFactories().get(0),
+        AggregationBuilders.terms(facetFieldName).field(facetFieldName).size(5));
   }
 
   private static SearchHit makeSearchHit(int id) {

--- a/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
+++ b/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
@@ -2,7 +2,6 @@ package com.linkedin.metadata.dao.search;
 
 import com.linkedin.testing.EntityDocument;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -10,7 +9,7 @@ public class TestSearchConfig extends BaseSearchConfig<EntityDocument> {
   @Override
   @Nonnull
   public Set<String> getFacetFields() {
-    return Collections.unmodifiableSet(new HashSet<>());
+    return Collections.singleton("value");
   }
 
   @Override

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDocument.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDocument.pdl
@@ -11,4 +11,9 @@ record EntityDocument {
    * For unit tests
    */
   urn: Urn
+
+  /**
+   * For unit tests
+   */
+  value: optional string
 }


### PR DESCRIPTION
The default value of `DEFAULT_TERM_BUCKETS_SIZE_100` in `ESSearchDAO` might not always be good enough when aggregation happens on a high cardinality field. Using a high default instead is also not ideal because of potential query performance degradation. Instead, entities which have a rare use case of aggregating over high cardinality fields can use new setter method to override this default.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
