### PR TITLE
fix: actually fix commas in URN search queries not working

### DIFF
--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
@@ -10,7 +10,6 @@ import javax.annotation.Nullable;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScoreSortBuilder;
@@ -65,6 +64,8 @@ public class ESUtils {
     if (condition == Condition.EQUAL) {
       BoolQueryBuilder filters = new BoolQueryBuilder();
 
+      // TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using
+      // delimiters like comma. This is a hack to support equals with URN that has a comma in it.
       if (SearchUtils.isUrn(criterion.getValue())) {
         filters.should(QueryBuilders.matchQuery(criterion.getField(), criterion.getValue().trim()));
         return filters;

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.TermsQueryBuilder;
 
 
 @Slf4j

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 
 
 @Slf4j
@@ -44,6 +45,13 @@ public class SearchUtils {
     return requestParams.getCriteria().stream().collect(Collectors.toMap(Criterion::getField, Criterion::getValue));
   }
 
+  static boolean isUrn(@Nonnull String value) {
+    // TODO(https://github.com/linkedin/datahub-gma/issues/51): This method is a bit of a hack to support searching for
+    // URNs that have commas in them, while also using commas a delimiter for search. We should stop supporting commas
+    // as delimiter, and then we can stop using this hack.
+    return value.startsWith("urn:li:");
+  }
+
   /**
    * Builds search query given a {@link Criterion}, containing field, value and association/condition between the two.
    *
@@ -55,7 +63,8 @@ public class SearchUtils {
    * <p>This approach of supporting multiple values using comma as delimiter, prevents us from specifying a value that has comma
    * as one of it's characters. This is particularly true when one of the values is an urn e.g. "urn:li:example:(1,2,3)".
    * Hence we do not split the value (using comma as delimiter) if the value starts with "urn:li:".
-   * TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using delimiters like comma.
+   * TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using
+   * delimiters like comma.
    *
    * <p>If the condition between a field and value is not the same as EQUAL, a Range query is constructed. This
    * condition does not support multiple values for the same field.
@@ -66,7 +75,9 @@ public class SearchUtils {
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {
     final Condition condition = criterion.getCondition();
     if (condition == Condition.EQUAL) {
-      if (criterion.getValue().startsWith("urn:li:")) {
+      // TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using
+      // delimiters like comma. This is a hack to support equals with URN that has a comma in it.
+      if (isUrn(criterion.getValue())) {
         return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim());
       }
       return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));


### PR DESCRIPTION
We split on commas in a few places for some reason, not sure why. I've added more TODOs to stop the comma parsing.

#51 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
