### PR TITLE
fix: do not split value of a filter by comma for an urn

### DIFF
--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -47,17 +47,20 @@ public class SearchUtils {
   /**
    * Builds search query given a {@link Criterion}, containing field, value and association/condition between the two.
    *
-   * <p> If the condition between a field and value (specified in {@link Criterion}) is EQUAL, we construct a Terms query.
+   * <p>If the condition between a field and value (specified in {@link Criterion}) is EQUAL, we construct a Terms query.
    * In this case, a field can take multiple values, specified using comma as a delimiter - this method will split
    * tokens accordingly. This is done because currently there is no support of associating two different {@link Criterion}
    * in a {@link Filter} with an OR operator - default operator is AND.
+   *
+   * <p>This approach of supporting multiple values using comma as delimiter, prevents us from specifying a value that has comma
+   * as one of it's characters. This is particularly true when one of the values is an urn e.g. "urn:li:example:(1,2,3)".
+   * Hence we do not split the value (using comma as delimiter) if the value starts with "urn:li:".
    * TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using delimiters like comma.
    *
-   * <p> If the condition between a field and value is not the same as EQUAL, a Range query is constructed. This
+   * <p>If the condition between a field and value is not the same as EQUAL, a Range query is constructed. This
    * condition does not support multiple values for the same field.
    *
    * @param criterion {@link Criterion} single criterion which contains field, value and a comparison operator
-   * @return QueryBuilder
    */
   @Nonnull
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {

--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -1,12 +1,10 @@
 package com.linkedin.metadata.dao.utils;
 
-import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
 import com.linkedin.metadata.query.Filter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -56,12 +54,10 @@ public class SearchUtils {
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {
     final Condition condition = criterion.getCondition();
     if (condition == Condition.EQUAL) {
-      try {
-        Urn.createFromString(criterion.getValue());
+      if (criterion.getValue().startsWith("urn:li:")) {
         return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim());
-      } catch (URISyntaxException e) {
-        return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
       }
+      return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
     } else if (condition == Condition.GREATER_THAN) {
       return QueryBuilders.rangeQuery(criterion.getField()).gt(criterion.getValue().trim());
     } else if (condition == Condition.GREATER_THAN_OR_EQUAL_TO) {

--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -1,10 +1,12 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
 import com.linkedin.metadata.query.Filter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -54,7 +56,12 @@ public class SearchUtils {
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {
     final Condition condition = criterion.getCondition();
     if (condition == Condition.EQUAL) {
-      return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
+      try {
+        Urn.createFromString(criterion.getValue());
+        return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim());
+      } catch (URISyntaxException e) {
+        return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
+      }
     } else if (condition == Condition.GREATER_THAN) {
       return QueryBuilders.rangeQuery(criterion.getField()).gt(criterion.getValue().trim());
     } else if (condition == Condition.GREATER_THAN_OR_EQUAL_TO) {

--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -45,7 +45,16 @@ public class SearchUtils {
   }
 
   /**
-   * Builds search query using criterion.
+   * Builds search query given a {@link Criterion}, containing field, value and association/condition between the two.
+   *
+   * <p> If the condition between a field and value (specified in {@link Criterion}) is EQUAL, we construct a Terms query.
+   * In this case, a field can take multiple values, specified using comma as a delimiter - this method will split
+   * tokens accordingly. This is done because currently there is no support of associating two different {@link Criterion}
+   * in a {@link Filter} with an OR operator - default operator is AND.
+   * TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using delimiters like comma.
+   *
+   * <p> If the condition between a field and value is not the same as EQUAL, a Range query is constructed. This
+   * condition does not support multiple values for the same field.
    *
    * @param criterion {@link Criterion} single criterion which contains field, value and a comparison operator
    * @return QueryBuilder

--- a/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
+++ b/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
@@ -178,6 +178,18 @@ public class ESSearchDAOTest {
   }
 
   @Test
+  public void testFilteredQueryWithUrnValue() throws IOException {
+    int from = 0;
+    int size = 10;
+    Filter filter = newFilter(ImmutableMap.of("key1", "value1, value2 ", "key2", "urn:li:entity:(foo,bar,baz)"));
+    SortCriterion sortCriterion = new SortCriterion().setOrder(SortOrder.ASCENDING).setField("urn");
+
+    SearchRequest searchRequest = _searchDAO.getFilteredSearchQuery(filter, sortCriterion, from, size);
+    assertEquals(searchRequest.source().toString(), loadJsonFromResource("UrnFilterQuery.json"));
+    assertEquals(searchRequest.indices(), new String[]{_testSearchConfig.getIndexName()});
+  }
+
+  @Test
   public void testFilteredQueryWithRangeFilter() throws IOException {
     int from = 0;
     int size = 10;

--- a/dao-impl/elasticsearch-dao-7/src/test/resources/UrnFilterQuery.json
+++ b/dao-impl/elasticsearch-dao-7/src/test/resources/UrnFilterQuery.json
@@ -1,0 +1,36 @@
+{
+  "from" : 0,
+  "size" : 10,
+  "query" : {
+    "bool" : {
+      "filter" : [
+        {
+          "terms" : {
+            "key1" : [
+              "value1",
+              "value2"
+            ],
+            "boost" : 1.0
+          }
+        },
+        {
+          "terms" : {
+            "key2" : [
+              "urn:li:entity:(foo,bar,baz)"
+            ],
+            "boost" : 1.0
+          }
+        }
+      ],
+      "adjust_pure_negative" : true,
+      "boost" : 1.0
+    }
+  },
+  "sort" : [
+    {
+      "urn" : {
+        "order" : "asc"
+      }
+    }
+  ]
+}

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -47,17 +47,20 @@ public class SearchUtils {
   /**
    * Builds search query given a {@link Criterion}, containing field, value and association/condition between the two.
    *
-   * <p> If the condition between a field and value (specified in {@link Criterion}) is EQUAL, we construct a Terms query.
+   * <p>If the condition between a field and value (specified in {@link Criterion}) is EQUAL, we construct a Terms query.
    * In this case, a field can take multiple values, specified using comma as a delimiter - this method will split
    * tokens accordingly. This is done because currently there is no support of associating two different {@link Criterion}
    * in a {@link Filter} with an OR operator - default operator is AND.
+   *
+   * <p>This approach of supporting multiple values using comma as delimiter, prevents us from specifying a value that has comma
+   * as one of it's characters. This is particularly true when one of the values is an urn e.g. "urn:li:example:(1,2,3)".
+   * Hence we do not split the value (using comma as delimiter) if the value starts with "urn:li:".
    * TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using delimiters like comma.
    *
-   * <p> If the condition between a field and value is not the same as EQUAL, a Range query is constructed. This
+   * <p>If the condition between a field and value is not the same as EQUAL, a Range query is constructed. This
    * condition does not support multiple values for the same field.
    *
    * @param criterion {@link Criterion} single criterion which contains field, value and a comparison operator
-   * @return QueryBuilder
    */
   @Nonnull
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -1,12 +1,10 @@
 package com.linkedin.metadata.dao.utils;
 
-import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
 import com.linkedin.metadata.query.Filter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -56,12 +54,10 @@ public class SearchUtils {
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {
     final Condition condition = criterion.getCondition();
     if (condition == Condition.EQUAL) {
-      try {
-        Urn.createFromString(criterion.getValue());
+      if (criterion.getValue().startsWith("urn:li:")) {
         return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim());
-      } catch (URISyntaxException e) {
-        return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
       }
+      return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
     } else if (condition == Condition.GREATER_THAN) {
       return QueryBuilders.rangeQuery(criterion.getField()).gt(criterion.getValue().trim());
     } else if (condition == Condition.GREATER_THAN_OR_EQUAL_TO) {

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -1,10 +1,12 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
 import com.linkedin.metadata.query.Filter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -54,7 +56,12 @@ public class SearchUtils {
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {
     final Condition condition = criterion.getCondition();
     if (condition == Condition.EQUAL) {
-      return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
+      try {
+        Urn.createFromString(criterion.getValue());
+        return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim());
+      } catch (URISyntaxException e) {
+        return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));
+      }
     } else if (condition == Condition.GREATER_THAN) {
       return QueryBuilders.rangeQuery(criterion.getField()).gt(criterion.getValue().trim());
     } else if (condition == Condition.GREATER_THAN_OR_EQUAL_TO) {

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -45,7 +45,16 @@ public class SearchUtils {
   }
 
   /**
-   * Builds search query using criterion.
+   * Builds search query given a {@link Criterion}, containing field, value and association/condition between the two.
+   *
+   * <p> If the condition between a field and value (specified in {@link Criterion}) is EQUAL, we construct a Terms query.
+   * In this case, a field can take multiple values, specified using comma as a delimiter - this method will split
+   * tokens accordingly. This is done because currently there is no support of associating two different {@link Criterion}
+   * in a {@link Filter} with an OR operator - default operator is AND.
+   * TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using delimiters like comma.
+   *
+   * <p> If the condition between a field and value is not the same as EQUAL, a Range query is constructed. This
+   * condition does not support multiple values for the same field.
    *
    * @param criterion {@link Criterion} single criterion which contains field, value and a comparison operator
    * @return QueryBuilder

--- a/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
+++ b/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
@@ -176,6 +176,18 @@ public class ESSearchDAOTest {
   }
 
   @Test
+  public void testFilteredQueryWithUrnValue() throws IOException {
+    int from = 0;
+    int size = 10;
+    Filter filter = newFilter(ImmutableMap.of("key1", "value1, value2 ", "key2", "urn:li:entity:(foo,bar,baz)"));
+    SortCriterion sortCriterion = new SortCriterion().setOrder(SortOrder.ASCENDING).setField("urn");
+
+    SearchRequest searchRequest = _searchDAO.getFilteredSearchQuery(filter, sortCriterion, from, size);
+    assertEquals(searchRequest.source().toString(), loadJsonFromResource("UrnFilterQuery.json"));
+    assertEquals(searchRequest.indices(), new String[]{_testSearchConfig.getIndexName()});
+  }
+
+  @Test
   public void testFilteredQueryWithRangeFilter() throws IOException {
     int from = 0;
     int size = 10;

--- a/dao-impl/elasticsearch-dao/src/test/resources/UrnFilterQuery.json
+++ b/dao-impl/elasticsearch-dao/src/test/resources/UrnFilterQuery.json
@@ -1,0 +1,37 @@
+{
+  "from" : 0,
+  "size" : 10,
+  "query" : {
+    "bool" : {
+      "filter" : [
+        {
+          "terms" : {
+            "key1" : [
+              "value1",
+              "value2"
+            ],
+            "boost" : 1.0
+          }
+        },
+        {
+          "terms" : {
+            "key2" : [
+              "urn:li:entity:(foo,bar,baz)"
+            ],
+            "boost" : 1.0
+          }
+        }
+      ],
+      "disable_coord" : false,
+      "adjust_pure_negative" : true,
+      "boost" : 1.0
+    }
+  },
+  "sort" : [
+    {
+      "urn" : {
+        "order" : "asc"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Currently clients are using `comma` to provide multiple values a key can take while issuing filtered search query. Elasticsearch DAO splits the value by comma delimiter to populate the `terms` query. This does not work well when the value is an `Urn` with comma as some of the characters.
This change ensure we do not split the value by comma when the value is an Urn. Ideally we should be using the `OR` criterion to provide multiple values a key can take. But this will need changes on the client side before we stop supporting the `comma` feature to specify multiple values on the DAO side.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
