### PR TITLE
feat: add offset pagination to SCSI

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -416,7 +416,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public abstract <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter,
-      @Nullable IndexSortCriterion indexSortCriterion, @Nonnull int start, int pageSize);
+      @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize);
 
   /**
    * Similar to {@link #listUrns(IndexFilter, Urn, int)}. This is to get all urns with type URN.
@@ -437,7 +437,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   private List<UrnAspectEntry<URN>> getUrnAspectEntries(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      List<URN> urns) {
+      @Nonnull List<URN> urns) {
     final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnAspectMap =
         get(aspectClasses, new HashSet<>(urns));
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -380,8 +380,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param newValue {@link RecordTemplate} of the new value of aspect
    * @param version version of the aspect
    */
-  public abstract <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn,
-      @Nullable ASPECT newValue, long version);
+  public abstract <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn, @Nullable ASPECT newValue,
+      long version);
 
   /**
    * Returns list of urns from local secondary index that satisfy the given filter conditions.
@@ -423,8 +423,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public List<URN> listUrns(@Nonnull Class<URN> urnClazz, @Nullable URN lastUrn, int pageSize) {
-    final IndexFilter indexFilter = new IndexFilter()
-            .setCriteria(new IndexCriterionArray(new IndexCriterion().setAspect(urnClazz.getCanonicalName())));
+    final IndexFilter indexFilter = new IndexFilter().setCriteria(
+        new IndexCriterionArray(new IndexCriterion().setAspect(urnClazz.getCanonicalName())));
     return listUrns(indexFilter, lastUrn, pageSize);
   }
 
@@ -476,7 +476,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public List<UrnAspectEntry<URN>> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      @Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, @Nullable URN lastUrn, int pageSize) {
+      @Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, @Nullable URN lastUrn,
+      int pageSize) {
 
     final List<URN> urns = listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize);
 
@@ -489,7 +490,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public List<UrnAspectEntry<URN>> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-    @Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
+      @Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
     return getAspects(aspectClasses, indexFilter, null, lastUrn, pageSize);
   }
 
@@ -510,8 +511,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     final List<UrnAspectEntry<URN>> urnAspectEntries = getUrnAspectEntries(aspectClasses, urns);
 
-    return ListResult.<UrnAspectEntry<URN>>builder()
-        .values(urnAspectEntries)
+    return ListResult.<UrnAspectEntry<URN>>builder().values(urnAspectEntries)
         .metadata(listResult.getMetadata())
         .nextStart(listResult.getNextStart())
         .havingMore(listResult.isHavingMore())
@@ -597,7 +597,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @deprecated Use {@link #backfill(Set, Set)} instead
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn) {
+  public <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull Class<ASPECT> aspectClass,
+      @Nonnull URN urn) {
     return backfill(BackfillMode.BACKFILL_ALL, aspectClass, urn);
   }
 
@@ -637,7 +638,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   private Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
       @Nonnull BackfillMode mode, @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
     checkValidAspects(aspectClasses);
-    final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnToAspects = get(aspectClasses, urns);
+    final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnToAspects =
+        get(aspectClasses, urns);
     urnToAspects.forEach((urn, aspects) -> {
       aspects.forEach((aspectClass, aspect) -> aspect.ifPresent(value -> backfill(mode, value, urn)));
     });
@@ -672,7 +674,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param urn {@link Urn} for the entity
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
    */
-  private <ASPECT extends RecordTemplate> void backfill(@Nonnull BackfillMode mode,  @Nonnull ASPECT aspect, @Nonnull URN urn) {
+  private <ASPECT extends RecordTemplate> void backfill(@Nonnull BackfillMode mode, @Nonnull ASPECT aspect,
+      @Nonnull URN urn) {
     if (_enableLocalSecondaryIndex && (mode == BackfillMode.SCSI_ONLY || mode == BackfillMode.BACKFILL_ALL)) {
       updateLocalIndex(urn, aspect, FIRST_VERSION);
     }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -109,7 +109,7 @@ public class BaseLocalDAOTest {
     @Override
     public ListResult<FooUrn> listUrns(@Nonnull IndexFilter indexFilter,
         @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
-      return null;
+      return ListResult.<FooUrn>builder().build();
     }
 
     @Override

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -107,6 +107,12 @@ public class BaseLocalDAOTest {
     }
 
     @Override
+    public ListResult<FooUrn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+        int start, int pageSize) {
+      return null;
+    }
+
+    @Override
     public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, FooUrn urn, int start,
         int pageSize) {
       return null;

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -51,8 +51,8 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    public <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull FooUrn urn,
-        @Nullable ASPECT newValue, long version) {
+    public <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull FooUrn urn, @Nullable ASPECT newValue,
+        long version) {
 
     }
 
@@ -107,8 +107,8 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    public ListResult<FooUrn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-        int start, int pageSize) {
+    public ListResult<FooUrn> listUrns(@Nonnull IndexFilter indexFilter,
+        @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
       return null;
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -248,7 +248,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     DataSourceConfig dataSourceConfig = new DataSourceConfig();
     dataSourceConfig.setUsername("tester");
     dataSourceConfig.setPassword("");
-    dataSourceConfig.setUrl("jdbc:h2:mem:;IGNORECASE=TRUE;");
+    dataSourceConfig.setUrl("jdbc:h2:mem:testdb;IGNORECASE=TRUE;");
     dataSourceConfig.setDriver("org.h2.Driver");
 
     ServerConfig serverConfig = new ServerConfig();
@@ -298,7 +298,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       // update latest version
       if (_useOptimisticLocking) {
         saveWithOptimisticLocking(urn, newValue, newAuditStamp, LATEST_VERSION, false,
-                new Timestamp(oldAuditStamp.getTime()));
+            new Timestamp(oldAuditStamp.getTime()));
       } else {
         save(urn, newValue, newAuditStamp, LATEST_VERSION, false);
       }
@@ -339,7 +339,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Nonnull
   private EbeanMetadataAspect buildMetadataAspectBean(@Nonnull URN urn, @Nonnull RecordTemplate value,
-                                                      @Nonnull AuditStamp auditStamp, long version) {
+      @Nonnull AuditStamp auditStamp, long version) {
 
     final String aspectName = ModelUtils.getAspectName(value.getClass());
 
@@ -359,9 +359,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   // visible for testing
   protected void saveWithOptimisticLocking(@Nonnull URN urn, @Nonnull RecordTemplate value,
-                                           @Nonnull AuditStamp newAuditStamp,
-                                           long version, boolean insert,
-                                           @Nonnull Object oldTimestamp) {
+      @Nonnull AuditStamp newAuditStamp, long version, boolean insert, @Nonnull Object oldTimestamp) {
 
     final EbeanMetadataAspect aspect = buildMetadataAspectBean(urn, value, newAuditStamp, version);
 
@@ -379,8 +377,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     // Ideally, another column for the sake of optimistic locking would be preferred but that means a change to
     // metadata_aspect schema and we don't take this route here to keep this change backward compatible.
     final String updateQuery = String.format("UPDATE metadata_aspect "
-            + "SET urn = :urn, aspect = :aspect, version = :version, metadata = :metadata, createdOn = :createdOn, createdBy = :createdBy "
-            + "WHERE urn = :urn and aspect = :aspect and version = :version and createdOn = :oldTimestamp");
+        + "SET urn = :urn, aspect = :aspect, version = :version, metadata = :metadata, createdOn = :createdOn, createdBy = :createdBy "
+        + "WHERE urn = :urn and aspect = :aspect and version = :version and createdOn = :oldTimestamp");
 
     final SqlUpdate update = _server.createSqlUpdate(updateQuery);
     update.setParameter("urn", aspect.getKey().getUrn());
@@ -394,7 +392,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     // If there is no single updated row, emit OptimisticLockException
     int numOfUpdatedRows = _server.execute(update);
     if (numOfUpdatedRows != 1) {
-      throw new OptimisticLockException(numOfUpdatedRows + " rows updated during save query: " + update.getGeneratedSql());
+      throw new OptimisticLockException(
+          numOfUpdatedRows + " rows updated during save query: " + update.getGeneratedSql());
     }
   }
 
@@ -450,8 +449,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
 
     final Map<String, Object> pathValueMap = _urnPathExtractor.extractPaths(urn);
-    pathValueMap.forEach(
-        (path, value) -> saveSingleRecordToLocalIndex(urn, _urnClass.getCanonicalName(), path, value));
+    pathValueMap.forEach((path, value) -> saveSingleRecordToLocalIndex(urn, _urnClass.getCanonicalName(), path, value));
   }
 
   private <ASPECT extends RecordTemplate> void updateAspectInLocalIndex(@Nonnull URN urn, @Nonnull ASPECT newValue) {
@@ -909,7 +907,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     } else if (indexValue.isString()) {
       object = getValueFromIndexCriterion(criterion);
       return new GMAIndexPair(EbeanMetadataIndex.STRING_COLUMN, object);
-    } else if (indexValue.isArray() && indexValue.getArray().size() > 0 && indexValue.getArray().get(0).getClass() == String.class) {
+    } else if (indexValue.isArray() && indexValue.getArray().size() > 0
+        && indexValue.getArray().get(0).getClass() == String.class) {
       object = indexValue.getArray();
       return new GMAIndexPair(EbeanMetadataIndex.STRING_COLUMN, object);
     } else {
@@ -938,8 +937,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param pageSize maximum number of distinct urns to return which is essentially the LIMIT clause of SQL query
    * @param offsetPagination used to determine whether to used cursor or offset pagination
    */
-  private static void setParameters(@Nonnull IndexCriterionArray indexCriterionArray, @Nullable IndexSortCriterion indexSortCriterion,
-      @Nonnull Query<EbeanMetadataIndex> indexQuery, @Nonnull String lastUrn, int pageSize, boolean offsetPagination) {
+  private static void setParameters(@Nonnull IndexCriterionArray indexCriterionArray,
+      @Nullable IndexSortCriterion indexSortCriterion, @Nonnull Query<EbeanMetadataIndex> indexQuery,
+      @Nonnull String lastUrn, int pageSize, boolean offsetPagination) {
     int pos = 1;
     if (!offsetPagination) {
       indexQuery.setParameter(pos++, lastUrn);
@@ -1015,7 +1015,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     } else if (type == DataSchema.Type.STRING || type == DataSchema.Type.BOOLEAN || type == DataSchema.Type.ENUM) {
       return EbeanMetadataIndex.STRING_COLUMN;
     } else {
-      throw new UnsupportedOperationException("The type stored in the path field of the aspect can not be sorted on" + indexSortCriterion);
+      throw new UnsupportedOperationException(
+          "The type stored in the path field of the aspect can not be sorted on" + indexSortCriterion);
     }
   }
 
@@ -1087,7 +1088,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     } else {
       orderByClause = "ORDER BY urn ASC";
     }
-    final String limitClause = offsetPagination ?  "" : "LIMIT ?";
+    final String limitClause = offsetPagination ? "" : "LIMIT ?";
     return String.join(" ", selectClause, whereClause, orderByClause, limitClause);
   }
 
@@ -1134,10 +1135,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     addEntityTypeFilter(indexFilter);
 
-    final Query<EbeanMetadataIndex> query = _server
-        .findNative(EbeanMetadataIndex.class, constructSQLQuery(indexCriterionArray, indexSortCriterion, false))
-        .setTimeout(INDEX_QUERY_TIMEOUT_IN_SEC);
-    setParameters(indexCriterionArray, indexSortCriterion, query, lastUrn == null ? "" : lastUrn.toString(), pageSize, false);
+    final Query<EbeanMetadataIndex> query =
+        _server.findNative(EbeanMetadataIndex.class, constructSQLQuery(indexCriterionArray, indexSortCriterion, false))
+            .setTimeout(INDEX_QUERY_TIMEOUT_IN_SEC);
+    setParameters(indexCriterionArray, indexSortCriterion, query, lastUrn == null ? "" : lastUrn.toString(), pageSize,
+        false);
 
     final List<EbeanMetadataIndex> pagedList = query.findList();
 
@@ -1153,8 +1155,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   @Override
   @Nonnull
-  public ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter,
-      @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
+  public ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+      int start, int pageSize) {
     if (!isLocalSecondaryIndexEnabled()) {
       throw new UnsupportedOperationException("Local secondary index isn't supported");
     }
@@ -1164,20 +1166,17 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     addEntityTypeFilter(indexFilter);
 
-    final Query<EbeanMetadataIndex> query = _server
-        .findNative(EbeanMetadataIndex.class, constructSQLQuery(indexCriterionArray, indexSortCriterion, true))
-        .setTimeout(INDEX_QUERY_TIMEOUT_IN_SEC);
+    final Query<EbeanMetadataIndex> query =
+        _server.findNative(EbeanMetadataIndex.class, constructSQLQuery(indexCriterionArray, indexSortCriterion, true))
+            .setTimeout(INDEX_QUERY_TIMEOUT_IN_SEC);
     setParameters(indexCriterionArray, indexSortCriterion, query, "", pageSize, true);
 
-    final PagedList<EbeanMetadataIndex> pagedList = query
-        .setFirstRow(start)
-        .setMaxRows(pageSize)
-        .findPagedList();
+    final PagedList<EbeanMetadataIndex> pagedList = query.setFirstRow(start).setMaxRows(pageSize).findPagedList();
+
+    pagedList.loadCount();
 
     final List<URN> urns =
         pagedList.getList().stream().map(entry -> getUrn(entry.getUrn())).collect(Collectors.toList());
-
-    pagedList.loadCount();
 
     return toListResult(urns, null, pagedList, start);
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -940,12 +940,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   private static void setParameters(@Nonnull IndexCriterionArray indexCriterionArray, @Nullable IndexSortCriterion indexSortCriterion,
       @Nonnull Query<EbeanMetadataIndex> indexQuery, @Nonnull String lastUrn, int pageSize, boolean offsetPagination) {
-    int pos;
+    int pos = 1;
     if (!offsetPagination) {
-      indexQuery.setParameter(1, lastUrn);
-      pos = 2;
-    } else {
-      pos = 1;
+      indexQuery.setParameter(pos++, lastUrn);
     }
     for (IndexCriterion criterion : indexCriterionArray) {
       indexQuery.setParameter(pos++, criterion.getAspect());
@@ -1176,6 +1173,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .setFirstRow(start)
         .setMaxRows(pageSize)
         .findPagedList();
+
+    pagedList.loadCount();
 
     final List<URN> urns =
         pagedList.getList().stream().map(entry -> getUrn(entry.getUrn())).collect(Collectors.toList());

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1174,10 +1174,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .setMaxRows(pageSize)
         .findPagedList();
 
-    pagedList.loadCount();
-
     final List<URN> urns =
         pagedList.getList().stream().map(entry -> getUrn(entry.getUrn())).collect(Collectors.toList());
+
+    pagedList.loadCount();
 
     return toListResult(urns, null, pagedList, start);
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -92,9 +92,7 @@ public class EbeanLocalDAOTest {
 
   @DataProvider
   public static Object[][] inputList() {
-    return new Object[][]{
-        {false, false}, {true, true}
-    };
+    return new Object[][]{{false, false}, {true, true}};
   }
 
   @BeforeMethod
@@ -451,7 +449,6 @@ public class EbeanLocalDAOTest {
     // then when
     assertEquals(getAllRecordsFromLocalIndex(urn).size(), 0);
   }
-
 
   @Test
   public void testLocalSecondaryIndexBackfillEnabled() {
@@ -856,63 +853,71 @@ public class EbeanLocalDAOTest {
   public void testGetSortingColumn() {
     // 1. string corresponds to string column
     IndexSortCriterion indexSortCriterion1 = new IndexSortCriterion().setAspect(AspectFoo.class.getCanonicalName())
-        .setPath("/value").setOrder(SortOrder.DESCENDING);
+        .setPath("/value")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn1 = EbeanLocalDAO.getSortingColumn(indexSortCriterion1);
     assertEquals(sortingColumn1, EbeanMetadataIndex.STRING_COLUMN);
 
     // 2. boolean corresponds to string column
     IndexSortCriterion indexSortCriterion2 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/boolField").setOrder(SortOrder.DESCENDING);
+        .setPath("/boolField")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn2 = EbeanLocalDAO.getSortingColumn(indexSortCriterion2);
     assertEquals(sortingColumn2, EbeanMetadataIndex.STRING_COLUMN);
 
     // 3. int corresponds to long column
     IndexSortCriterion indexSortCriterion3 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/intField").setOrder(SortOrder.DESCENDING);
+        .setPath("/intField")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn3 = EbeanLocalDAO.getSortingColumn(indexSortCriterion3);
     assertEquals(sortingColumn3, EbeanMetadataIndex.LONG_COLUMN);
 
     // 4. long corresponds to long column
     IndexSortCriterion indexSortCriterion4 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/longField").setOrder(SortOrder.DESCENDING);
+        .setPath("/longField")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn4 = EbeanLocalDAO.getSortingColumn(indexSortCriterion4);
     assertEquals(sortingColumn4, EbeanMetadataIndex.LONG_COLUMN);
 
     // 5. double corresponds to double column
     IndexSortCriterion indexSortCriterion5 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/doubleField").setOrder(SortOrder.DESCENDING);
+        .setPath("/doubleField")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn5 = EbeanLocalDAO.getSortingColumn(indexSortCriterion5);
     assertEquals(sortingColumn5, EbeanMetadataIndex.DOUBLE_COLUMN);
 
     // 6. float corresponds to double column
     IndexSortCriterion indexSortCriterion6 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/floatField").setOrder(SortOrder.DESCENDING);
+        .setPath("/floatField")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn6 = EbeanLocalDAO.getSortingColumn(indexSortCriterion6);
     assertEquals(sortingColumn6, EbeanMetadataIndex.DOUBLE_COLUMN);
 
     // 7. enum corresponds to string column
     IndexSortCriterion indexSortCriterion7 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/enumField").setOrder(SortOrder.DESCENDING);
+        .setPath("/enumField")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn7 = EbeanLocalDAO.getSortingColumn(indexSortCriterion7);
     assertEquals(sortingColumn7, EbeanMetadataIndex.STRING_COLUMN);
 
     // 8. nested field
     IndexSortCriterion indexSortCriterion8 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/recordField/value").setOrder(SortOrder.DESCENDING);
+        .setPath("/recordField/value")
+        .setOrder(SortOrder.DESCENDING);
     String sortingColumn8 = EbeanLocalDAO.getSortingColumn(indexSortCriterion8);
     assertEquals(sortingColumn8, EbeanMetadataIndex.STRING_COLUMN);
 
     // 9. invalid type
     IndexSortCriterion indexSortCriterion9 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/arrayField").setOrder(SortOrder.DESCENDING);
-    assertThrows(UnsupportedOperationException.class,
-        () -> EbeanLocalDAO.getSortingColumn(indexSortCriterion9));
+        .setPath("/arrayField")
+        .setOrder(SortOrder.DESCENDING);
+    assertThrows(UnsupportedOperationException.class, () -> EbeanLocalDAO.getSortingColumn(indexSortCriterion9));
 
     // 10. array of records is invalid type
     IndexSortCriterion indexSortCriterion10 = new IndexSortCriterion().setAspect(MixedRecord.class.getCanonicalName())
-        .setPath("/recordArray/*/value").setOrder(SortOrder.DESCENDING);
-    assertThrows(UnsupportedOperationException.class,
-        () -> EbeanLocalDAO.getSortingColumn(indexSortCriterion10));
+        .setPath("/recordArray/*/value")
+        .setOrder(SortOrder.DESCENDING);
+    assertThrows(UnsupportedOperationException.class, () -> EbeanLocalDAO.getSortingColumn(indexSortCriterion10));
   }
 
   @Test
@@ -947,7 +952,8 @@ public class EbeanLocalDAOTest {
     IndexValue indexValue1 = new IndexValue();
     indexValue1.setString("val");
     IndexCriterion criterion1 = new IndexCriterion().setAspect(aspect1)
-        .setPathParams(new IndexPathParams().setPath("/value").setValue(indexValue1).setCondition(Condition.START_WITH));
+        .setPathParams(
+            new IndexPathParams().setPath("/value").setValue(indexValue1).setCondition(Condition.START_WITH));
 
     IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray(Collections.singletonList(criterion1));
     final IndexFilter indexFilter1 = new IndexFilter().setCriteria(indexCriterionArray1);
@@ -956,15 +962,15 @@ public class EbeanLocalDAOTest {
     assertEquals(urns1, Arrays.asList(urn1, urn2, urn3));
 
     // filter and sort on same aspect and path
-    IndexSortCriterion indexSortCriterion1 = new IndexSortCriterion().setAspect(aspect1)
-        .setPath("/value").setOrder(SortOrder.DESCENDING);
+    IndexSortCriterion indexSortCriterion1 =
+        new IndexSortCriterion().setAspect(aspect1).setPath("/value").setOrder(SortOrder.DESCENDING);
 
     List<FooUrn> urns2 = dao.listUrns(indexFilter1, indexSortCriterion1, null, 5);
-        assertEquals(urns2, Arrays.asList(urn2, urn1, urn3));
+    assertEquals(urns2, Arrays.asList(urn2, urn1, urn3));
 
     // filter and sort on different aspect and path
-    IndexSortCriterion indexSortCriterion2 = new IndexSortCriterion().setAspect(aspect2)
-        .setPath("/stringField").setOrder(SortOrder.ASCENDING);
+    IndexSortCriterion indexSortCriterion2 =
+        new IndexSortCriterion().setAspect(aspect2).setPath("/stringField").setOrder(SortOrder.ASCENDING);
 
     List<FooUrn> urns3 = dao.listUrns(indexFilter1, indexSortCriterion2, null, 5);
     assertEquals(urns3, Arrays.asList(urn3, urn1, urn2));
@@ -973,20 +979,21 @@ public class EbeanLocalDAOTest {
     IndexValue indexValue2 = new IndexValue();
     indexValue2.setString("do");
     IndexCriterion criterion2 = new IndexCriterion().setAspect(aspect2)
-        .setPathParams(new IndexPathParams().setPath("/stringField").setValue(indexValue2).setCondition(Condition.START_WITH));
+        .setPathParams(
+            new IndexPathParams().setPath("/stringField").setValue(indexValue2).setCondition(Condition.START_WITH));
 
     IndexCriterionArray indexCriterionArray2 = new IndexCriterionArray(Collections.singletonList(criterion2));
     final IndexFilter indexFilter2 = new IndexFilter().setCriteria(indexCriterionArray2);
 
-    IndexSortCriterion indexSortCriterion3 = new IndexSortCriterion().setAspect(aspect2)
-        .setPath("/longField").setOrder(SortOrder.DESCENDING);
+    IndexSortCriterion indexSortCriterion3 =
+        new IndexSortCriterion().setAspect(aspect2).setPath("/longField").setOrder(SortOrder.DESCENDING);
 
     List<FooUrn> urns4 = dao.listUrns(indexFilter2, indexSortCriterion3, null, 5);
     assertEquals(urns4, Arrays.asList(urn3, urn1));
 
     // sorting on nested field
-    IndexSortCriterion indexSortCriterion4 = new IndexSortCriterion().setAspect(aspect2)
-        .setPath("/recordField/value").setOrder(SortOrder.ASCENDING);
+    IndexSortCriterion indexSortCriterion4 =
+        new IndexSortCriterion().setAspect(aspect2).setPath("/recordField/value").setOrder(SortOrder.ASCENDING);
 
     List<FooUrn> urns5 = dao.listUrns(indexFilter1, indexSortCriterion4, null, 5);
     assertEquals(urns5, Arrays.asList(urn3, urn2, urn1));
@@ -1126,7 +1133,7 @@ public class EbeanLocalDAOTest {
     assertEquals(results3.getTotalCount(), 3);
     assertEquals(results3.getPageSize(), 2);
     assertEquals(results3.getTotalPageCount(), 2);
-  };
+  }
 
   @Test
   public void testListUrns() {
@@ -1220,8 +1227,7 @@ public class EbeanLocalDAOTest {
     assertEquals(actual, Arrays.asList(entry1, entry2));
 
     // offset pagination
-    ListResult<UrnAspectEntry<FooUrn>> actualListResult = dao.getAspects(aspectClasses, indexFilter,
-        null, 0, 2);
+    ListResult<UrnAspectEntry<FooUrn>> actualListResult = dao.getAspects(aspectClasses, indexFilter, null, 0, 2);
 
     assertEquals(actualListResult.getValues(), Arrays.asList(entry1, entry2));
     assertFalse(actualListResult.isHavingMore());
@@ -1261,8 +1267,8 @@ public class EbeanLocalDAOTest {
     assertNotNull(results.getMetadata());
     List<Long> expectedVersions = Arrays.asList(0L, 1L, 2L, 3L, 4L);
     List<Urn> expectedUrns = Arrays.asList(makeFooUrn(0), makeFooUrn(1), makeFooUrn(2), makeFooUrn(3), makeFooUrn(4));
-    assertVersionMetadata(results.getMetadata(), expectedVersions, expectedUrns, 1234L, Urns.createFromTypeSpecificString("test", "foo"),
-        Urns.createFromTypeSpecificString("test", "bar"));
+    assertVersionMetadata(results.getMetadata(), expectedVersions, expectedUrns, 1234L,
+        Urns.createFromTypeSpecificString("test", "foo"), Urns.createFromTypeSpecificString("test", "bar"));
 
     // List next page
     results = dao.list(AspectFoo.class, urn0, 5, 9);
@@ -1791,8 +1797,8 @@ public class EbeanLocalDAOTest {
     AspectFoo aspectFoo5 = new AspectFoo().setValue("fooVal5");
     AspectFoo aspectFoo6 = new AspectFoo().setValue("fooVal6");
 
-    final AspectFooArray
-        aspectFooArray1 = new AspectFooArray(Arrays.asList(aspectFoo1, aspectFoo2, aspectFoo3, aspectFoo4));
+    final AspectFooArray aspectFooArray1 =
+        new AspectFooArray(Arrays.asList(aspectFoo1, aspectFoo2, aspectFoo3, aspectFoo4));
     final MixedRecord aspect1 = new MixedRecord().setRecordArray(aspectFooArray1);
     aspect1.setValue("val1");
 
@@ -2177,8 +2183,7 @@ public class EbeanLocalDAOTest {
 
     // call save method with timestamp 123 but timestamp is already changed to 456
     // expect OptimisticLockException if optimistic locking is enabled
-    dao.saveWithOptimisticLocking(fooUrn, fooAspect,
-            makeAuditStamp("fooActor", 789), 0, false, new Timestamp(123));
+    dao.saveWithOptimisticLocking(fooUrn, fooAspect, makeAuditStamp("fooActor", 789), 0, false, new Timestamp(123));
   }
 
   private void addMetadata(Urn urn, String aspectName, long version, RecordTemplate metadata) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -1052,13 +1052,10 @@ public class EbeanLocalDAOTest {
   @Test
   public void testCheckValidIndexCriterionArray() {
     EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
-
-    // secondary index not enabled
-    final IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray();
-    assertThrows(UnsupportedOperationException.class, () -> dao.checkValidIndexCriterionArray(indexCriterionArray1));
+    dao.enableLocalSecondaryIndex(true);
 
     // empty index criterion array
-    dao.enableLocalSecondaryIndex(true);
+    final IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray();
     assertThrows(UnsupportedOperationException.class, () -> dao.checkValidIndexCriterionArray(indexCriterionArray1));
 
     // >10 criterion in array


### PR DESCRIPTION
This change adds offset pagination to SCSI. A new listUrns function returns a ListResult with pagination information. 

The next step is to add a filter method for offset pagination in BaseEntityResource, which will be done in a separate PR.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
