### PR TITLE
Fix resource loading in the ES test framework.

### DIFF
--- a/testing/elasticsearch-dao-integ-testing-7/src/main/java/com/linkedin/metadata/testing/ElasticsearchIntegrationTestExtension.java
+++ b/testing/elasticsearch-dao-integ-testing-7/src/main/java/com/linkedin/metadata/testing/ElasticsearchIntegrationTestExtension.java
@@ -72,13 +72,15 @@ final class ElasticsearchIntegrationTestExtension
     }, ReflectionUtils.HierarchyTraversalMode.TOP_DOWN);
 
     final SearchIndexFactory indexFactory = new SearchIndexFactory(_connection);
-    final List<SearchIndex<?>> indices = createIndices(indexFactory, context.getRequiredTestClass(), fields,
-        fieldName -> String.format("%s_%s_%s", fieldName, testClass.getSimpleName(), System.currentTimeMillis()));
+    final List<SearchIndex<?>> indices =
+        createIndices(indexFactory, context.getRequiredTestClass(), context.getRequiredTestClass(), fields,
+            fieldName -> String.format("%s_%s_%s", fieldName, testClass.getSimpleName(), System.currentTimeMillis()));
     store.put(STATIC_INDICIES, indices);
   }
 
-  private List<SearchIndex<?>> createIndices(@Nonnull SearchIndexFactory indexFactory, @Nonnull Object testInstance,
-      @Nonnull List<Field> fields, @Nonnull Function<String, String> nameFn) throws Exception {
+  private List<SearchIndex<?>> createIndices(@Nonnull SearchIndexFactory indexFactory, @Nonnull Class<?> testClass,
+      @Nonnull Object testInstance, @Nonnull List<Field> fields, @Nonnull Function<String, String> nameFn)
+      throws Exception {
     final List<SearchIndex<?>> indices = new ArrayList<>();
 
     for (Field field : fields) {
@@ -92,10 +94,10 @@ final class ElasticsearchIntegrationTestExtension
       final String indexName = nameFn.apply(field.getName()).replaceAll("^_*", "").toLowerCase();
 
       final SearchIndexSettings settings = field.getAnnotation(SearchIndexSettings.class);
-      final String settingsJson = settings == null ? null : loadResource(testInstance.getClass(), settings.value());
+      final String settingsJson = settings == null ? null : loadResource(testClass, settings.value());
 
       final SearchIndexMappings mappings = field.getAnnotation(SearchIndexMappings.class);
-      final String mappingsJson = mappings == null ? null : loadResource(testInstance.getClass(), mappings.value());
+      final String mappingsJson = mappings == null ? null : loadResource(testClass, mappings.value());
 
       final SearchIndex<?> index =
           indexFactory.createIndex(searchIndexType.value(), indexName, settingsJson, mappingsJson);
@@ -164,9 +166,10 @@ final class ElasticsearchIntegrationTestExtension
     }, ReflectionUtils.HierarchyTraversalMode.TOP_DOWN);
 
     final SearchIndexFactory indexFactory = new SearchIndexFactory(_connection);
-    final List<SearchIndex<?>> indices = createIndices(indexFactory, context.getRequiredTestInstance(), fields,
-        fieldName -> String.format("%s_%s_%s_%s", fieldName, context.getRequiredTestMethod().getName(),
-            context.getRequiredTestClass().getSimpleName(), System.currentTimeMillis()));
+    final List<SearchIndex<?>> indices =
+        createIndices(indexFactory, context.getRequiredTestClass(), context.getRequiredTestInstance(), fields,
+            fieldName -> String.format("%s_%s_%s_%s", fieldName, context.getRequiredTestMethod().getName(),
+                context.getRequiredTestClass().getSimpleName(), System.currentTimeMillis()));
     store.put(INDICIES, indices);
   }
 

--- a/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/ElasticsearchIntegrationTestExtension.java
+++ b/testing/elasticsearch-dao-integ-testing/src/main/java/com/linkedin/metadata/testing/ElasticsearchIntegrationTestExtension.java
@@ -71,13 +71,15 @@ final class ElasticsearchIntegrationTestExtension
     }, ReflectionUtils.HierarchyTraversalMode.TOP_DOWN);
 
     final SearchIndexFactory indexFactory = new SearchIndexFactory(_connection);
-    final List<SearchIndex<?>> indices = createIndices(indexFactory, context.getRequiredTestClass(), fields,
-        fieldName -> String.format("%s_%s_%s", fieldName, testClass.getSimpleName(), System.currentTimeMillis()));
+    final List<SearchIndex<?>> indices =
+        createIndices(indexFactory, context.getRequiredTestClass(), context.getRequiredTestClass(), fields,
+            fieldName -> String.format("%s_%s_%s", fieldName, testClass.getSimpleName(), System.currentTimeMillis()));
     store.put(STATIC_INDICIES, indices);
   }
 
-  private List<SearchIndex<?>> createIndices(@Nonnull SearchIndexFactory indexFactory, @Nonnull Object testInstance,
-      @Nonnull List<Field> fields, @Nonnull Function<String, String> nameFn) throws Exception {
+  private List<SearchIndex<?>> createIndices(@Nonnull SearchIndexFactory indexFactory,
+      @Nonnull Class<?> testClass, @Nonnull Object testInstance, @Nonnull List<Field> fields,
+      @Nonnull Function<String, String> nameFn) throws Exception {
     final List<SearchIndex<?>> indices = new ArrayList<>();
 
     for (Field field : fields) {
@@ -91,10 +93,10 @@ final class ElasticsearchIntegrationTestExtension
       final String indexName = nameFn.apply(field.getName()).replaceAll("^_*", "").toLowerCase();
 
       final SearchIndexSettings settings = field.getAnnotation(SearchIndexSettings.class);
-      final String settingsJson = settings == null ? null : loadResource(testInstance.getClass(), settings.value());
+      final String settingsJson = settings == null ? null : loadResource(testClass, settings.value());
 
       final SearchIndexMappings mappings = field.getAnnotation(SearchIndexMappings.class);
-      final String mappingsJson = mappings == null ? null : loadResource(testInstance.getClass(), mappings.value());
+      final String mappingsJson = mappings == null ? null : loadResource(testClass, mappings.value());
 
       final DocType docType = field.getAnnotation(DocType.class);
       final String docTypeStr = docType == null ? null : docType.value();
@@ -166,9 +168,10 @@ final class ElasticsearchIntegrationTestExtension
     }, ReflectionUtils.HierarchyTraversalMode.TOP_DOWN);
 
     final SearchIndexFactory indexFactory = new SearchIndexFactory(_connection);
-    final List<SearchIndex<?>> indices = createIndices(indexFactory, context.getRequiredTestInstance(), fields,
-        fieldName -> String.format("%s_%s_%s_%s", fieldName, context.getRequiredTestMethod().getName(),
-            context.getRequiredTestClass().getSimpleName(), System.currentTimeMillis()));
+    final List<SearchIndex<?>> indices =
+        createIndices(indexFactory, context.getRequiredTestClass(), context.getRequiredTestInstance(), fields,
+            fieldName -> String.format("%s_%s_%s_%s", fieldName, context.getRequiredTestMethod().getName(),
+                context.getRequiredTestClass().getSimpleName(), System.currentTimeMillis()));
     store.put(INDICIES, indices);
   }
 


### PR DESCRIPTION
For static indices, we would end up calling testInstance.getClass().getClass().getResource() (indirectly). Somehow java 8 is fine with this and can locate the resource (off java.lang.Class), but java 11 is not okay with it (which is what I would expect).

Fix the code by being explicit about which class to use.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
