### PR TITLE
fix: Use UNION for batch get rather than OR.

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -536,6 +536,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     //   ...
     // Note: UNION ALL should be safe and more performant than UNION. We're selecting the entire entity key (as well
     // as data), so each result should be unique. No need to deduplicate.
+    // Another note: ebean doesn't support UNION ALL, so we need to manually build the SQL statement ourselves.
     final StringBuilder sb = new StringBuilder();
     final int end = Math.min(keys.size(), position + keysCount);
     final Map<String, Object> params = new HashMap<>();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -246,7 +246,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   protected <ASPECT extends RecordTemplate> long saveLatest(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
-      @Nullable ASPECT oldValue, @Nullable AuditStamp oldAuditStamp, @Nonnull ASPECT newValue, @Nonnull AuditStamp newAuditStamp) {
+      @Nullable ASPECT oldValue, @Nullable AuditStamp oldAuditStamp, @Nonnull ASPECT newValue,
+      @Nonnull AuditStamp newAuditStamp) {
     // Save oldValue as the largest version + 1
     long largestVersion = 0;
     if (oldValue != null && oldAuditStamp != null) {
@@ -260,8 +261,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  protected <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn,
-      @Nonnull ASPECT newValue, long version) {
+  protected <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn, @Nonnull ASPECT newValue,
+      long version) {
     if (!isLocalSecondaryIndexEnabled()) {
       throw new UnsupportedOperationException("Local secondary index isn't supported");
     }
@@ -311,13 +312,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
-  protected long saveSingleRecordToLocalIndex(@Nonnull URN urn, @Nonnull String aspect,
-      @Nonnull String path, @Nonnull Object value) {
+  protected long saveSingleRecordToLocalIndex(@Nonnull URN urn, @Nonnull String aspect, @Nonnull String path,
+      @Nonnull Object value) {
 
-    final EbeanMetadataIndex record = new EbeanMetadataIndex()
-        .setUrn(urn.toString())
-        .setAspect(aspect)
-        .setPath(path);
+    final EbeanMetadataIndex record = new EbeanMetadataIndex().setUrn(urn.toString()).setAspect(aspect).setPath(path);
     if (value instanceof Integer || value instanceof Long) {
       record.setLongVal(Long.valueOf(value.toString()));
     } else if (value instanceof Float || value instanceof Double) {
@@ -342,15 +340,13 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     final Map<String, Object> pathValueMap = _urnPathExtractor.extractPaths(urn);
     pathValueMap.forEach(
-        (path, value) -> saveSingleRecordToLocalIndex(urn, urn.getClass().getCanonicalName(), path, value)
-    );
+        (path, value) -> saveSingleRecordToLocalIndex(urn, urn.getClass().getCanonicalName(), path, value));
   }
 
   private <ASPECT extends RecordTemplate> void updateAspectInLocalIndex(@Nonnull URN urn, @Nonnull ASPECT newValue) {
 
     if (!_storageConfig.getAspectStorageConfigMap().containsKey(newValue.getClass())
-        || _storageConfig.getAspectStorageConfigMap().get(newValue.getClass()) == null
-    ) {
+        || _storageConfig.getAspectStorageConfigMap().get(newValue.getClass()) == null) {
       return;
     }
     // step1: remove all rows from the index table corresponding to <urn, aspect> pair
@@ -454,11 +450,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     return result;
   }
 
-
   public boolean existsInLocalIndex(@Nonnull URN urn) {
-    return _server.find(EbeanMetadataIndex.class)
-        .where().eq(URN_COLUMN, urn.toString())
-        .exists();
+    return _server.find(EbeanMetadataIndex.class).where().eq(URN_COLUMN, urn.toString()).exists();
   }
 
   // Will be migrated to use {@link #batchGet(Set<AspectKey<URN, ? extends RecordTemplate>>, int)}
@@ -499,7 +492,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param keysCount the max number of keys for each sub query
    */
   @Nonnull
-  private List<EbeanMetadataAspect> batchGet(@Nonnull Set<AspectKey<URN, ? extends RecordTemplate>> keys, int keysCount) {
+  private List<EbeanMetadataAspect> batchGet(@Nonnull Set<AspectKey<URN, ? extends RecordTemplate>> keys,
+      int keysCount) {
 
     int position = 0;
     final int totalPageCount = QueryUtils.getTotalPageCount(keys.size(), keysCount);
@@ -514,7 +508,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  private List<EbeanMetadataAspect> batchGetHelper(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys, int keysCount, int position) {
+  private List<EbeanMetadataAspect> batchGetHelper(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
+      int keysCount, int position) {
     ExpressionList<EbeanMetadataAspect> query = _server.find(EbeanMetadataAspect.class).select(ALL_COLUMNS).where();
 
     // add or if it is not the last element
@@ -584,7 +579,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .asc(URN_COLUMN)
         .findPagedList();
 
-    final List<URN> urns = pagedList.getList().stream().map(entry -> getUrn(entry.getKey().getUrn())).collect(Collectors.toList());
+    final List<URN> urns =
+        pagedList.getList().stream().map(entry -> getUrn(entry.getKey().getUrn())).collect(Collectors.toList());
     return toListResult(urns, null, pagedList, start);
   }
 
@@ -608,8 +604,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     final List<ASPECT> aspects =
         pagedList.getList().stream().map(a -> toRecordTemplate(aspectClass, a)).collect(Collectors.toList());
-    final ListResultMetadata listResultMetadata =
-        makeListResultMetadata(pagedList.getList().stream().map(EbeanLocalDAO::toExtraInfo).collect(Collectors.toList()));
+    final ListResultMetadata listResultMetadata = makeListResultMetadata(
+        pagedList.getList().stream().map(EbeanLocalDAO::toExtraInfo).collect(Collectors.toList()));
     return toListResult(aspects, listResultMetadata, pagedList, start);
   }
 
@@ -633,8 +629,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     final List<ASPECT> aspects =
         pagedList.getList().stream().map(a -> toRecordTemplate(aspectClass, a)).collect(Collectors.toList());
-    final ListResultMetadata listResultMetadata =
-        makeListResultMetadata(pagedList.getList().stream().map(EbeanLocalDAO::toExtraInfo).collect(Collectors.toList()));
+    final ListResultMetadata listResultMetadata = makeListResultMetadata(
+        pagedList.getList().stream().map(EbeanLocalDAO::toExtraInfo).collect(Collectors.toList()));
     return toListResult(aspects, listResultMetadata, pagedList, start);
   }
 
@@ -671,7 +667,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   private <T> ListResult<T> toListResult(@Nonnull List<T> values, @Nullable ListResultMetadata listResultMetadata,
       @Nonnull PagedList<?> pagedList, @Nullable Integer start) {
-    final int nextStart = (start != null && pagedList.hasNext()) ? start + pagedList.getList().size() : ListResult.INVALID_NEXT_START;
+    final int nextStart =
+        (start != null && pagedList.hasNext()) ? start + pagedList.getList().size() : ListResult.INVALID_NEXT_START;
     return ListResult.<T>builder()
         // Format
         .values(values)
@@ -745,7 +742,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (indexValue.isBoolean()) {
       object = indexValue.getBoolean().toString();
       return new GMAIndexPair(EbeanMetadataIndex.STRING_COLUMN, object);
-    }  else if (indexValue.isDouble()) {
+    } else if (indexValue.isDouble()) {
       object = indexValue.getDouble();
       return new GMAIndexPair(EbeanMetadataIndex.DOUBLE_COLUMN, object);
     } else if (indexValue.isFloat()) {
@@ -775,8 +772,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param lastUrn string representation of the urn whose value is used to set the last urn parameter in index query
    * @param pageSize maximum number of distinct urns to return which is essentially the LIMIT clause of SQL query
    */
-  private static void setParameters(@Nonnull IndexCriterionArray indexCriterionArray, @Nonnull Query<EbeanMetadataIndex> indexQuery,
-      @Nonnull String lastUrn, int pageSize) {
+  private static void setParameters(@Nonnull IndexCriterionArray indexCriterionArray,
+      @Nonnull Query<EbeanMetadataIndex> indexQuery, @Nonnull String lastUrn, int pageSize) {
     indexQuery.setParameter(1, lastUrn);
     int pos = 2;
     for (IndexCriterion criterion : indexCriterionArray) {
@@ -792,7 +789,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   private static String getStringForOperator(@Nonnull Condition condition) {
     if (!CONDITION_STRING_MAP.containsKey(condition)) {
-      throw new UnsupportedOperationException(condition.toString() + " condition is not supported in local secondary index");
+      throw new UnsupportedOperationException(
+          condition.toString() + " condition is not supported in local secondary index");
     }
     return CONDITION_STRING_MAP.get(condition);
   }
@@ -807,8 +805,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   private static String constructSQLQuery(@Nonnull IndexCriterionArray indexCriterionArray) {
     String selectClause = "SELECT DISTINCT(t0.urn) FROM metadata_index t0";
-    selectClause += IntStream.range(1, indexCriterionArray.size()).mapToObj(i -> " INNER JOIN metadata_index " + "t"
-        + i + " ON t0.urn = " + "t" + i + ".urn").collect(Collectors.joining(""));
+    selectClause += IntStream.range(1, indexCriterionArray.size())
+        .mapToObj(i -> " INNER JOIN metadata_index " + "t" + i + " ON t0.urn = " + "t" + i + ".urn")
+        .collect(Collectors.joining(""));
     final StringBuilder whereClause = new StringBuilder("WHERE t0.urn > ?");
     IntStream.range(0, indexCriterionArray.size()).forEach(i -> {
       final IndexCriterion criterion = indexCriterionArray.get(i);
@@ -860,7 +859,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       throw new UnsupportedOperationException("Empty Index Filter is not supported by EbeanLocalDAO");
     }
     if (indexCriterionArray.size() > 10) {
-      throw new UnsupportedOperationException("Currently more than 10 filter conditions is not supported by EbeanLocalDAO");
+      throw new UnsupportedOperationException(
+          "Currently more than 10 filter conditions is not supported by EbeanLocalDAO");
     }
 
     addEntityTypeFilter(indexFilter);
@@ -872,8 +872,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     final List<EbeanMetadataIndex> pagedList = query.findList();
 
-    return pagedList.stream()
-        .map(entry -> getUrn(entry.getUrn()))
-        .collect(Collectors.toList());
+    return pagedList.stream().map(entry -> getUrn(entry.getUrn())).collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
UNION ALL can be much more performant than OR, and the mysql team at LI has indicated this query is cauasing performance issues. Switch to UNION ALL on their guidance.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
