### PR TITLE
feat(search-by-field): Add match highlights to BaseSearchDAO

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/SearchResultMetadata.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/SearchResultMetadata.pdl
@@ -27,4 +27,26 @@ record SearchResultMetadata {
    * A list of urns corresponding to search documents (in order) as returned by the search index
    */
   urns: array[Urn]
+
+  /**
+   * A list of match metadata for each search result, containing the list of fields in the search document that matched the query
+   */
+  matches: optional array[record MatchMetadata {
+
+    /**
+     * Matched field name and values
+     */
+    matchedFields: array[record MatchedField {
+
+      /**
+       * Matched field name
+       */
+      name: string
+
+      /**
+       * Matched field value
+       */
+      value: string
+    }]
+  }]
 }

--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/search/BaseSearchConfig.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/search/BaseSearchConfig.java
@@ -1,6 +1,8 @@
 package com.linkedin.metadata.dao.search;
 
 import com.linkedin.data.template.RecordTemplate;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,6 +31,15 @@ public abstract class BaseSearchConfig<DOCUMENT extends RecordTemplate> {
 
   @Nonnull
   public abstract String getSearchQueryTemplate();
+
+  /**
+   * List of fields to check for matches.
+   * Note, resulting matches are ranked by the order of fields in this list
+   */
+  @Nonnull
+  public List<String> getFieldsToHighlightMatch() {
+    return Collections.emptyList();
+  }
 
   @Nonnull
   public abstract String getAutocompleteQueryTemplate();

--- a/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
+++ b/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/ESSearchDAOTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.dao.search;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.UrnArray;
 import com.linkedin.data.DataList;
@@ -11,6 +12,7 @@ import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
 import com.linkedin.metadata.query.CriterionArray;
 import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.MatchedField;
 import com.linkedin.metadata.query.SearchResultMetadata;
 import com.linkedin.metadata.query.SortCriterion;
 import com.linkedin.metadata.query.SortOrder;
@@ -23,20 +25,27 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static com.linkedin.metadata.dao.utils.QueryUtils.*;
-import static com.linkedin.testing.TestUtils.*;
-import static org.testng.Assert.*;
-import static org.mockito.Mockito.*;
+import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+import static com.linkedin.testing.TestUtils.makeUrn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 
 public class ESSearchDAOTest {
@@ -62,35 +71,35 @@ public class ESSearchDAOTest {
     // Test empty fieldVal
     List<String> fieldValList = Collections.emptyList();
     String searchInput = "searchInput";
-    List<String> searchResult = ESAutoCompleteQueryForHighCardinalityFields
-        .decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
+    List<String> searchResult =
+        ESAutoCompleteQueryForHighCardinalityFields.decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
     assertEquals(searchResult.size(), 0);
 
     // Test non-list fieldVal
     String fieldValString = "fieldVal";
     searchInput = "searchInput";
-    searchResult = ESAutoCompleteQueryForHighCardinalityFields
-        .decoupleArrayToGetSubstringMatch(fieldValString, searchInput);
+    searchResult =
+        ESAutoCompleteQueryForHighCardinalityFields.decoupleArrayToGetSubstringMatch(fieldValString, searchInput);
     assertEquals(searchResult.size(), 1);
 
     // Test list fieldVal with no match
     fieldValList = Arrays.asList("fieldVal1", "fieldVal2", "fieldVal3");
     searchInput = "searchInput";
-    searchResult = ESAutoCompleteQueryForHighCardinalityFields
-        .decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
+    searchResult =
+        ESAutoCompleteQueryForHighCardinalityFields.decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
     assertEquals(searchResult.size(), 0);
 
     // Test list fieldVal with single match
     searchInput = "val1";
-    searchResult = ESAutoCompleteQueryForHighCardinalityFields
-        .decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
+    searchResult =
+        ESAutoCompleteQueryForHighCardinalityFields.decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
     assertEquals(searchResult.size(), 1);
     assertEquals(searchResult.get(0), "fieldVal1");
 
     // Test list fieldVal with multiple match
     searchInput = "val";
-    searchResult = ESAutoCompleteQueryForHighCardinalityFields
-        .decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
+    searchResult =
+        ESAutoCompleteQueryForHighCardinalityFields.decoupleArrayToGetSubstringMatch(fieldValList, searchInput);
     assertEquals(searchResult.size(), 3);
     assertTrue(searchResult.equals(fieldValList));
   }
@@ -106,7 +115,7 @@ public class ESSearchDAOTest {
     SearchResponse searchResponse = mock(SearchResponse.class);
     when(searchResponse.getHits()).thenReturn(searchHits);
 
-    StringArray res  = _esAutoCompleteQuery.getSuggestionList(searchResponse, "name", "test", 2);
+    StringArray res = _esAutoCompleteQuery.getSuggestionList(searchResponse, "name", "test", 2);
 
     assertEquals(res.size(), 2);
   }
@@ -128,7 +137,8 @@ public class ESSearchDAOTest {
     SearchResponse searchResponse2 = mock(SearchResponse.class);
     when(searchResponse2.getHits()).thenReturn(searchHits2);
     UrnArray urns = new UrnArray(Arrays.asList(makeUrn(1), makeUrn(2)));
-    assertEquals(_searchDAO.extractSearchResultMetadata(searchResponse2), getDefaultSearchResultMetadata().setUrns(urns));
+    assertEquals(_searchDAO.extractSearchResultMetadata(searchResponse2),
+        getDefaultSearchResultMetadata().setUrns(urns));
 
     // Test: urn field does not exist in one search document, exists in another
     SearchHits searchHits3 = mock(SearchHits.class);
@@ -139,6 +149,34 @@ public class ESSearchDAOTest {
     SearchResponse searchResponse3 = mock(SearchResponse.class);
     when(searchResponse3.getHits()).thenReturn(searchHits3);
     assertThrows(RuntimeException.class, () -> _searchDAO.extractSearchResultMetadata(searchResponse3));
+
+    // Test: highlights exist in one search document, and doesn't exist in another
+    SearchHits searchHits4 = mock(SearchHits.class);
+    SearchHit hit5 = makeSearchHit(5);
+    SearchHit hit6 = makeSearchHit(6, ImmutableMap.of("field1", ImmutableList.of("fieldValue1")));
+    SearchHit hit7 = makeSearchHit(7, ImmutableMap.of("field1", ImmutableList.of("fieldValue1"), "field2",
+        ImmutableList.of("fieldValue21", "fieldValue22")));
+    SearchHit hit8 = makeSearchHit(8, ImmutableMap.of("field1", ImmutableList.of("fieldValue1"), "field1.delimited",
+        ImmutableList.of("fieldValue1", "fieldValue2")));
+    when(searchHits4.getHits()).thenReturn(new SearchHit[]{hit5, hit6, hit7, hit8});
+    SearchResponse searchResponse4 = mock(SearchResponse.class);
+    when(searchResponse4.getHits()).thenReturn(searchHits4);
+    SearchResultMetadata searchResultMetadata = _searchDAO.extractSearchResultMetadata(searchResponse4);
+    assertEquals(searchResultMetadata.getMatches().size(), 4);
+    assertEquals(extractMatchedFields(searchResultMetadata, 0), ImmutableList.of());
+    assertEquals(extractMatchedFields(searchResultMetadata, 1),
+        ImmutableList.of(new MatchedField().setName("field1").setValue("fieldValue1")));
+    List<MatchedField> matchesHit7 = extractMatchedFields(searchResultMetadata, 2);
+    assertEquals(matchesHit7.size(), 3);
+    assertEquals(matchesHit7.get(0), new MatchedField().setName("field1").setValue("fieldValue1"));
+    // Note order of values are not deterministic
+    assertEquals(matchesHit7.get(1).getName(), "field2");
+    assertEquals(matchesHit7.get(2).getName(), "field2");
+    List<MatchedField> matchesHit8 = extractMatchedFields(searchResultMetadata, 3);
+    assertEquals(matchesHit8.size(), 2);
+    // Note order of values are not deterministic
+    assertEquals(matchesHit8.get(0).getName(), "field1");
+    assertEquals(matchesHit8.get(1).getName(), "field1");
   }
 
   @Test
@@ -164,17 +202,17 @@ public class ESSearchDAOTest {
     // Test 1: sort order provided
     SearchRequest searchRequest = _searchDAO.getFilteredSearchQuery(filter, sortCriterion, from, size);
     assertEquals(searchRequest.source().toString(), loadJsonFromResource("SortByUrnTermsFilterQuery.json"));
-    assertEquals(searchRequest.indices(), new String[] {_testSearchConfig.getIndexName()});
+    assertEquals(searchRequest.indices(), new String[]{_testSearchConfig.getIndexName()});
 
     // Test 2: no sort order provided, default is used.
     searchRequest = _searchDAO.getFilteredSearchQuery(filter, null, from, size);
     assertEquals(searchRequest.source().toString(), loadJsonFromResource("DefaultSortTermsFilterQuery.json"));
-    assertEquals(searchRequest.indices(), new String[] {_testSearchConfig.getIndexName()});
+    assertEquals(searchRequest.indices(), new String[]{_testSearchConfig.getIndexName()});
 
     // Test 3: empty request map provided
     searchRequest = _searchDAO.getFilteredSearchQuery(EMPTY_FILTER, sortCriterion, from, size);
     assertEquals(searchRequest.source().toString(), loadJsonFromResource("EmptyFilterQuery.json"));
-    assertEquals(searchRequest.indices(), new String[] {_testSearchConfig.getIndexName()});
+    assertEquals(searchRequest.indices(), new String[]{_testSearchConfig.getIndexName()});
   }
 
   @Test
@@ -193,17 +231,16 @@ public class ESSearchDAOTest {
   public void testFilteredQueryWithRangeFilter() throws IOException {
     int from = 0;
     int size = 10;
-    final Filter filter1 = new Filter().setCriteria(new CriterionArray(Arrays.asList(
-        new Criterion().setField("field_gt").setValue("100").setCondition(Condition.GREATER_THAN),
-        new Criterion().setField("field_gte").setValue("200").setCondition(Condition.GREATER_THAN_OR_EQUAL_TO),
-        new Criterion().setField("field_lt").setValue("300").setCondition(Condition.LESS_THAN),
-        new Criterion().setField("field_lte").setValue("400").setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
-    )));
+    final Filter filter1 = new Filter().setCriteria(new CriterionArray(
+        Arrays.asList(new Criterion().setField("field_gt").setValue("100").setCondition(Condition.GREATER_THAN),
+            new Criterion().setField("field_gte").setValue("200").setCondition(Condition.GREATER_THAN_OR_EQUAL_TO),
+            new Criterion().setField("field_lt").setValue("300").setCondition(Condition.LESS_THAN),
+            new Criterion().setField("field_lte").setValue("400").setCondition(Condition.LESS_THAN_OR_EQUAL_TO))));
     SortCriterion sortCriterion = new SortCriterion().setOrder(SortOrder.ASCENDING).setField("urn");
 
     SearchRequest searchRequest = _searchDAO.getFilteredSearchQuery(filter1, sortCriterion, from, size);
     assertEquals(searchRequest.source().toString(), loadJsonFromResource("RangeFilterQuery.json"));
-    assertEquals(searchRequest.indices(), new String[] {_testSearchConfig.getIndexName()});
+    assertEquals(searchRequest.indices(), new String[]{_testSearchConfig.getIndexName()});
   }
 
   @Test
@@ -211,10 +248,10 @@ public class ESSearchDAOTest {
     int from = 0;
     int size = 10;
     final Filter filter2 = new Filter().setCriteria(new CriterionArray(Arrays.asList(
-        new Criterion().setField("field_contain").setValue("value_contain").setCondition(Condition.CONTAIN)
-    )));
+        new Criterion().setField("field_contain").setValue("value_contain").setCondition(Condition.CONTAIN))));
     SortCriterion sortCriterion = new SortCriterion().setOrder(SortOrder.ASCENDING).setField("urn");
-    assertThrows(UnsupportedOperationException.class, () -> _searchDAO.getFilteredSearchQuery(filter2, sortCriterion, from, size));
+    assertThrows(UnsupportedOperationException.class,
+        () -> _searchDAO.getFilteredSearchQuery(filter2, sortCriterion, from, size));
   }
 
   @Test
@@ -252,11 +289,28 @@ public class ESSearchDAOTest {
     sourceMap.put("urn", makeUrn(id).toString());
     sourceMap.put("name", "test" + id);
     when(hit.getSourceAsMap()).thenReturn(sourceMap);
+    return hit;
+  }
+
+  private static SearchHit makeSearchHit(int id, Map<String, List<String>> highlightedFields) {
+    SearchHit hit = mock(SearchHit.class);
+    Map<String, Object> sourceMap = new HashMap<>();
+    sourceMap.put("urn", makeUrn(id).toString());
+    sourceMap.put("name", "test" + id);
     when(hit.getSourceAsMap()).thenReturn(sourceMap);
+    when(hit.getHighlightFields()).thenReturn(highlightedFields.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> new HighlightField(entry.getKey(),
+            entry.getValue().stream().map(Text::new).toArray(Text[]::new)))));
     return hit;
   }
 
   private static SearchResultMetadata getDefaultSearchResultMetadata() {
-    return new SearchResultMetadata().setSearchResultMetadatas(new AggregationMetadataArray()).setUrns(new UrnArray());
+    return new SearchResultMetadata().setSearchResultMetadatas(new AggregationMetadataArray())
+        .setUrns(new UrnArray());
+  }
+
+  private static List<MatchedField> extractMatchedFields(SearchResultMetadata searchResultMetadata, int index) {
+    return new ArrayList<>(searchResultMetadata.getMatches().get(index).getMatchedFields());
   }
 }

--- a/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
+++ b/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
@@ -1,7 +1,9 @@
 package com.linkedin.metadata.dao.search;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.testing.EntityDocument;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -34,5 +36,11 @@ public class TestSearchConfig extends BaseSearchConfig<EntityDocument> {
   @Nonnull
   public String getAutocompleteQueryTemplate() {
     return "";
+  }
+
+  @Override
+  @Nonnull
+  public List<String> getFieldsToHighlightMatch() {
+    return ImmutableList.of("field1", "field2");
   }
 }

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/BaseSearchConfig.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/BaseSearchConfig.java
@@ -1,6 +1,8 @@
 package com.linkedin.metadata.dao.search;
 
 import com.linkedin.data.template.RecordTemplate;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,6 +31,15 @@ public abstract class BaseSearchConfig<DOCUMENT extends RecordTemplate> {
 
   @Nonnull
   public abstract String getSearchQueryTemplate();
+
+  /**
+   * List of fields to check for matches.
+   * Note, resulting matches are ranked by the order of fields in this list
+   */
+  @Nonnull
+  public List<String> getFieldsToHighlightMatch() {
+    return Collections.emptyList();
+  }
 
   @Nonnull
   public abstract String getAutocompleteQueryTemplate();

--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESSearchDAO.java
@@ -16,16 +16,23 @@ import com.linkedin.metadata.query.AggregationMetadataArray;
 import com.linkedin.metadata.query.AutoCompleteResult;
 import com.linkedin.metadata.query.Criterion;
 import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.MatchMetadata;
+import com.linkedin.metadata.query.MatchMetadataArray;
+import com.linkedin.metadata.query.MatchedField;
+import com.linkedin.metadata.query.MatchedFieldArray;
 import com.linkedin.metadata.query.SearchResultMetadata;
 import com.linkedin.metadata.query.SortCriterion;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -45,8 +53,10 @@ import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 
-import static com.linkedin.metadata.dao.utils.SearchUtils.*;
+import static com.linkedin.metadata.dao.utils.SearchUtils.getQueryBuilderFromCriterion;
 
 
 /**
@@ -64,6 +74,9 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
   private BaseESAutoCompleteQuery _autoCompleteQueryForHighCardFields;
   private int _maxTermBucketSize = DEFAULT_TERM_BUCKETS_SIZE_100;
 
+  // Regex patterns for matching original field names to the highlighted field name returned by elasticsearch
+  private Map<String, Pattern> _highlightedFieldNamePatterns;
+
   // TODO: Currently takes elastic search client, in future, can take other clients such as galene
   // TODO: take params and settings needed to create the client
   public ESSearchDAO(@Nonnull RestHighLevelClient esClient, @Nonnull Class<DOCUMENT> documentClass,
@@ -73,6 +86,11 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
     _config = config;
     _autoCompleteQueryForLowCardFields = new ESAutoCompleteQueryForLowCardinalityFields(_config);
     _autoCompleteQueryForHighCardFields = new ESAutoCompleteQueryForHighCardinalityFields(_config);
+    // Add regex pattern that checks whether the field name from elasticsearch
+    // matches the original field name or any sub-fields i.e. name, name.delimited, name.edge_ngram
+    _highlightedFieldNamePatterns = config.getFieldsToHighlightMatch()
+        .stream()
+        .collect(Collectors.toMap(Function.identity(), fieldName -> Pattern.compile(fieldName + "(\\..+)?")));
   }
 
   @Nonnull
@@ -150,8 +168,8 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
 
   @Override
   @Nonnull
-  public SearchResult<DOCUMENT> filter(@Nullable Filter filters, @Nullable SortCriterion sortCriterion,
-      int from, int size) {
+  public SearchResult<DOCUMENT> filter(@Nullable Filter filters, @Nullable SortCriterion sortCriterion, int from,
+      int size) {
 
     final SearchRequest searchRequest = getFilteredSearchQuery(filters, sortCriterion, from, size);
     return executeAndExtract(searchRequest, from, size);
@@ -168,16 +186,16 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
    * @return {@link SearchRequest} that contains the filtered query
    */
   @Nonnull
-  SearchRequest getFilteredSearchQuery(@Nullable Filter filters, @Nullable SortCriterion sortCriterion,
-      int from, int size) {
+  SearchRequest getFilteredSearchQuery(@Nullable Filter filters, @Nullable SortCriterion sortCriterion, int from,
+      int size) {
 
     final BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
     if (filters != null) {
       filters.getCriteria().forEach(criterion -> {
-            if (!criterion.getValue().trim().isEmpty()) {
-              boolQueryBuilder.filter(getQueryBuilderFromCriterion(criterion));
-            }
-          });
+        if (!criterion.getValue().trim().isEmpty()) {
+          boolQueryBuilder.filter(getQueryBuilderFromCriterion(criterion));
+        }
+      });
     }
     final SearchRequest searchRequest = new SearchRequest(_config.getIndexName());
     final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
@@ -199,7 +217,7 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
    * @param from index to start the search from
    * @param size the number of search hits to return
    * @return a valid search request
-   * @deprecated  please use {@link #constructSearchQuery(String, Filter, SortCriterion, String, int, int)} instead
+   * @deprecated please use {@link #constructSearchQuery(String, Filter, SortCriterion, String, int, int)} instead
    */
   @Nonnull
   public SearchRequest constructSearchQuery(@Nonnull String input, @Nullable Filter filter,
@@ -236,6 +254,7 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
     searchSourceBuilder.query(buildQueryString(input));
     searchSourceBuilder.postFilter(ESUtils.buildFilterQuery(filter));
     buildAggregations(searchSourceBuilder, filter);
+    buildHighlights(searchSourceBuilder, _config.getFieldsToHighlightMatch());
     ESUtils.buildSortOrder(searchSourceBuilder, sortCriterion);
 
     searchRequest.source(searchSourceBuilder);
@@ -251,8 +270,7 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
    * @param searchSourceBuilder the builder to build search source for search request
    * @param filter the search filters
    */
-  private void buildAggregations(@Nonnull SearchSourceBuilder searchSourceBuilder,
-      @Nullable Filter filter) {
+  private void buildAggregations(@Nonnull SearchSourceBuilder searchSourceBuilder, @Nullable Filter filter) {
     Set<String> facetFields = _config.getFacetFields();
     for (String facet : facetFields) {
       AggregationBuilder aggBuilder = AggregationBuilders.terms(facet).field(facet).size(_maxTermBucketSize);
@@ -267,6 +285,24 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
       });
       searchSourceBuilder.aggregation(aggBuilder);
     }
+  }
+
+  /**
+   * Constructs the highlighter based on the list of fields to highlight.
+   *
+   * @param searchSourceBuilder the builder to build search source for search request
+   * @param fieldsToHighlight list of fields to highlight
+   */
+  private void buildHighlights(@Nonnull SearchSourceBuilder searchSourceBuilder,
+      @Nullable List<String> fieldsToHighlight) {
+    if (fieldsToHighlight == null || fieldsToHighlight.isEmpty()) {
+      return;
+    }
+    HighlightBuilder highlightBuilder = new HighlightBuilder();
+    highlightBuilder.preTags("");
+    highlightBuilder.postTags("");
+    fieldsToHighlight.forEach(field -> highlightBuilder.field(field).field(field + ".*"));
+    searchSourceBuilder.highlighter(highlightBuilder);
   }
 
   /**
@@ -303,8 +339,8 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
    */
   @Nonnull
   List<DOCUMENT> getDocuments(@Nonnull SearchResponse searchResponse) {
-    return (Arrays.stream(searchResponse.getHits().getHits())).map(hit ->
-      newDocument(buildDocumentsDataMap(hit.getSourceAsMap()))).collect(Collectors.toList());
+    return (Arrays.stream(searchResponse.getHits().getHits())).map(
+        hit -> newDocument(buildDocumentsDataMap(hit.getSourceAsMap()))).collect(Collectors.toList());
   }
 
   /**
@@ -379,20 +415,34 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
     }
 
     final Aggregations aggregations = searchResponse.getAggregations();
-    if (aggregations == null) {
-      return searchResultMetadata;
+    if (aggregations != null) {
+      final AggregationMetadataArray aggregationMetadataArray = new AggregationMetadataArray();
+
+      for (Map.Entry<String, Aggregation> entry : aggregations.getAsMap().entrySet()) {
+        final Map<String, Long> oneTermAggResult = extractTermAggregations((ParsedTerms) entry.getValue());
+        final AggregationMetadata aggregationMetadata =
+            new AggregationMetadata().setName(entry.getKey()).setAggregations(new LongMap(oneTermAggResult));
+        aggregationMetadataArray.add(aggregationMetadata);
+      }
+
+      searchResultMetadata.setSearchResultMetadatas(aggregationMetadataArray);
     }
 
-    final AggregationMetadataArray aggregationMetadataArray = new AggregationMetadataArray();
-
-    for (Map.Entry<String, Aggregation> entry : aggregations.getAsMap().entrySet()) {
-      final Map<String, Long> oneTermAggResult = extractTermAggregations((ParsedTerms) entry.getValue());
-      final AggregationMetadata aggregationMetadata =
-          new AggregationMetadata().setName(entry.getKey()).setAggregations(new LongMap(oneTermAggResult));
-      aggregationMetadataArray.add(aggregationMetadata);
+    if (searchResponse.getHits() != null && searchResponse.getHits().getHits() != null) {
+      boolean hasMatch = false;
+      final List<MatchMetadata> highlightMetadataList = new ArrayList<>(searchResponse.getHits().getHits().length);
+      for (SearchHit hit : searchResponse.getHits().getHits()) {
+        if (!hit.getHighlightFields().isEmpty()) {
+          hasMatch = true;
+        }
+        highlightMetadataList.add(extractMatchMetadata(hit.getHighlightFields()));
+      }
+      if (hasMatch) {
+        searchResultMetadata.setMatches(new MatchMetadataArray(highlightMetadataList));
+      }
     }
 
-    return searchResultMetadata.setSearchResultMetadatas(aggregationMetadataArray);
+    return searchResultMetadata;
   }
 
   /**
@@ -437,6 +487,54 @@ public class ESSearchDAO<DOCUMENT extends RecordTemplate> extends BaseSearchDAO<
     }
 
     return parsedFilter;
+  }
+
+  /**
+   * Extracts highlight metadata from highlighted fields returned by Elasticsearch.
+   *
+   * @param highlightedFields map of matched field name to list of field values
+   * @return highlight metadata
+   */
+  @Nonnull
+  private MatchMetadata extractMatchMetadata(@Nonnull Map<String, HighlightField> highlightedFields) {
+    Map<String, Set<String>> highlightedFieldNamesAndValues = new HashMap<>();
+    for (Map.Entry<String, HighlightField> entry : highlightedFields.entrySet()) {
+      // Get the field name from source e.g. name.delimited -> name
+      Optional<String> fieldName = getFieldName(entry.getKey());
+      if (!fieldName.isPresent()) {
+        continue;
+      }
+      if (!highlightedFieldNamesAndValues.containsKey(fieldName.get())) {
+        highlightedFieldNamesAndValues.put(fieldName.get(), new HashSet<>());
+      }
+      for (Text fieldValue : entry.getValue().getFragments()) {
+        highlightedFieldNamesAndValues.get(fieldName.get()).add(fieldValue.string());
+      }
+    }
+    // Rank the highlights based on the order of field names in the config
+    return new MatchMetadata().setMatchedFields(new MatchedFieldArray(_config.getFieldsToHighlightMatch()
+        .stream()
+        .filter(highlightedFieldNamesAndValues::containsKey)
+        .flatMap(fieldName -> highlightedFieldNamesAndValues.get(fieldName)
+            .stream()
+            .map(value -> new MatchedField().setName(fieldName).setValue(value)))
+        .collect(Collectors.toList())));
+  }
+
+  /**
+   * Get the original field name that matches the given highlighted field name.
+   * i.e. name.delimited, name.ngram, name -> name
+   *
+   * @param highlightedFieldName highlighted field name from search response
+   * @return original field name
+   */
+  @Nonnull
+  private Optional<String> getFieldName(String highlightedFieldName) {
+    return _highlightedFieldNamePatterns.entrySet()
+        .stream()
+        .filter(entry -> entry.getValue().matcher(highlightedFieldName).matches())
+        .map(Map.Entry::getKey)
+        .findFirst();
   }
 
   @Nonnull

--- a/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
+++ b/dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/search/TestSearchConfig.java
@@ -1,7 +1,9 @@
 package com.linkedin.metadata.dao.search;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.testing.EntityDocument;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -34,5 +36,11 @@ public class TestSearchConfig extends BaseSearchConfig<EntityDocument> {
   @Nonnull
   public String getAutocompleteQueryTemplate() {
     return "";
+  }
+
+  @Override
+  @Nonnull
+  public List<String> getFieldsToHighlightMatch() {
+    return ImmutableList.of("field1", "field2");
   }
 }


### PR DESCRIPTION
Add the ability to highlight which part of the search document matched the query. This allows us to highlight any matches that do not show up in the preview (for instance, search for field names in a dataset will highlight the field name that matched the query)

In order for us to control the order of highlighted matches, the PDL matchMetadata field in SearchResultsMetadata holds a list of matched fields for each search element. 

*** Tests ***
Once GMS is deployed with this version of gma, 
http://localhost:8080/datasets?q=search&input=covid19
```
{
    "metadata": {
        "urns": [ ... ],
        "matches": [
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_usafacts.deaths",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_usafacts.confirmed_cases",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_italy.data_by_region",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_public_forecasts.state_14d",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_ecdc.covid_19_geographic_distribution_worldwide",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_public_forecasts.japan_prefecture_28d",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_public_forecasts.state_14d_historical",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_symptom_search.symptom_search_country_weekly",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_weathersource_com.county_day_forecast",
                        "fieldName": "name"
                    }
                ]
            },
            {
                "matchedFields": [
                    {
                        "fieldValue": "bigquery-public-data.covid19_weathersource_com.postal_code_day_forecast",
                        "fieldName": "name"
                    }
                ]
            }
        ],
        "searchResultMetadatas": [ ... ]
    },
    "elements": [ ... ],
    "paging": { ... }
}
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
