### PR TITLE
feat: add @DocType annotation for ES5 tests.

### DIFF
--- a/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/ElasticsearchIntegrationTestExtension.java
+++ b/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/ElasticsearchIntegrationTestExtension.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.testing;
 
+import com.linkedin.metadata.testing.annotations.DocType;
 import com.linkedin.metadata.testing.annotations.SearchIndexMappings;
 import com.linkedin.metadata.testing.annotations.SearchIndexSettings;
 import com.linkedin.metadata.testing.annotations.SearchIndexType;
@@ -95,8 +96,11 @@ final class ElasticsearchIntegrationTestExtension
       final SearchIndexMappings mappings = field.getAnnotation(SearchIndexMappings.class);
       final String mappingsJson = mappings == null ? null : loadResource(testInstance.getClass(), mappings.value());
 
+      final DocType docType = field.getAnnotation(DocType.class);
+      final String docTypeStr = docType == null ? null : docType.value();
+
       final SearchIndex<?> index =
-          indexFactory.createIndex(searchIndexType.value(), indexName, settingsJson, mappingsJson);
+          indexFactory.createIndex(searchIndexType.value(), indexName, settingsJson, mappingsJson, docTypeStr);
       field.set(testInstance, index);
       indices.add(index);
     }

--- a/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/SearchIndex.java
+++ b/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/SearchIndex.java
@@ -29,7 +29,7 @@ public final class SearchIndex<DOCUMENT extends RecordTemplate> {
   private final BulkRequestsContainer _requestContainer;
 
   public SearchIndex(@Nonnull Class<DOCUMENT> documentClass, @Nonnull ElasticsearchConnection connection,
-      @Nonnull String name) {
+      @Nonnull String name, @Nonnull String doctype) {
     _documentClass = documentClass;
     _connection = connection;
     _name = name;
@@ -38,7 +38,7 @@ public final class SearchIndex<DOCUMENT extends RecordTemplate> {
     final BulkProcessor bulkProcessor = BulkProcessor.builder(connection.getTransportClient(), bulkListener).build();
     _requestContainer = new BulkRequestsContainer(bulkProcessor, bulkListener);
 
-    _bulkWriterDAO = new ESBulkWriterDAO<DOCUMENT>(documentClass, bulkProcessor, name);
+    _bulkWriterDAO = new ESBulkWriterDAO<DOCUMENT>(documentClass, bulkProcessor, name, doctype);
   }
 
   /**

--- a/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/SearchIndexFactory.java
+++ b/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/SearchIndexFactory.java
@@ -36,7 +36,6 @@ final class SearchIndexFactory {
     }
 
     if (mappingsJson != null) {
-      // TODO
       createIndexRequest.mapping(doctype, mappingsJson, XContentType.JSON);
     }
 

--- a/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/SearchIndexFactory.java
+++ b/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/SearchIndexFactory.java
@@ -27,8 +27,9 @@ final class SearchIndexFactory {
    * @param name the name to use for the index
    */
   public <DOCUMENT extends RecordTemplate> SearchIndex<DOCUMENT> createIndex(@Nonnull Class<DOCUMENT> documentClass,
-      @Nonnull String name, @Nullable String settingsJson, @Nullable String mappingsJson) {
+      @Nonnull String name, @Nullable String settingsJson, @Nullable String mappingsJson, @Nullable String doctype) {
     final CreateIndexRequest createIndexRequest = new CreateIndexRequest(name);
+    doctype = doctype == null ? "doc" : doctype;
 
     if (settingsJson != null) {
       createIndexRequest.settings(settingsJson, XContentType.JSON);
@@ -36,7 +37,7 @@ final class SearchIndexFactory {
 
     if (mappingsJson != null) {
       // TODO
-      createIndexRequest.mapping("doc", mappingsJson, XContentType.JSON);
+      createIndexRequest.mapping(doctype, mappingsJson, XContentType.JSON);
     }
 
     try {
@@ -45,6 +46,6 @@ final class SearchIndexFactory {
       throw new RuntimeException(e);
     }
 
-    return new SearchIndex<>(documentClass, _connection, name);
+    return new SearchIndex<>(documentClass, _connection, name, doctype);
   }
 }

--- a/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/annotations/DocType.java
+++ b/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/annotations/DocType.java
@@ -1,0 +1,26 @@
+package com.linkedin.metadata.testing.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Indicates the document type used for the documents in this index.
+ *
+ * <p>Optional parameter for {@link com.linkedin.metadata.testing.SearchIndex}es in tests.
+ *
+ * <p>Primarily a work around for LinkedIn internally, where Datasets are old and did not set the doc type to "doc".
+ *
+ * <p>Also note that doctypes as a whole are deprecated in ES7, so this annotation is not carried forward to the ES7
+ * framework.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DocType {
+  /**
+   * The document type.
+   */
+  String value();
+}


### PR DESCRIPTION
Needed for LI internally where datasets for legacy reasons did not use "doc" as the doc type.

Note for ES7 doc types are no longer a concept and so this API is only needed in 5.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
