### PR TITLE
feat: Add an interface to get lower level neo4j metrics

### DIFF
--- a/dao-impl/neo4j-dao/build.gradle
+++ b/dao-impl/neo4j-dao/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile externalDependency.neo4jJavaDriver
 
   compileOnly externalDependency.lombok
+  annotationProcessor externalDependency.lombok
 
   testCompile project(':testing:test-models')
   testCompile externalDependency.neo4jHarness


### PR DESCRIPTION
The current metrics we have I believe have a lot of overhead with respect to doing transformations and reflection before doing the actual query. I want to see how long our actual queries are taking.

Also replace some lambdas with for loops to make java profile heatmaps easier to read (each java stream lambda can add 5+ layers to the call stack).

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
