### PR TITLE
fix: Use ElasticSearch in single-node mode

### DIFF
--- a/testing/elasticsearch-dao-integ-testing-docker/src/main/java/com/linkedin/metadata/testing/ElasticsearchContainerFactoryDockerImpl.java
+++ b/testing/elasticsearch-dao-integ-testing-docker/src/main/java/com/linkedin/metadata/testing/ElasticsearchContainerFactoryDockerImpl.java
@@ -59,7 +59,8 @@ public final class ElasticsearchContainerFactoryDockerImpl implements Elasticsea
   public ElasticsearchConnection start() throws Exception {
     if (_container == null) {
       _container = new GenericContainerImpl(IMAGE_NAME).withExposedPorts(HTTP_PORT, TRANSPORT_PORT)
-          .withEnv("xpack.security.enabled", "false");
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("discovery.type", "single-node");
       _container.start();
     }
 


### PR DESCRIPTION
## Checklist

We've been seeing datahub integration tests fail on Linux machines (e.g. https://github.com/linkedin/datahub/issues/2088). The core reason for this issue is that production deployments of ElasticSearch require some [extra configuration](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html) on Linux machines.

However, we don't need a production deployment for integration tests, and as per [the ES docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-dev-mode), we can use single-node mode to bypass these checks and make the tests succeed on Linux-based distros.

Note that this is already done in the es-7 directories: https://github.com/linkedin/datahub-gma/blob/e7bb1d96f2b822658d3390c493204ad1ec5194ee/testing/elasticsearch-dao-integ-testing-docker-7/src/main/java/com/linkedin/metadata/testing/ElasticsearchContainerFactoryDockerImpl.java#L49. 

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
