### PR TITLE
feat: add integration tests for ES Search DAO.

### DIFF
--- a/testing/elasticsearch-dao-integ-testing-docker-7/src/test/java/com/linkedin/metadata/testing/ESSearchDaoIntegTest.java
+++ b/testing/elasticsearch-dao-integ-testing-docker-7/src/test/java/com/linkedin/metadata/testing/ESSearchDaoIntegTest.java
@@ -1,0 +1,439 @@
+package com.linkedin.metadata.testing;
+
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.dao.SearchResult;
+import com.linkedin.metadata.dao.search.BaseSearchConfig;
+import com.linkedin.metadata.dao.search.ESBulkWriterDAO;
+import com.linkedin.metadata.dao.search.ESSearchDAO;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.Condition;
+import com.linkedin.metadata.query.Criterion;
+import com.linkedin.metadata.query.CriterionArray;
+import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.SortCriterion;
+import com.linkedin.metadata.query.SortOrder;
+import com.linkedin.metadata.testing.annotations.SearchIndexMappings;
+import com.linkedin.metadata.testing.annotations.SearchIndexSettings;
+import com.linkedin.metadata.testing.annotations.SearchIndexType;
+import com.linkedin.testing.PizzaSearchDocument;
+import com.linkedin.testing.PizzaSize;
+import com.linkedin.testing.urn.PizzaUrn;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+/**
+ * Integration tests for {@link ESSearchDAO} that run against a real Elasticsearch instance.
+ */
+@ElasticsearchIntegrationTest
+public class ESSearchDaoIntegTest {
+  @SearchIndexType(PizzaSearchDocument.class)
+  @SearchIndexSettings("/pizza/settings.json")
+  @SearchIndexMappings("/pizza/mappings.json")
+  public SearchIndex<PizzaSearchDocument> _searchIndex;
+
+  ESBulkWriterDAO<PizzaSearchDocument> _bulkDao;
+  ESSearchDAO<PizzaSearchDocument> _searchDao;
+
+  private static final class PizzaSearchConfig extends BaseSearchConfig<PizzaSearchDocument> {
+    private static final String QUERY_TEMPLATE;
+    private static final String AUTOCOMPLETE_TEMPLATE;
+
+    static {
+      try {
+        QUERY_TEMPLATE = IOUtils.resourceToString("/pizza/queryTemplate.json", StandardCharsets.UTF_8);
+        AUTOCOMPLETE_TEMPLATE = IOUtils.resourceToString("/pizza/autocompleteTemplate.json", StandardCharsets.UTF_8);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getLowCardinalityFields() {
+      return Collections.singleton("size");
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getFacetFields() {
+      return Collections.emptySet();
+    }
+
+    @Nonnull
+    @Override
+    public Class<PizzaSearchDocument> getSearchDocument() {
+      return PizzaSearchDocument.class;
+    }
+
+    @Nonnull
+    @Override
+    public String getDefaultAutocompleteField() {
+      return "toppings";
+    }
+
+    @Nonnull
+    @Override
+    public String getSearchQueryTemplate() {
+      return QUERY_TEMPLATE;
+    }
+
+    @Nonnull
+    @Override
+    public String getAutocompleteQueryTemplate() {
+      return AUTOCOMPLETE_TEMPLATE;
+    }
+  }
+
+  @BeforeEach
+  public void setup() {
+    _bulkDao = _searchIndex.getWriteDao();
+    _searchDao = _searchIndex.createReadDao(new PizzaSearchConfig());
+  }
+
+  @Test
+  public void autocompletePrefix() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Sausage Links")).setUrn(urn0),
+        urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Sausage crumble")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Sausage", null, null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactly("Sausage Links", "Sausage crumble");
+  }
+
+  @Test
+  public void autocompleteSuffix() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Mild Sausage")).setUrn(urn0),
+        urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Spicy Sausage")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Sausage", null, null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("Mild Sausage", "Spicy Sausage");
+  }
+
+  @Test
+  public void autocompleteUsesDefaultField() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.MEDIUM)
+        .setToppings(new StringArray("Large Meatballs"))
+        .setUrn(urn0), urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Pineapple")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Large", null, null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactly("Large Meatballs");
+  }
+
+  @Test
+  public void autocompleteNonDefaultField() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.LARGE)
+        .setToppings(new StringArray("Large Meatballs"))
+        .setMadeBy("New York Pizzas")
+        .setUrn(urn0), urn0.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.LARGE)
+        .setToppings(new StringArray("Pesto"))
+        .setMadeBy("New Wave Pizza")
+        .setUrn(urn1), urn1.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("New", "madeBy", null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("New York Pizzas", "New Wave Pizza");
+  }
+
+  @Test
+  public void autocompleteFilter() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.MEDIUM)
+        .setToppings(new StringArray("Small pepperoni"))
+        .setUrn(urn0), urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1),
+        urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Pepperoni")).setUrn(urn2),
+        urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("pepperoni", null, new Filter().setCriteria(
+        new CriterionArray(
+            new Criterion().setCondition(Condition.EQUAL).setField("size").setValue(PizzaSize.LARGE.toString()))), 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("Big pepperoni", "Pepperoni");
+  }
+
+  @Test
+  public void autocompleteLimit() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Mild Sausage")).setUrn(urn0),
+        urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Spicy Sausage")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Sausage", null, null, 1);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("Mild Sausage");
+  }
+
+  @Test
+  public void search() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Pineapple")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", null, null, 0, 10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza0, pizza1);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void searchLimit() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", null, null, 0, 2);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza0, pizza1);
+    assertThat(result.isHavingMore()).isTrue();
+  }
+
+  @Test
+  public void searchPaging() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", null, null, 2, 10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void searchFilter() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", new Filter().setCriteria(
+        new CriterionArray(new Criterion().setCondition(Condition.EQUAL).setField("size").setValue("LARGE"))), null, 0,
+        10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza1, pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void searchSort() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result =
+        _searchDao.search("pepperoni", null, new SortCriterion().setField("toppings").setOrder(SortOrder.ASCENDING), 0,
+            10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza1, pizza0, pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void filter() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.filter(new Filter().setCriteria(new CriterionArray(
+            new Criterion().setCondition(Condition.EQUAL).setField("size").setValue(PizzaSize.LARGE.toString()))), null, 0,
+        10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza1, pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void filterSort() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.filter(new Filter().setCriteria(new CriterionArray(
+            new Criterion().setCondition(Condition.EQUAL).setField("size").setValue(PizzaSize.LARGE.toString()))),
+        new SortCriterion().setField("toppings").setOrder(SortOrder.DESCENDING), 0, 10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza2, pizza1);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/autocompleteTemplate.json
+++ b/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/autocompleteTemplate.json
@@ -1,0 +1,10 @@
+{
+  "query_string" : {
+    "query" : "$INPUT~",
+    "fields" : [
+      "$FIELD^32"
+    ],
+    "default_operator": "and",
+    "analyzer": "lowercase_keyword"
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/mappings.json
+++ b/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/mappings.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "urn": {
+      "type": "keyword",
+      "normalizer": "custom_normalizer"
+    },
+    "toppings": {
+      "type": "text",
+      "fielddata": true
+    },
+    "size": {
+      "type": "keyword"
+    }
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/queryTemplate.json
+++ b/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/queryTemplate.json
@@ -1,0 +1,11 @@
+{
+  "query_string" : {
+    "query" : "$INPUT~",
+    "fields" : [
+      "toppings^32",
+      "size"
+    ],
+    "default_operator": "and",
+    "analyzer": "lowercase_keyword"
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/settings.json
+++ b/testing/elasticsearch-dao-integ-testing-docker-7/src/test/resources/pizza/settings.json
@@ -1,0 +1,53 @@
+{
+  "index": {
+    "analysis": {
+      "filter": {
+        "autocomplete_filter": {
+          "type": "edge_ngram",
+          "min_gram": "3",
+          "max_gram": "20"
+        },
+        "custom_delimiter": {
+          "split_on_numerics": "false",
+          "split_on_case_change": "false",
+          "type": "word_delimiter",
+          "preserve_original": "true",
+          "catenate_words": "false"
+        }
+      },
+      "normalizer": {
+        "custom_normalizer": {
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ],
+          "type": "custom"
+        }
+      },
+      "analyzer": {
+        "delimit_edgengram": {
+          "filter": [
+            "lowercase",
+            "custom_delimiter",
+            "autocomplete_filter"
+          ],
+          "tokenizer": "whitespace"
+        },
+        "delimit": {
+          "filter": [
+            "lowercase",
+            "custom_delimiter"
+          ],
+          "tokenizer": "whitespace"
+        },
+        "lowercase_keyword": {
+          "filter": [
+            "lowercase"
+          ],
+          "type": "custom",
+          "tokenizer": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker/src/test/java/com/linkedin/metadata/testing/ESSearchDaoIntegTest.java
+++ b/testing/elasticsearch-dao-integ-testing-docker/src/test/java/com/linkedin/metadata/testing/ESSearchDaoIntegTest.java
@@ -113,7 +113,7 @@ public class ESSearchDaoIntegTest {
     _searchIndex.getRequestContainer().flushAndSettle();
 
     // when
-    final AutoCompleteResult result = _searchDao.autoComplete("Sausage", null, null, 10);
+    final AutoCompleteResult result = _searchDao.autoComplete("Sau", null, null, 10);
 
     // then
     assertThat(result.getSuggestions()).containsExactly("Sausage Links", "Sausage crumble");

--- a/testing/elasticsearch-dao-integ-testing-docker/src/test/java/com/linkedin/metadata/testing/ESSearchDaoIntegTest.java
+++ b/testing/elasticsearch-dao-integ-testing-docker/src/test/java/com/linkedin/metadata/testing/ESSearchDaoIntegTest.java
@@ -1,0 +1,439 @@
+package com.linkedin.metadata.testing;
+
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.dao.SearchResult;
+import com.linkedin.metadata.dao.search.BaseSearchConfig;
+import com.linkedin.metadata.dao.search.ESBulkWriterDAO;
+import com.linkedin.metadata.dao.search.ESSearchDAO;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.Condition;
+import com.linkedin.metadata.query.Criterion;
+import com.linkedin.metadata.query.CriterionArray;
+import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.SortCriterion;
+import com.linkedin.metadata.query.SortOrder;
+import com.linkedin.metadata.testing.annotations.SearchIndexMappings;
+import com.linkedin.metadata.testing.annotations.SearchIndexSettings;
+import com.linkedin.metadata.testing.annotations.SearchIndexType;
+import com.linkedin.testing.PizzaSearchDocument;
+import com.linkedin.testing.PizzaSize;
+import com.linkedin.testing.urn.PizzaUrn;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+/**
+ * Integration tests for {@link ESSearchDAO} that run against a real Elasticsearch instance.
+ */
+@ElasticsearchIntegrationTest
+public class ESSearchDaoIntegTest {
+  @SearchIndexType(PizzaSearchDocument.class)
+  @SearchIndexSettings("/pizza/settings.json")
+  @SearchIndexMappings("/pizza/mappings.json")
+  public SearchIndex<PizzaSearchDocument> _searchIndex;
+
+  ESBulkWriterDAO<PizzaSearchDocument> _bulkDao;
+  ESSearchDAO<PizzaSearchDocument> _searchDao;
+
+  private static final class PizzaSearchConfig extends BaseSearchConfig<PizzaSearchDocument> {
+    private static final String QUERY_TEMPLATE;
+    private static final String AUTOCOMPLETE_TEMPLATE;
+
+    static {
+      try {
+        QUERY_TEMPLATE = IOUtils.resourceToString("/pizza/queryTemplate.json", StandardCharsets.UTF_8);
+        AUTOCOMPLETE_TEMPLATE = IOUtils.resourceToString("/pizza/autocompleteTemplate.json", StandardCharsets.UTF_8);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getLowCardinalityFields() {
+      return Collections.singleton("size");
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getFacetFields() {
+      return Collections.emptySet();
+    }
+
+    @Nonnull
+    @Override
+    public Class<PizzaSearchDocument> getSearchDocument() {
+      return PizzaSearchDocument.class;
+    }
+
+    @Nonnull
+    @Override
+    public String getDefaultAutocompleteField() {
+      return "toppings";
+    }
+
+    @Nonnull
+    @Override
+    public String getSearchQueryTemplate() {
+      return QUERY_TEMPLATE;
+    }
+
+    @Nonnull
+    @Override
+    public String getAutocompleteQueryTemplate() {
+      return AUTOCOMPLETE_TEMPLATE;
+    }
+  }
+
+  @BeforeEach
+  public void setup() {
+    _bulkDao = _searchIndex.getWriteDao();
+    _searchDao = _searchIndex.createReadDao(new PizzaSearchConfig());
+  }
+
+  @Test
+  public void autocompletePrefix() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Sausage Links")).setUrn(urn0),
+        urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Sausage crumble")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Sausage", null, null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactly("Sausage Links", "Sausage crumble");
+  }
+
+  @Test
+  public void autocompleteSuffix() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Mild Sausage")).setUrn(urn0),
+        urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Spicy Sausage")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Sausage", null, null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("Mild Sausage", "Spicy Sausage");
+  }
+
+  @Test
+  public void autocompleteUsesDefaultField() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.MEDIUM)
+        .setToppings(new StringArray("Large Meatballs"))
+        .setUrn(urn0), urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Pineapple")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Large", null, null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactly("Large Meatballs");
+  }
+
+  @Test
+  public void autocompleteNonDefaultField() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.LARGE)
+        .setToppings(new StringArray("Large Meatballs"))
+        .setMadeBy("New York Pizzas")
+        .setUrn(urn0), urn0.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.LARGE)
+        .setToppings(new StringArray("Pesto"))
+        .setMadeBy("New Wave Pizza")
+        .setUrn(urn1), urn1.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("New", "madeBy", null, 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("New York Pizzas", "New Wave Pizza");
+  }
+
+  @Test
+  public void autocompleteFilter() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    _bulkDao.upsertDocument(new PizzaSearchDocument().setSize(PizzaSize.MEDIUM)
+        .setToppings(new StringArray("Small pepperoni"))
+        .setUrn(urn0), urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1),
+        urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Pepperoni")).setUrn(urn2),
+        urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("pepperoni", null, new Filter().setCriteria(
+        new CriterionArray(
+            new Criterion().setCondition(Condition.EQUAL).setField("size").setValue(PizzaSize.LARGE.toString()))), 10);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("Big pepperoni", "Pepperoni");
+  }
+
+  @Test
+  public void autocompleteLimit() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Mild Sausage")).setUrn(urn0),
+        urn0.toString());
+    _bulkDao.upsertDocument(
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Spicy Sausage")).setUrn(urn1),
+        urn1.toString());
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final AutoCompleteResult result = _searchDao.autoComplete("Sausage", null, null, 1);
+
+    // then
+    assertThat(result.getSuggestions()).containsExactlyInAnyOrder("Mild Sausage");
+  }
+
+  @Test
+  public void search() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Pineapple")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", null, null, 0, 10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza0, pizza1);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void searchLimit() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", null, null, 0, 2);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza0, pizza1);
+    assertThat(result.isHavingMore()).isTrue();
+  }
+
+  @Test
+  public void searchPaging() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", null, null, 2, 10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void searchFilter() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.search("pepperoni", new Filter().setCriteria(
+        new CriterionArray(new Criterion().setCondition(Condition.EQUAL).setField("size").setValue("LARGE"))), null, 0,
+        10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza1, pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void searchSort() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result =
+        _searchDao.search("pepperoni", null, new SortCriterion().setField("toppings").setOrder(SortOrder.ASCENDING), 0,
+            10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza1, pizza0, pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void filter() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.filter(new Filter().setCriteria(new CriterionArray(
+            new Criterion().setCondition(Condition.EQUAL).setField("size").setValue(PizzaSize.LARGE.toString()))), null, 0,
+        10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza1, pizza2);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+
+  @Test
+  public void filterSort() throws Exception {
+    // given
+    final PizzaUrn urn0 = new PizzaUrn(0);
+    final PizzaSearchDocument pizza0 =
+        new PizzaSearchDocument().setSize(PizzaSize.MEDIUM).setToppings(new StringArray("Pepperoni")).setUrn(urn0);
+    _bulkDao.upsertDocument(pizza0, urn0.toString());
+
+    final PizzaUrn urn1 = new PizzaUrn(1);
+    final PizzaSearchDocument pizza1 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Big pepperoni")).setUrn(urn1);
+    _bulkDao.upsertDocument(pizza1, urn1.toString());
+
+    final PizzaUrn urn2 = new PizzaUrn(2);
+    final PizzaSearchDocument pizza2 =
+        new PizzaSearchDocument().setSize(PizzaSize.LARGE).setToppings(new StringArray("Small Pepperoni")).setUrn(urn2);
+    _bulkDao.upsertDocument(pizza2, urn2.toString());
+
+    _searchIndex.getRequestContainer().flushAndSettle();
+
+    // when
+    final SearchResult<PizzaSearchDocument> result = _searchDao.filter(new Filter().setCriteria(new CriterionArray(
+            new Criterion().setCondition(Condition.EQUAL).setField("size").setValue(PizzaSize.LARGE.toString()))),
+        new SortCriterion().setField("toppings").setOrder(SortOrder.DESCENDING), 0, 10);
+
+    // then
+    assertThat(result.getDocumentList()).containsExactly(pizza2, pizza1);
+    assertThat(result.isHavingMore()).isFalse();
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/autocompleteTemplate.json
+++ b/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/autocompleteTemplate.json
@@ -1,0 +1,10 @@
+{
+  "query_string" : {
+    "query" : "$INPUT~",
+    "fields" : [
+      "$FIELD^32"
+    ],
+    "default_operator": "and",
+    "analyzer": "lowercase_keyword"
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/mappings.json
+++ b/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/mappings.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "urn": {
+      "type": "keyword",
+      "normalizer": "custom_normalizer"
+    },
+    "toppings": {
+      "type": "text",
+      "fielddata": true
+    },
+    "size": {
+      "type": "keyword"
+    }
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/queryTemplate.json
+++ b/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/queryTemplate.json
@@ -1,0 +1,11 @@
+{
+  "query_string" : {
+    "query" : "$INPUT~",
+    "fields" : [
+      "toppings^32",
+      "size"
+    ],
+    "default_operator": "and",
+    "analyzer": "lowercase_keyword"
+  }
+}

--- a/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/settings.json
+++ b/testing/elasticsearch-dao-integ-testing-docker/src/test/resources/pizza/settings.json
@@ -1,0 +1,53 @@
+{
+  "index": {
+    "analysis": {
+      "filter": {
+        "autocomplete_filter": {
+          "type": "edge_ngram",
+          "min_gram": "3",
+          "max_gram": "20"
+        },
+        "custom_delimiter": {
+          "split_on_numerics": "false",
+          "split_on_case_change": "false",
+          "type": "word_delimiter",
+          "preserve_original": "true",
+          "catenate_words": "false"
+        }
+      },
+      "normalizer": {
+        "custom_normalizer": {
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ],
+          "type": "custom"
+        }
+      },
+      "analyzer": {
+        "delimit_edgengram": {
+          "filter": [
+            "lowercase",
+            "custom_delimiter",
+            "autocomplete_filter"
+          ],
+          "tokenizer": "whitespace"
+        },
+        "delimit": {
+          "filter": [
+            "lowercase",
+            "custom_delimiter"
+          ],
+          "tokenizer": "whitespace"
+        },
+        "lowercase_keyword": {
+          "filter": [
+            "lowercase"
+          ],
+          "type": "custom",
+          "tokenizer": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/PizzaUrn.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/PizzaUrn.java
@@ -1,0 +1,43 @@
+package com.linkedin.testing.urn;
+
+import com.linkedin.common.urn.TupleKey;
+import com.linkedin.common.urn.Urn;
+import java.net.URISyntaxException;
+
+
+public final class PizzaUrn extends Urn {
+
+  public static final String ENTITY_TYPE = "pizza";
+  // Can be obtained via getEntityKey, but not in open source. We need to unify the internal / external URN definitions.
+  private final int _id;
+
+  public PizzaUrn(int id) {
+    super(ENTITY_TYPE, TupleKey.create(id));
+    this._id = id;
+  }
+
+  public int getPizzaId() {
+    return _id;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    // Override for find bugs, bug delegate to super implementation, both in open source and internally.
+    return super.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  public static PizzaUrn createFromString(String rawUrn) throws URISyntaxException {
+    final Urn urn = Urn.createFromString(rawUrn);
+
+    if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Can't cast Urn to PizzaUrn, not same ENTITY");
+    }
+
+    return new PizzaUrn(urn.getIdAsInt());
+  }
+}

--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/PizzaUrnCoercer.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/PizzaUrnCoercer.java
@@ -1,0 +1,8 @@
+package com.linkedin.testing.urn;
+
+import com.linkedin.data.template.Custom;
+
+
+public class PizzaUrnCoercer extends BaseUrnCoercer<PizzaUrn> {
+  private static final boolean REGISTER_COERCER = Custom.registerCoercer(new PizzaUrnCoercer(), PizzaUrn.class);
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaSearchDocument.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaSearchDocument.pdl
@@ -1,0 +1,26 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit testing, a pretend search document over pizzas.
+ */
+record PizzaSearchDocument {
+  /**
+   * Urn of the entity.
+   */
+  urn: PizzaUrn
+
+  /**
+   * Size of the pizza.
+   */
+  size: optional PizzaSize
+
+  /**
+   * Toppings on the pizza.
+   */
+  toppings: optional array[string]
+
+  /**
+   * The shop that made this pizza.
+   */
+  madeBy: optional string
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaSize.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaSize.pdl
@@ -1,0 +1,11 @@
+namespace com.linkedin.testing
+
+/**
+ * Possible sizes of pizzas.
+ */
+enum PizzaSize {
+  PERSONAL,
+  MEDIUM,
+  LARGE,
+  SICILIAN
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaUrn.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaUrn.pdl
@@ -1,0 +1,23 @@
+namespace com.linkedin.testing
+
+/**
+ * Pizza identifier.
+ */
+@java = {
+  "class" : "com.linkedin.testing.urn.PizzaUrn",
+  "coercerClass" : "com.linkedin.testing.urn.PizzaUrnCoercer"
+}
+@validate.`com.linkedin.common.validator.TypedUrnValidator` = {
+  "owningTeam" : "urn:li:internalTeam:metadata",
+  "entityType" : "pizza",
+  "namespace" : "li",
+  "name" : "Pizza",
+  "doc" : "Pizza identifier.",
+  "owners" : [ "urn:li:corpuser:fbar", "urn:li:corpuser:bfoo" ],
+  "fields" : [ {
+    "type" : "int",
+    "name" : "pizzaId",
+    "doc" : "GUID for this pizza"
+  } ]
+}
+typeref PizzaUrn = string


### PR DESCRIPTION
Note the existing test model (BarSaerchDocument) is a little too vague and only had one field. Rather than expand it, I figured I'd make a more congrete and silly piece of test data for Pizzas.

Note: tests are the same across 5 and 7. Which makes sense as the DAO API did not change across versions.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
