### PR TITLE
Update Shipkit plugins configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
     classpath 'com.linkedin.pegasus:gradle-plugins:' + pegasusVersion
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.2.RELEASE'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
-    classpath "org.shipkit:shipkit-auto-version:0.0.60"
-    classpath "org.shipkit:shipkit-changelog:0.0.45"
+    classpath "org.shipkit:shipkit-auto-version:1.1.1"
+    classpath "org.shipkit:shipkit-changelog:1.1.1"
   }
 }
 

--- a/docs/how/releases/continuous-releases.md
+++ b/docs/how/releases/continuous-releases.md
@@ -4,8 +4,8 @@ We create [GitHub releases](https://github.com/linkedin/datahub-gma/releases) an
 [Bintray](https://bintray.com/linkedin/maven/datahub-gma).
 
 We use [shipkit-auto-version](https://github.com/shipkit/shipkit-auto-version),
-[shipkit-changelog](https://github.com/shipkit/shipkit-changelog), and shipkit-gh-release (part of shipkit-changelog) to
-help create our continuous releases.
+[shipkit-changelog](https://github.com/shipkit/shipkit-changelog), and shipkit-github-release (part of
+shipkit-changelog) to help create our continuous releases.
 
 ## Automatic Versioning
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'org.shipkit.shipkit-auto-version'
 apply plugin: 'org.shipkit.shipkit-changelog'
-apply plugin: 'org.shipkit.shipkit-gh-release'
+apply plugin: 'org.shipkit.shipkit-github-release'
 
 
 if (!project.hasProperty('disableShipkit')) {
@@ -15,8 +15,8 @@ if (!project.hasProperty('disableShipkit')) {
 
   tasks.named("generateChangelog") {
     dependsOn checkGitHubToken
-    previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
-    readOnlyToken = System.getenv("GITHUB_TOKEN")
+    previousRevision = project.ext.'shipkit-auto-version.previous-tag'
+    githubToken = System.getenv("GITHUB_TOKEN")
     repository = System.getenv("GITHUB_REPOSITORY")
   }
 
@@ -25,7 +25,8 @@ if (!project.hasProperty('disableShipkit')) {
     dependsOn checkGitHubToken
     repository = System.getenv("GITHUB_REPOSITORY")
     changelog = tasks.named("generateChangelog").get().outputFile
-    writeToken = System.getenv("GITHUB_TOKEN")
+    githubToken = System.getenv("GITHUB_TOKEN")
+    newTagRevision = System.getenv("GITHUB_SHA")
   }
 }
 


### PR DESCRIPTION
Hello, 

I'd like to let you know that recently new properties has been added to Shipkit Changelog and Shipkit Auto Version plugins. The latter exposes new 'ext' property for getting previous revision: _project.ext.'shipkit-auto-version.previous-tag'._ Using this property makes code clearer.

Configuration in _release.gradle_ file can be also updated with 2 new Shipkit Changelog plugin properties:
1) `newTagRevision` that ensures predictable tagging (adding this property fixes shipkit/shipkit-changelog#46). _'GITHUB_SHA'_ that supplies the property, is an GH Action's env variable that exposes SHA of the commit that triggered the workflow.
2) Token that is set by `githubToken property` is used both to fetch and post via GH API. Earlier used _'readOnlyToken'_ and _'writeToken'_ properties are now deprecated.

There has been also applied to Shipkit Changelog new consistent naming convention for classes/objects and packages that refer to GitHub. According to this rename, info on Shipkit plugins can be updated in _continuos-releases.md_ file.
Proposed changes can be applied to your project along with Shipkit plugins versions bumped to the latest ones.

Thanks!

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
