### PR TITLE
Add a topic convention class for MXE v5, which determines how to name…

### DIFF
--- a/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5.java
+++ b/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5.java
@@ -1,0 +1,71 @@
+package com.linkedin.mxe;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import javax.annotation.Nonnull;
+
+
+/**
+ * The convention for naming event topics, meant to be used in conjunction with a {@link
+ * com.linkedin.metadata.dao.producer.BaseMetadataEventProducer}.
+ *
+ * <p>Different companies may have different naming conventions or styles for their kafka topics. Namely, companies
+ * should pick _ or . as a delimiter, but not both, as they collide in metric names.
+ *
+ * <p>This convention applies to MXE v5, not to MXE v4 or below. In MXE v5, every entity/aspect pair can have its
+ * own topic, where as in v4 (and below) topics were monolithic. There is a topic convention for v4 as well, but it is
+ * defined in the DataHub repo due to tight coupling with MXE v4.
+ */
+public interface TopicConventionV5 {
+  /**
+   * Returns the name of the metadata change event topic.
+   *
+   * @param urn the urn of the entity being updated
+   * @param aspect the aspect name being updated
+   */
+  @Nonnull
+  String getMetadataChangeEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect);
+
+  /**
+   * Returns the class that defines the MCE schema for a given topic.
+   *
+   * @param urn the urn of the entity being updated
+   * @param aspect the aspect name being updated
+   */
+  Class<?> getMetadataChangeEventSchema(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) throws ClassNotFoundException;
+
+  /**
+   * Returns the name of the metadata audit event topic.
+   *
+   * @param urn the urn of the entity being updated
+   * @param aspect the aspect name being updated
+   */
+  @Nonnull
+  String getMetadataAuditEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect);
+
+  /**
+   * Returns the class that defines the MAE schema for a given topic.
+   *
+   * @param urn the urn of the entity being updated
+   * @param aspect the aspect name being updated
+   */
+  Class<?> getMetadataAuditEventSchema(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) throws ClassNotFoundException;
+
+  /**
+   * Returns the name of the failed metadata change event topic.
+   *
+   * @param urn the urn of the entity being updated
+   * @param aspect the aspect name being updated
+   */
+  @Nonnull
+  String getFailedMetadataChangeEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect);
+
+  /**
+   * Returns the class that defines the FMCE schema for a given topic.
+   *
+   * @param urn the urn of the entity being updated
+   * @param aspect the aspect name being updated
+   */
+  Class<?> getFailedMetadataChangeEventSchema(@Nonnull Urn urn, @Nonnull RecordTemplate aspect)
+      throws ClassNotFoundException;
+}

--- a/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
+++ b/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
@@ -1,0 +1,234 @@
+package com.linkedin.mxe;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+
+
+/**
+ * Default implementation of a {@link TopicConventionV5}, which is fully customizable for event names.
+ *
+ * <p>The newer aspect-entity specific event names are based on a pattern that can also be configured. The pattern is a
+ * string, which can use {@link #EVENT_TYPE_PLACEHOLDER}, {@link #ENTITY_PLACEHOLDER}, and {@link #ASPECT_PLACEHOLDER}
+ * as placeholders for the event type (MCE, MAE, FMCE, etc), entity name, and aspect name, respectively.
+ *
+ * <p>The default pattern is {@code %EVENT%_%ENTITY%_%ASPECT%}. So, for example, given an URN like
+ * {@code urn:li:pizza:0} and an aspect like {@code PizzaInfo}, you would ge the following topic names by defalut:
+ *
+ * <ul>
+ *   <li>{@code MCE_Pizza_PizzaInfo}
+ *   <li>{@code MAE_Pizza_PizzaInfo}
+ *   <li>{@code FMCE_Pizza_PizzaInfo}
+ * </ul>
+ */
+public final class TopicConventionV5Impl implements TopicConventionV5 {
+  // Placeholders
+  public static final String EVENT_TYPE_PLACEHOLDER = "%EVENT%";
+  public static final String ENTITY_PLACEHOLDER = "%ENTITY%";
+  public static final String ASPECT_PLACEHOLDER = "%ASPECT%";
+
+  // v5 defaults
+  public static final String DEFAULT_EVENT_PATTERN = "%EVENT%_%ENTITY%_%ASPECT%";
+
+  // V5 event name placeholder replacements
+  private static final String METADATA_CHANGE_EVENT_TYPE = "MCE";
+  private static final String METADATA_AUDIT_EVENT_TYPE = "MAE";
+  private static final String FAILED_METADATA_CHANGE_EVENT_TYPE = "FMCE";
+
+  private static final String V5_EVENT_ROOT_NAMESPACE = "com.linkedin.pegasus2avro.mxe";
+  // should be %entityName%.%aspectName%.%EventClass%
+  private static final String V5_EVENT_NAMESPACE_TEMPLATE = V5_EVENT_ROOT_NAMESPACE + ".%s.%s.%s";
+  private static final String METADATA_CHANGE_EVENT = "MetadataChangeEvent";
+  private static final String METADATA_AUDIT_EVENT = "MetadataAuditEvent";
+  private static final String FAILED_METADATA_CHANGE_EVENT = "FailedMetadataChangeEvent";
+
+  // v5 patterns
+  private final String _eventPattern;
+
+  private final Map<String, String> _overrides;
+
+  public TopicConventionV5Impl(@Nonnull String eventPattern, @Nonnull Map<String, String> overrides) {
+    _eventPattern = eventPattern;
+    _overrides = overrides;
+  }
+
+  public TopicConventionV5Impl(@Nonnull String eventPattern) {
+    this(eventPattern, Collections.emptyMap());
+  }
+
+  public TopicConventionV5Impl() {
+    this(DEFAULT_EVENT_PATTERN);
+  }
+
+  /**
+   * Given a map from the default topic name to a topic name to use, returns a new convention that will respect these
+   * specific per-topic overrides.
+   *
+   * <p>Needed for LI internally as we made some off-pattern names before we finalized v5. Most users should not be
+   * using this. If you need to change topic names in your organization, try to do so consistently and change the
+   * {@code eventPattern} constructor parameter instead.
+   */
+  public TopicConventionV5Impl withOverrides(@Nonnull Map<String, String> overrides) {
+    final Map<String, String> merged = new HashMap<>(_overrides);
+
+    for (String key : overrides.keySet()) {
+      merged.put(key, overrides.get(key));
+    }
+
+    return new TopicConventionV5Impl(_eventPattern, merged);
+  }
+
+  public TopicConventionV5Impl withOverride(@Nonnull String schemaFqcn, @Nonnull String topicName) {
+    return withOverrides(new HashMap<String, String>() {{
+      put(schemaFqcn, topicName);
+    }});
+  }
+
+  /**
+   * Given a map from v5 event type to a topic name to use, returns a new convention that will respect these specific
+   * per-topic overrides.
+   *
+   * <p>Needed for LI internally as we made some off-pattern names before we finalized v5. Most users should not be
+   * using this. If you need to change topic names in your organization, try to do so consistently and change the
+   * {@code eventPattern} constructor parameter instead.
+   */
+  public TopicConventionV5Impl withSchemaOverrides(@Nonnull Map<Class<?>, String> overrides) {
+    final Map<String, String> merged = new HashMap<>(_overrides);
+
+    for (Class<?> key : overrides.keySet()) {
+      final String name = getDefaultEventName(key);
+      merged.put(name, overrides.get(key));
+    }
+
+    return new TopicConventionV5Impl(_eventPattern, merged);
+  }
+
+  public TopicConventionV5Impl withOverride(@Nonnull Class<?> schema, @Nonnull String topicName) {
+    return withSchemaOverrides(new HashMap<Class<?>, String>() {{
+      put(schema, topicName);
+    }});
+  }
+
+  @Nonnull
+  private String getDefaultEventName(@Nonnull Class<?> eventSchema) {
+    final Pattern pattern = Pattern.compile(
+        "com\\.linkedin\\.pegasus2avro\\.mxe\\.(?<entity>[A-z]+)\\.(?<aspect>[A-z]+)\\.(?<className>[A-z]+)");
+    final Matcher matcher = pattern.matcher(eventSchema.getName());
+
+    if (!matcher.find()) {
+      throw new IllegalArgumentException(String.format(
+          "Expected all events FCQN to match `com.linkedin.pegasus2avro.mxe.<entity>.<aspect>.<className>`. Got `%s`.",
+          eventSchema.getName()));
+    }
+
+    final String className = matcher.group("className");
+
+    String eventType;
+
+    if (METADATA_CHANGE_EVENT.equals(className)) {
+      eventType = METADATA_CHANGE_EVENT_TYPE;
+    } else if (METADATA_AUDIT_EVENT.equals(className)) {
+      eventType = METADATA_AUDIT_EVENT_TYPE;
+    } else if (FAILED_METADATA_CHANGE_EVENT.equals(className)) {
+      eventType = FAILED_METADATA_CHANGE_EVENT_TYPE;
+    } else {
+      throw new IllegalArgumentException(String.format("Unrecognized MXE class name: %s", className));
+    }
+
+    return buildEventName(eventType, toUpperCamelCase(matcher.group("entity")),
+        toUpperCamelCase(matcher.group("aspect")));
+  }
+
+  @Nonnull
+  private String buildEventName(@Nonnull String eventType, @Nonnull String entityName, @Nonnull String aspectName) {
+    final String name = _eventPattern.replace(EVENT_TYPE_PLACEHOLDER, eventType)
+        .replace(ENTITY_PLACEHOLDER, entityName)
+        .replace(ASPECT_PLACEHOLDER, aspectName);
+
+    return _overrides.getOrDefault(name, name);
+  }
+
+  @Nonnull
+  private String toUpperCamelCase(@Nonnull String str) {
+    if (str.isEmpty()) {
+      return str;
+    }
+
+    if (str.length() == 1) {
+      return str.toUpperCase();
+    }
+
+    return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+  }
+
+  @Nonnull
+  private String toLowerCamelCase(@Nonnull String str) {
+    if (str.isEmpty()) {
+      return str;
+    }
+
+    if (str.length() == 1) {
+      return str.toLowerCase();
+    }
+
+    return Character.toLowerCase(str.charAt(0)) + str.substring(1);
+  }
+
+  private String buildEventName(@Nonnull String eventType, @Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
+    final String entityType = toUpperCamelCase(urn.getEntityType());
+    final String aspectName = aspect.getClass().getSimpleName();
+
+    return buildEventName(eventType, entityType, aspectName);
+  }
+
+  @Nonnull
+  @Override
+  public String getMetadataChangeEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
+    return buildEventName(METADATA_CHANGE_EVENT_TYPE, urn, aspect);
+  }
+
+  private Class<?> getClass(@Nonnull Urn urn, @Nonnull RecordTemplate aspect, @Nonnull String eventType)
+      throws ClassNotFoundException {
+    final String entityType = urn.getEntityType();
+    final String aspectName = toLowerCamelCase(aspect.getClass().getSimpleName());
+
+    final String className = String.format(V5_EVENT_NAMESPACE_TEMPLATE, entityType, aspectName, eventType);
+
+    return Class.forName(className);
+  }
+
+  @Override
+  public Class<?> getMetadataChangeEventSchema(@Nonnull Urn urn, @Nonnull RecordTemplate aspect)
+      throws ClassNotFoundException {
+    return getClass(urn, aspect, METADATA_CHANGE_EVENT);
+  }
+
+  @Nonnull
+  @Override
+  public String getMetadataAuditEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
+    return buildEventName(METADATA_AUDIT_EVENT_TYPE, urn, aspect);
+  }
+
+  @Override
+  public Class<?> getMetadataAuditEventSchema(@Nonnull Urn urn, @Nonnull RecordTemplate aspect)
+      throws ClassNotFoundException {
+    return getClass(urn, aspect, METADATA_AUDIT_EVENT);
+  }
+
+  @Nonnull
+  @Override
+  public String getFailedMetadataChangeEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
+    return buildEventName(FAILED_METADATA_CHANGE_EVENT_TYPE, urn, aspect);
+  }
+
+  @Override
+  public Class<?> getFailedMetadataChangeEventSchema(@Nonnull Urn urn, @Nonnull RecordTemplate aspect)
+      throws ClassNotFoundException {
+    return getClass(urn, aspect, FAILED_METADATA_CHANGE_EVENT);
+  }
+}

--- a/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
+++ b/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
  * as placeholders for the event type (MCE, MAE, FMCE, etc), entity name, and aspect name, respectively.
  *
  * <p>The default pattern is {@code %EVENT%_%ENTITY%_%ASPECT%}. So, for example, given an URN like
- * {@code urn:li:pizza:0} and an aspect like {@code PizzaInfo}, you would ge the following topic names by default:
+ * {@code urn:li:pizza:0} and an aspect like {@code PizzaInfo}, you would get the following topic names by default:
  *
  * <ul>
  *   <li>{@code MCE_Pizza_PizzaInfo}
@@ -33,7 +33,7 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
   public static final String ASPECT_PLACEHOLDER = "%ASPECT%";
 
   // v5 defaults
-  public static final String DEFAULT_EVENT_PATTERN = "%EVENT%_%ENTITY%_%ASPECT%";
+  public static final String DEFAULT_TOPIC_NAME_PATTERN = "%EVENT%_%ENTITY%_%ASPECT%";
 
   // V5 event name placeholder replacements
   private static final String METADATA_CHANGE_EVENT_TYPE = "MCE";
@@ -62,7 +62,7 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
   }
 
   public TopicConventionV5Impl() {
-    this(DEFAULT_EVENT_PATTERN);
+    this(DEFAULT_TOPIC_NAME_PATTERN);
   }
 
   /**
@@ -101,7 +101,7 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
     final Map<String, String> merged = new HashMap<>(_overrides);
 
     for (Class<?> key : overrides.keySet()) {
-      final String name = getDefaultEventName(key);
+      final String name = getDefaultTopicName(key);
       merged.put(name, overrides.get(key));
     }
 
@@ -115,7 +115,7 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
   }
 
   @Nonnull
-  private String getDefaultEventName(@Nonnull Class<?> eventSchema) {
+  private String getDefaultTopicName(@Nonnull Class<?> eventSchema) {
     final Pattern pattern = Pattern.compile(
         "com\\.linkedin\\.pegasus2avro\\.mxe\\.(?<entity>[A-z]+)\\.(?<aspect>[A-z]+)\\.(?<className>[A-z]+)");
     final Matcher matcher = pattern.matcher(eventSchema.getName());
@@ -140,12 +140,12 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
       throw new IllegalArgumentException(String.format("Unrecognized MXE class name: %s", className));
     }
 
-    return buildEventName(eventType, toUpperCamelCase(matcher.group("entity")),
+    return buildTopicName(eventType, toUpperCamelCase(matcher.group("entity")),
         toUpperCamelCase(matcher.group("aspect")));
   }
 
   @Nonnull
-  private String buildEventName(@Nonnull String eventType, @Nonnull String entityName, @Nonnull String aspectName) {
+  private String buildTopicName(@Nonnull String eventType, @Nonnull String entityName, @Nonnull String aspectName) {
     final String name = _eventPattern.replace(EVENT_TYPE_PLACEHOLDER, eventType)
         .replace(ENTITY_PLACEHOLDER, entityName)
         .replace(ASPECT_PLACEHOLDER, aspectName);
@@ -179,17 +179,17 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
     return Character.toLowerCase(str.charAt(0)) + str.substring(1);
   }
 
-  private String buildEventName(@Nonnull String eventType, @Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
+  private String buildTopicName(@Nonnull String eventType, @Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
     final String entityType = toUpperCamelCase(urn.getEntityType());
     final String aspectName = aspect.getClass().getSimpleName();
 
-    return buildEventName(eventType, entityType, aspectName);
+    return buildTopicName(eventType, entityType, aspectName);
   }
 
   @Nonnull
   @Override
   public String getMetadataChangeEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
-    return buildEventName(METADATA_CHANGE_EVENT_TYPE, urn, aspect);
+    return buildTopicName(METADATA_CHANGE_EVENT_TYPE, urn, aspect);
   }
 
   private Class<?> getClass(@Nonnull Urn urn, @Nonnull RecordTemplate aspect, @Nonnull String eventType)
@@ -211,7 +211,7 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
   @Nonnull
   @Override
   public String getMetadataAuditEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
-    return buildEventName(METADATA_AUDIT_EVENT_TYPE, urn, aspect);
+    return buildTopicName(METADATA_AUDIT_EVENT_TYPE, urn, aspect);
   }
 
   @Override
@@ -223,7 +223,7 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
   @Nonnull
   @Override
   public String getFailedMetadataChangeEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
-    return buildEventName(FAILED_METADATA_CHANGE_EVENT_TYPE, urn, aspect);
+    return buildTopicName(FAILED_METADATA_CHANGE_EVENT_TYPE, urn, aspect);
   }
 
   @Override

--- a/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
+++ b/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
  * as placeholders for the event type (MCE, MAE, FMCE, etc), entity name, and aspect name, respectively.
  *
  * <p>The default pattern is {@code %EVENT%_%ENTITY%_%ASPECT%}. So, for example, given an URN like
- * {@code urn:li:pizza:0} and an aspect like {@code PizzaInfo}, you would ge the following topic names by defalut:
+ * {@code urn:li:pizza:0} and an aspect like {@code PizzaInfo}, you would ge the following topic names by default:
  *
  * <ul>
  *   <li>{@code MCE_Pizza_PizzaInfo}

--- a/dao-api/src/test/java/com/linkedin/mxe/TopicConventionV5ImplTest.java
+++ b/dao-api/src/test/java/com/linkedin/mxe/TopicConventionV5ImplTest.java
@@ -5,12 +5,8 @@ import com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo.MetadataAuditEvent;
 import com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo.MetadataChangeEvent;
 import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
-import com.linkedin.testing.Pizza;
-import com.linkedin.testing.PizzaAspect;
 import com.linkedin.testing.PizzaInfo;
-import com.linkedin.testing.urn.FooUrn;
 import com.linkedin.testing.urn.PizzaUrn;
-import java.net.URISyntaxException;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;

--- a/dao-api/src/test/java/com/linkedin/mxe/TopicConventionV5ImplTest.java
+++ b/dao-api/src/test/java/com/linkedin/mxe/TopicConventionV5ImplTest.java
@@ -1,0 +1,147 @@
+package com.linkedin.mxe;
+
+import com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo.FailedMetadataChangeEvent;
+import com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo.MetadataAuditEvent;
+import com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo.MetadataChangeEvent;
+import com.linkedin.testing.AspectBar;
+import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.Pizza;
+import com.linkedin.testing.PizzaAspect;
+import com.linkedin.testing.PizzaInfo;
+import com.linkedin.testing.urn.FooUrn;
+import com.linkedin.testing.urn.PizzaUrn;
+import java.net.URISyntaxException;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class TopicConventionV5ImplTest {
+  @Test
+  public void metadataChangeEventName() {
+    assertEquals("MCE_Pizza_PizzaInfo",
+        new TopicConventionV5Impl().getMetadataChangeEventTopicName(new PizzaUrn(0), new PizzaInfo()));
+  }
+
+  @Test
+  public void metadataChangeEventNameCustomPattern() {
+    assertEquals("Pizza-PizzaInfo.MCE",
+        new TopicConventionV5Impl("%ENTITY%-%ASPECT%.%EVENT%").getMetadataChangeEventTopicName(new PizzaUrn(0),
+            new PizzaInfo()));
+  }
+
+  @Test
+  public void metadataChangeEventNameWithOverride() {
+    final TopicConventionV5 topicConvention =
+        new TopicConventionV5Impl().withOverride(MetadataChangeEvent.class, "customPizzaInfo")
+            .withOverride("MCE_Pizza_AspectBar", "customBar");
+
+    assertEquals("customPizzaInfo", topicConvention.getMetadataChangeEventTopicName(new PizzaUrn(0), new PizzaInfo()));
+    assertEquals("customBar", topicConvention.getMetadataChangeEventTopicName(new PizzaUrn(0), new AspectBar()));
+    assertEquals("MCE_Pizza_AspectFoo",
+        topicConvention.getMetadataChangeEventTopicName(new PizzaUrn(0), new AspectFoo()));
+  }
+
+  @Test
+  public void metadataChangeEventSchema() throws Exception {
+    final Class<?> schema = new TopicConventionV5Impl().getMetadataChangeEventSchema(new PizzaUrn(0), new PizzaInfo());
+
+    assertEquals(schema, MetadataChangeEvent.class);
+  }
+
+  @Test
+  public void missingMetadataChangeEventSchema() {
+    try {
+      new TopicConventionV5Impl().getMetadataChangeEventSchema(new PizzaUrn(0), new AspectFoo());
+      fail("Expected ClassNotFoundException");
+    } catch (ClassNotFoundException e) {
+      assertEquals(e.getMessage(), "com.linkedin.pegasus2avro.mxe.pizza.aspectFoo.MetadataChangeEvent");
+    }
+  }
+
+  @Test
+  public void metadataAuditEventName() {
+    assertEquals("MAE_Pizza_PizzaInfo",
+        new TopicConventionV5Impl().getMetadataAuditEventTopicName(new PizzaUrn(0), new PizzaInfo()));
+  }
+
+  @Test
+  public void metadataAuditEventNameWithOverride() {
+    final TopicConventionV5 topicConvention =
+        new TopicConventionV5Impl().withOverride(MetadataAuditEvent.class, "customPizzaInfo")
+            .withOverride("MAE_Pizza_AspectBar", "customBar");
+
+    assertEquals("customPizzaInfo", topicConvention.getMetadataAuditEventTopicName(new PizzaUrn(0), new PizzaInfo()));
+    assertEquals("customBar", topicConvention.getMetadataAuditEventTopicName(new PizzaUrn(0), new AspectBar()));
+    assertEquals("MAE_Pizza_AspectFoo",
+        topicConvention.getMetadataAuditEventTopicName(new PizzaUrn(0), new AspectFoo()));
+  }
+
+  @Test
+  public void metadataAuditEventNameCustomPattern() {
+    assertEquals("Pizza-PizzaInfo.MAE",
+        new TopicConventionV5Impl("%ENTITY%-%ASPECT%.%EVENT%").getMetadataAuditEventTopicName(new PizzaUrn(0),
+            new PizzaInfo()));
+  }
+
+  @Test
+  public void metadataAuditEventSchema() throws Exception {
+    final Class<?> schema = new TopicConventionV5Impl().getMetadataAuditEventSchema(new PizzaUrn(0), new PizzaInfo());
+
+    assertEquals(schema, MetadataAuditEvent.class);
+  }
+
+  @Test
+  public void missingMetadataAuditEventSchema() {
+    try {
+      new TopicConventionV5Impl().getMetadataAuditEventSchema(new PizzaUrn(0), new AspectFoo());
+      fail("Expected ClassNotFoundException");
+    } catch (ClassNotFoundException e) {
+      assertEquals(e.getMessage(), "com.linkedin.pegasus2avro.mxe.pizza.aspectFoo.MetadataAuditEvent");
+    }
+  }
+
+  @Test
+  public void failedMetadataChangeEventName() {
+    assertEquals("FMCE_Pizza_PizzaInfo",
+        new TopicConventionV5Impl().getFailedMetadataChangeEventTopicName(new PizzaUrn(0), new PizzaInfo()));
+  }
+
+  @Test
+  public void failedMetadataChangeEventNameWithOverride() {
+    final TopicConventionV5 topicConvention =
+        new TopicConventionV5Impl().withOverride(FailedMetadataChangeEvent.class, "customPizzaInfo")
+            .withOverride("FMCE_Pizza_AspectBar", "customBar");
+
+    assertEquals("customPizzaInfo",
+        topicConvention.getFailedMetadataChangeEventTopicName(new PizzaUrn(0), new PizzaInfo()));
+    assertEquals("customBar", topicConvention.getFailedMetadataChangeEventTopicName(new PizzaUrn(0), new AspectBar()));
+    assertEquals("FMCE_Pizza_AspectFoo",
+        topicConvention.getFailedMetadataChangeEventTopicName(new PizzaUrn(0), new AspectFoo()));
+  }
+
+  @Test
+  public void failedMetadataChangeEventNameCustomPattern() {
+    assertEquals("Pizza-PizzaInfo.FMCE",
+        new TopicConventionV5Impl("%ENTITY%-%ASPECT%.%EVENT%").getFailedMetadataChangeEventTopicName(new PizzaUrn(0),
+            new PizzaInfo()));
+  }
+
+  @Test
+  public void failedMetadataChangeEventSchema() throws Exception {
+    final Class<?> schema =
+        new TopicConventionV5Impl().getFailedMetadataChangeEventSchema(new PizzaUrn(0), new PizzaInfo());
+
+    assertEquals(schema, FailedMetadataChangeEvent.class);
+  }
+
+  @Test
+  public void missingFailedMetadataChangeEventSchema() {
+    try {
+      new TopicConventionV5Impl().getFailedMetadataChangeEventSchema(new PizzaUrn(0), new AspectFoo());
+      fail("Expected ClassNotFoundException");
+    } catch (ClassNotFoundException e) {
+      assertEquals(e.getMessage(), "com.linkedin.pegasus2avro.mxe.pizza.aspectFoo.FailedMetadataChangeEvent");
+    }
+  }
+}

--- a/dao-api/src/test/java/com/linkedin/pegasus2avro/mxe/pizza/pizzaInfo/FailedMetadataChangeEvent.java
+++ b/dao-api/src/test/java/com/linkedin/pegasus2avro/mxe/pizza/pizzaInfo/FailedMetadataChangeEvent.java
@@ -1,0 +1,9 @@
+package com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo;
+
+/**
+ * Manually created FMCE for testing. We cannot easily apply the plugin to generate this event because it is in the
+ * same gradle project.
+ */
+public class FailedMetadataChangeEvent {
+
+}

--- a/dao-api/src/test/java/com/linkedin/pegasus2avro/mxe/pizza/pizzaInfo/MetadataAuditEvent.java
+++ b/dao-api/src/test/java/com/linkedin/pegasus2avro/mxe/pizza/pizzaInfo/MetadataAuditEvent.java
@@ -1,0 +1,9 @@
+package com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo;
+
+/**
+ * Manually created MAE for testing. We cannot easily apply the plugin to generate this event because it is in the
+ * same gradle project.
+ */
+public class MetadataAuditEvent {
+
+}

--- a/dao-api/src/test/java/com/linkedin/pegasus2avro/mxe/pizza/pizzaInfo/MetadataChangeEvent.java
+++ b/dao-api/src/test/java/com/linkedin/pegasus2avro/mxe/pizza/pizzaInfo/MetadataChangeEvent.java
@@ -1,0 +1,9 @@
+package com.linkedin.pegasus2avro.mxe.pizza.pizzaInfo;
+
+/**
+ * Manually created MCE for testing. We cannot easily apply the plugin to generate this event because it is in the
+ * same gradle project.
+ */
+public class MetadataChangeEvent {
+
+}

--- a/gradle/checkstyle/suppressions.xml
+++ b/gradle/checkstyle/suppressions.xml
@@ -4,4 +4,6 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
   <suppress checks=".*" files="src/mainGeneratedDataTemplate"/>
+  <!-- Suppress camelCase package name warnings. -->
+  <suppress checks=".*" files="src/test/java/com/linkedin/pegasus2avro/mxe/pizza"/>
 </suppressions>

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/Pizza.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/Pizza.pdl
@@ -1,0 +1,27 @@
+namespace com.linkedin.testing
+
+
+/**
+ * Test entity that represnts a Pizza.
+ */
+record Pizza {
+  /**
+   * Urn of the entity.
+   */
+  urn: PizzaUrn
+
+  /**
+   * Size of the pizza.
+   */
+  size: optional PizzaSize
+
+  /**
+   * Toppings on the pizza.
+   */
+  toppings: optional array[string]
+
+  /**
+   * The shop that made this pizza.
+   */
+  madeBy: optional string
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaAspect.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaAspect.pdl
@@ -1,0 +1,6 @@
+namespace com.linkedin.testing
+
+
+typeref PizzaAspect = union[
+  PizzaInfo
+]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaInfo.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaInfo.pdl
@@ -1,0 +1,22 @@
+namespace com.linkedin.testing
+
+
+/**
+ * Test aspect that represnts basic information for a pizza Pizza.
+ */
+record PizzaInfo {
+  /**
+   * Size of the pizza.
+   */
+  size: optional PizzaSize
+
+  /**
+   * Toppings on the pizza.
+   */
+  toppings: optional array[string]
+
+  /**
+   * The shop that made this pizza.
+   */
+  madeBy: optional string
+}


### PR DESCRIPTION
… MXE v5 event topics and get their schemas.

We can then use this to dynamically get topic names (and schemas) from Urn/RecordTemplates, rather than hard code everything, which we have done internally.

This ships with a default implementation that allows for some customization, but without any will do %event type%_%entity%_%aspect%.

This is being split off from the one in DataHub, which was both v4 and v5 (but v5 was not implemented there; it is here, we can delete it there in a follow up).

https://github.com/linkedin/datahub/tree/125ae288f1601bef2c42f44db6d8eb58b380a304/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
