### PR TITLE
fix: Upgrade testcontainers dependency to 1.15.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,8 @@ project.ext.externalDependency = [
     'reflections': 'org.reflections:reflections:0.9.11',
     'rythmEngine': 'org.rythmengine:rythm-engine:1.3.0',
     'spock': 'org.spockframework:spock-core:1.3-groovy-2.4',
-    'testContainers': 'org.testcontainers:testcontainers:1.15.0',
-    'testContainersJunit': 'org.testcontainers:junit-jupiter:1.15.0',
+    'testContainers': 'org.testcontainers:testcontainers:1.15.1',
+    'testContainersJunit': 'org.testcontainers:junit-jupiter:1.15.1',
     'testng': 'org.testng:testng:6.9.9'
 ]
 


### PR DESCRIPTION
We seem to be experiencing flaky builds on datahub (CI/CD fails on PRs: e.g. https://github.com/linkedin/datahub/pull/2084/checks)
specifically:
Execution failed for task ':gms:impl:integrationTest'

and the root cause seems to be: https://github.com/testcontainers/testcontainers-java/issues/3574

Upgrading to 1.15.1 hoping that this fixes it 🤞

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
