### PR TITLE
feat: update local publish scripts to publish a SNAPSHOT version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     classpath 'com.linkedin.pegasus:gradle-plugins:' + pegasusVersion
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.2.RELEASE'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
-    classpath "org.shipkit:shipkit-auto-version:0.0.48"
+    classpath "org.shipkit:shipkit-auto-version:0.0.60"
     classpath "org.shipkit:shipkit-changelog:0.0.45"
   }
 }

--- a/scripts/li-local-release.sh
+++ b/scripts/li-local-release.sh
@@ -13,13 +13,13 @@ if [ ! -d $LOCAL_REPO ]; then
   mkdir $LOCAL_REPO
 fi
 
-VERSION=$(./gradlew -q getVersion)
+VERSION="$(./gradlew -q getVersion)-SNAPSHOT"
 
 echo "Publishing GMA $VERSION to ${LOCAL_REPO}..."
 
-# Publish artifacts to Maven local, but override the repo path
-# TODO might be nice to override version to include SNAPSHOT. Requires https://github.com/shipkit/shipkit-auto-version/issues/37.
-./gradlew -Dmaven.repo.local=$LOCAL_REPO publishToMavenLocal
+# Publish artifacts to Maven local, but override the repo path and add a -SNAPSHOT suffix to avoid confusion with
+# versions published to bintray.
+./gradlew -Dmaven.repo.local=$LOCAL_REPO publishToMavenLocal -Pversion="${VERSION}-SNAPSHOT"
 
 if [ $? = 0 ]; then
   echo "Published GMA $VERSION to $LOCAL_REPO"

--- a/scripts/li-local-release.sh
+++ b/scripts/li-local-release.sh
@@ -19,7 +19,7 @@ echo "Publishing GMA $VERSION to ${LOCAL_REPO}..."
 
 # Publish artifacts to Maven local, but override the repo path and add a -SNAPSHOT suffix to avoid confusion with
 # versions published to bintray.
-./gradlew -Dmaven.repo.local=$LOCAL_REPO publishToMavenLocal -Pversion="${VERSION}-SNAPSHOT"
+./gradlew -Dmaven.repo.local=$LOCAL_REPO publishToMavenLocal -Pversion="${VERSION}"
 
 if [ $? = 0 ]; then
   echo "Published GMA $VERSION to $LOCAL_REPO"

--- a/scripts/local-release.sh
+++ b/scripts/local-release.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Publishes artifacts to the local maven repository, also setting the version to a SNAPSHOT version to avoid confusion
+# with the artifacts published to bintray.
+
+VERSION="$(./gradlew -q getVersion)-SNAPSHOT"
+
+echo "Publishing GMA $VERSION to ${LOCAL_REPO}..."
+
+./gradlew publishToMavenLocal -Pversion="${VERSION}"
+
+if [ $? = 0 ]; then
+  echo "Published GMA $VERSION to local maven"
+else
+  exit 1
+fi


### PR DESCRIPTION
This will make it clearer what versions will be used; we don't publish SNAPSHOTs to bintray, so if you are using a SNAPSHOT version, it must be on your machine.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
