### PR TITLE
fix: remove use of deprecated APIs in bulk writer DAO.

### DIFF
--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/search/ESBulkWriterDAO.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/search/ESBulkWriterDAO.java
@@ -15,12 +15,10 @@ import org.elasticsearch.common.xcontent.XContentType;
  * A {@link BaseSearchWriterDAO} that uses ElasticSearch's bulk update API.
  */
 public final class ESBulkWriterDAO<DOCUMENT extends RecordTemplate> extends BaseSearchWriterDAO<DOCUMENT> {
-  private static final String DEFAULT_DOCUMENT_TYPE = "doc";
   private static final int MAX_RETRIES = 3;
 
   private final BulkProcessor _bulkProcessor;
   private final String _indexName;
-  private final String _documentType;
 
   /**
    * Constructor.
@@ -31,41 +29,25 @@ public final class ESBulkWriterDAO<DOCUMENT extends RecordTemplate> extends Base
    */
   public ESBulkWriterDAO(@Nonnull Class<DOCUMENT> documentClass, @Nonnull BulkProcessor bulkProcessor,
       @Nonnull String indexName) {
-    this(documentClass, bulkProcessor, indexName, DEFAULT_DOCUMENT_TYPE);
-  }
-
-  /**
-   * Constructor.
-   *
-   * @param documentClass schema of the class to index
-   * @param bulkProcessor the bulk process to use to write to ES
-   * @param indexName the name of the index to write updates to
-   * @param documentType the type of document
-   */
-  public ESBulkWriterDAO(@Nonnull Class<DOCUMENT> documentClass, @Nonnull BulkProcessor bulkProcessor,
-      @Nonnull String indexName, @Nonnull String documentType) {
     super(documentClass);
     _bulkProcessor = bulkProcessor;
     _indexName = indexName;
-    _documentType = documentType;
   }
 
   @Override
   public void upsertDocument(@Nonnull DOCUMENT document, @Nonnull String docId) {
     final String documentJson = RecordUtils.toJsonString(document);
-    final IndexRequest indexRequest =
-        new IndexRequest(_indexName, _documentType, docId).source(documentJson, XContentType.JSON);
-    final UpdateRequest updateRequest =
-        new UpdateRequest(_indexName, _documentType, docId).doc(documentJson, XContentType.JSON)
-            .detectNoop(false)
-            .upsert(indexRequest)
-            .retryOnConflict(MAX_RETRIES);
+    final IndexRequest indexRequest = new IndexRequest(_indexName).id(docId).source(documentJson, XContentType.JSON);
+    final UpdateRequest updateRequest = new UpdateRequest(_indexName, docId).doc(documentJson, XContentType.JSON)
+        .detectNoop(false)
+        .upsert(indexRequest)
+        .retryOnConflict(MAX_RETRIES);
     _bulkProcessor.add(updateRequest);
   }
 
   @Override
   public void deleteDocument(@Nonnull String docId) {
-    _bulkProcessor.add(new DeleteRequest(_indexName, _documentType, docId));
+    _bulkProcessor.add(new DeleteRequest(_indexName).id(docId));
   }
 
   @Override


### PR DESCRIPTION
Not bumping the semi major version since this is under development and not yet used.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
