### PR TITLE
fix: Fixate build-info-extractor-gradle version to 4.24.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     classpath 'com.github.node-gradle:gradle-node-plugin:2.2.4'
     classpath 'com.linkedin.pegasus:gradle-plugins:' + pegasusVersion
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.2.RELEASE'
-    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4+"
+    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.24.5"
     classpath "org.shipkit:shipkit-auto-version:1.1.1"
     classpath "org.shipkit:shipkit-changelog:1.1.1"
   }


### PR DESCRIPTION
Version 4.24.8 of the library fails the build with below exception. Using the exact version of 4.24.5 builds fine in my local. 4.24.5 is also the latest version according to [maven repository](https://mvnrepository.com/artifact/org.jfrog.buildinfo/build-info-extractor-gradle).

```
* What went wrong:
A problem occurred configuring root project 'datahub-gma'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.jfrog.filespecs:file-specs-java:1.0.0.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.pom
       - https://jcenter.bintray.com/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.pom
       - https://jcenter.bintray.com/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.jar
       - file:/home/runner/.m2/repository/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.pom
       - file:/home/runner/.m2/repository/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.jar
       - https://repo.maven.apache.org/maven2/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.pom
       - https://repo.maven.apache.org/maven2/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.jar
       - https://packages.confluent.io/maven/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.pom
       - https://packages.confluent.io/maven/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.jar
       - https://plugins.gradle.org/m2/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.jar
       - https://linkedin.jfrog.io/artifactory/open-source/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.pom
       - https://linkedin.jfrog.io/artifactory/open-source/org/jfrog/filespecs/file-specs-java/1.0.0/file-specs-java-1.0.0.jar
     Required by:
         project : > org.jfrog.buildinfo:build-info-extractor-gradle:4.24.8 > org.jfrog.buildinfo:build-info-extractor:2.28.2
```
