### PR TITLE
feat: Use optimistic locking for db updates in ebean dao

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -178,9 +178,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Determines whether we should use optimistic locking in updates.
-   *
-   * <p>The column to execute optimistic locking is controlled by {@link #DEFAULT_COLUMN_FOR_OPTIMISTIC_LOCK}
+   * Determines whether we should use optimistic locking in updates. Optimistic locking is done on {@code createdOn} column
    *
    * <p>DO NOT USE THIS FLAG! This is for LinkedIn use to help us test this feature without a rollback. Once we've
    * vetted this in production we will be removing this flag and making the the default behavior. So if you set this

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -371,7 +371,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     //   2. When using @version annotation, Ebean starts to override all updates to that column
     //      by disregarding any user change.
     // Ideally, another column for the sake of optimistic locking would be preferred but that means a change to
-    // metadata_aspect schema and we don't take this route here to keep this change backward incompatible.
+    // metadata_aspect schema and we don't take this route here to keep this change backward compatible.
     final String updateQuery = String.format("UPDATE metadata_aspect "
             + "SET urn = :urn, aspect = :aspect, version = :version, metadata = :metadata, createdOn = :createdOn, createdBy = :createdBy "
             + "WHERE urn = :urn and aspect = :aspect and version = :version and createdOn = :oldTimestamp");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -179,7 +179,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Determines whether we should use optimistic locking in updates. Optimistic locking is done on {@code createdOn} column
+   * Determines whether we should use optimistic locking in updates.
+   *
+   * <p>The column to execute optimistic locking is controlled by {@link #DEFAULT_COLUMN_FOR_OPTIMISTIC_LOCK}
    *
    * <p>DO NOT USE THIS FLAG! This is for LinkedIn use to help us test this feature without a rollback. Once we've
    * vetted this in production we will be removing this flag and making the the default behavior. So if you set this

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -349,7 +349,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
                         + "SET urn = :urn, aspect = :aspect, version = :version, metadata = :metadata, createdOn = :createdOn, createdBy = :createdBy "
                         + "WHERE urn = :urn and aspect = :aspect and version = :version and createdOn = :oldCreatedOn";
 
-        SqlUpdate update = _server.createSqlUpdate(updateQuery);
+        final SqlUpdate update = _server.createSqlUpdate(updateQuery);
         update.setParameter("urn", aspect.getKey().getUrn());
         update.setParameter("aspect", aspect.getKey().getAspect());
         update.setParameter("version", aspect.getKey().getVersion());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -1858,8 +1858,9 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
-  public void testOptimisticLocking() {
+  public void testSaveWithOptimisticLocking() {
     EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+    dao.setUseOptimisticLocking(true);
     FooUrn fooUrn = makeFooUrn(1);
     AspectFoo fooAspect = new AspectFoo().setValue("foo");
 
@@ -1879,18 +1880,8 @@ public class EbeanLocalDAOTest {
 
     // call save method with timestamp 123 but timestamp is already changed to 456
     // expect OptimisticLockException if optimistic locking is enabled
-
-    ThrowingRunnable runnable = () -> dao.save(fooUrn, fooAspect, makeAuditStamp("fooActor", 789),
-            0, false, makeAuditStamp("fooActor", 123));
-    if (_useOptimisticLocking) {
-      assertThrows(OptimisticLockException.class, runnable);
-    } else {
-      try {
-        runnable.run();
-      } catch (Throwable t) {
-        fail("This shouldn't have failed when optimistic locking is disabled");
-      }
-    }
+    assertThrows(OptimisticLockException.class, () -> dao.saveWithOptimisticLocking(fooUrn, fooAspect,
+            makeAuditStamp("fooActor", 789), 0, false, "createdOn", new Timestamp(123)));
   }
 
   private void addMetadata(Urn urn, String aspectName, long version, RecordTemplate metadata) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -1881,7 +1881,7 @@ public class EbeanLocalDAOTest {
     // call save method with timestamp 123 but timestamp is already changed to 456
     // expect OptimisticLockException if optimistic locking is enabled
     dao.saveWithOptimisticLocking(fooUrn, fooAspect,
-            makeAuditStamp("fooActor", 789), 0, false, "createdOn", new Timestamp(123));
+            makeAuditStamp("fooActor", 789), 0, false, new Timestamp(123));
   }
 
   private void addMetadata(Urn urn, String aspectName, long version, RecordTemplate metadata) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -1857,8 +1857,8 @@ public class EbeanLocalDAOTest {
     testGetWithQuerySize(1000);
   }
 
-  @Test
-  public void testSaveWithOptimisticLocking() {
+  @Test(expectedExceptions = OptimisticLockException.class)
+  public void testOptimisticLockException() {
     EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
     dao.setUseOptimisticLocking(true);
     FooUrn fooUrn = makeFooUrn(1);
@@ -1880,8 +1880,8 @@ public class EbeanLocalDAOTest {
 
     // call save method with timestamp 123 but timestamp is already changed to 456
     // expect OptimisticLockException if optimistic locking is enabled
-    assertThrows(OptimisticLockException.class, () -> dao.saveWithOptimisticLocking(fooUrn, fooAspect,
-            makeAuditStamp("fooActor", 789), 0, false, "createdOn", new Timestamp(123)));
+    dao.saveWithOptimisticLocking(fooUrn, fooAspect,
+            makeAuditStamp("fooActor", 789), 0, false, "createdOn", new Timestamp(123));
   }
 
   private void addMetadata(Urn urn, String aspectName, long version, RecordTemplate metadata) {


### PR DESCRIPTION
Start using optimistic locking to prevent [lost updates](https://www.avaje.org/occ.html) in Ebean dao. The feature is flag guarded for now. After testing it in production, the plan is to make it the default behavior going forward.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Tests for the changes have been added/updated (if applicable)
