### PR TITLE
fix: Make neo4j updates partial updates.

### DIFF
--- a/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
+++ b/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
@@ -47,7 +47,7 @@ public class Neo4jUtil {
     // put all field values
     entity.data().forEach((k, v) -> fields.put(k, toValueObject(v)));
 
-    return Collections.unmodifiableMap(fields);
+    return fields;
   }
 
   /**

--- a/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAO.java
+++ b/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAO.java
@@ -335,7 +335,9 @@ public class Neo4jGraphWriterDAO extends BaseGraphWriterDAO {
 
     final Map<String, Object> params = new HashMap<>();
     params.put("urn", urn.toString());
-    params.put("properties", entityToNode(entity));
+    final Map<String, Object> props = entityToNode(entity);
+    props.remove("urn"); // no need to set twice (this is implied by MERGE), and they can be quite long.
+    params.put("properties", props);
 
     return buildStatement(statement, params);
   }

--- a/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAO.java
+++ b/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAO.java
@@ -329,8 +329,9 @@ public class Neo4jGraphWriterDAO extends BaseGraphWriterDAO {
     final Urn urn = getUrnFromEntity(entity);
     final String nodeType = getNodeType(urn);
 
-    final String mergeTemplate = "MERGE (node%s {urn: $urn}) ON CREATE SET node%s SET node = $properties RETURN node";
-    final String statement = String.format(mergeTemplate, nodeType, nodeType);
+    // Use += to ensure this doesn't override the node but merges in the new properties to allow for partial updates.
+    final String mergeTemplate = "MERGE (node%s {urn: $urn}) SET node += $properties RETURN node";
+    final String statement = String.format(mergeTemplate, nodeType);
 
     final Map<String, Object> params = new HashMap<>();
     params.put("urn", urn.toString());
@@ -434,7 +435,7 @@ public class Neo4jGraphWriterDAO extends BaseGraphWriterDAO {
 
       // Add/Update relationship
       final String mergeRelationshipTemplate =
-          "MATCH (source%s {urn: $sourceUrn}),(destination%s {urn: $destinationUrn}) MERGE (source)-[r:%s]->(destination) SET r = $properties";
+          "MATCH (source%s {urn: $sourceUrn}),(destination%s {urn: $destinationUrn}) MERGE (source)-[r:%s]->(destination) SET r += $properties";
       final String statement =
           String.format(mergeRelationshipTemplate, sourceNodeType, destinationNodeType, getType(relationship));
 


### PR DESCRIPTION
Updates before would be total node overrides; so if a property was missing from the second update it would be deleted from the node. With MXE v5 we need to preserve properties not touched by updates.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
