### PR TITLE
feat: add support for indexing array in SCSI

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -332,6 +332,18 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
+  protected void saveRecordsToLocalIndex(@Nonnull URN urn, @Nonnull String aspect, @Nonnull String path,
+      @Nonnull Object value) {
+
+    if (value instanceof List) {
+      for (Object obj : (List<?>) value) {
+        saveSingleRecordToLocalIndex(urn, aspect, path, obj);
+      }
+    } else {
+      saveSingleRecordToLocalIndex(urn, aspect, path, value);
+    }
+  }
+
   protected long saveSingleRecordToLocalIndex(@Nonnull URN urn, @Nonnull String aspect, @Nonnull String path,
       @Nonnull Object value) {
 
@@ -385,7 +397,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .filter(path -> pathStorageConfigMap.get(path).isStrongConsistentSecondaryIndex())
         .collect(Collectors.toMap(Function.identity(), path -> RecordUtils.getFieldValue(newValue, path)))
         .forEach((k, v) -> v.ifPresent(
-            value -> saveSingleRecordToLocalIndex(urn, newValue.getClass().getCanonicalName(), k, value)));
+            value -> saveRecordsToLocalIndex(urn, newValue.getClass().getCanonicalName(), k, value)));
   }
 
   @Override


### PR DESCRIPTION
This change adds support for indexing array elements to different rows in SCSI.
Currently you can index all elements of an array. Indexing a specific array index or range of indices is not supported.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
