### PR TITLE
feat: make updateLocalIndex public

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -380,7 +380,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param newValue {@link RecordTemplate} of the new value of aspect
    * @param version version of the aspect
    */
-  protected abstract <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn,
+  public abstract <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn,
       @Nullable ASPECT newValue, long version);
 
   /**

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -51,7 +51,7 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull FooUrn urn,
+    public <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull FooUrn urn,
         @Nullable ASPECT newValue, long version) {
 
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -308,7 +308,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  protected <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn, @Nonnull ASPECT newValue,
+  public <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn, @Nonnull ASPECT newValue,
       long version) {
     if (!isLocalSecondaryIndexEnabled()) {
       throw new UnsupportedOperationException("Local secondary index isn't supported");


### PR DESCRIPTION
In the post-update hook, one of the use cases is to call the `updateLocalIndex` function. This PR changes the signature of the `updateLocalIndex` function to public, so it can be called in the hook.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
