### PR TITLE
feat: add in filter criterion

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/Condition.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/Condition.pdl
@@ -31,6 +31,11 @@ enum Condition {
   GREATER_THAN_OR_EQUAL_TO
 
   /**
+   * Represent the relation: String field is one of the array values to, e.g. name in ["Profile", "Event"]
+   */
+  IN
+
+  /**
    * Represent the relation less than, e.g. ownerCount < 3
    */
   LESS_THAN

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/IndexValue.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/IndexValue.pdl
@@ -4,6 +4,7 @@ namespace com.linkedin.metadata.query
  * A union of all supported value types in the index table
  */
 typeref IndexValue = union[
+  array[string],
   boolean,
   double
   float,

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -964,6 +964,16 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
+  private static void validateConditionAndValue(@Nonnull IndexCriterion criterion) {
+    final Condition condition = criterion.getPathParams().getCondition();
+    final IndexValue indexValue = criterion.getPathParams().getValue();
+
+    if (condition == Condition.IN && !indexValue.isArray()) {
+      throw new IllegalArgumentException("Invalid condition " + condition + " for index value " + indexValue);
+    }
+  }
+
+  @Nonnull
   static <ASPECT extends RecordTemplate> String getSortingColumn(@Nonnull IndexSortCriterion indexSortCriterion) {
     final String[] pathSpecArray = RecordUtils.getPathSpecAsArray(indexSortCriterion.getPath());
 
@@ -1041,6 +1051,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
       whereClause.append(" AND t").append(i).append(".aspect = ?");
       if (criterion.getPathParams() != null) {
+        validateConditionAndValue(criterion);
         whereClause.append(" AND t")
             .append(i)
             .append(".path = ? AND t")

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -968,8 +968,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     final Condition condition = criterion.getPathParams().getCondition();
     final IndexValue indexValue = criterion.getPathParams().getValue();
 
-    if (condition == Condition.IN && (!indexValue.isArray() || indexValue.getArray().size() == 0
-        || indexValue.getArray().get(0).getClass() != String.class)) {
+    if (condition == Condition.IN && (!indexValue.isArray() || indexValue.getArray().size() == 0)) {
       throw new IllegalArgumentException("Invalid condition " + condition + " for index value " + indexValue);
     }
   }
@@ -1015,7 +1014,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   private static String getPlaceholderStringForValue(@Nonnull IndexValue indexValue) {
-    if (indexValue.isArray() && indexValue.getArray().size() > 0 && indexValue.getArray().get(0).getClass() == String.class) {
+    if (indexValue.isArray() && indexValue.getArray().size() > 0) {
       List<Object> values = Arrays.asList(indexValue.getArray().toArray());
       String placeholderString = "(";
       placeholderString += String.join(",", values.stream().map(value -> "?").collect(Collectors.toList()));

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -909,7 +909,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     } else if (indexValue.isString()) {
       object = getValueFromIndexCriterion(criterion);
       return new GMAIndexPair(EbeanMetadataIndex.STRING_COLUMN, object);
-    } else if (indexValue.isArray()) {
+    } else if (indexValue.isArray() && indexValue.getArray().size() > 0 && indexValue.getArray().get(0).getClass() == String.class) {
       object = indexValue.getArray();
       return new GMAIndexPair(EbeanMetadataIndex.STRING_COLUMN, object);
     } else {
@@ -968,7 +968,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     final Condition condition = criterion.getPathParams().getCondition();
     final IndexValue indexValue = criterion.getPathParams().getValue();
 
-    if (condition == Condition.IN && !indexValue.isArray()) {
+    if (condition == Condition.IN && (!indexValue.isArray() || indexValue.getArray().size() == 0
+        || indexValue.getArray().get(0).getClass() != String.class)) {
       throw new IllegalArgumentException("Invalid condition " + condition + " for index value " + indexValue);
     }
   }
@@ -1014,7 +1015,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   private static String getPlaceholderStringForValue(@Nonnull IndexValue indexValue) {
-    if (indexValue.isArray()) {
+    if (indexValue.isArray() && indexValue.getArray().size() > 0 && indexValue.getArray().get(0).getClass() == String.class) {
       List<Object> values = Arrays.asList(indexValue.getArray().toArray());
       String placeholderString = "(";
       placeholderString += String.join(",", values.stream().map(value -> "?").collect(Collectors.toList()));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -992,6 +992,7 @@ public class EbeanLocalDAOTest {
     assertEquals(urns5, Arrays.asList(urn3, urn2, urn1));
   }
 
+  @Test
   public void testIn() {
     EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
     dao.enableLocalSecondaryIndex(true);
@@ -1028,6 +1029,24 @@ public class EbeanLocalDAOTest {
     final IndexFilter indexFilter2 = new IndexFilter().setCriteria(indexCriterionArray2);
     List<FooUrn> urns2 = dao.listUrns(indexFilter2, null, 5);
     assertEquals(urns2, Arrays.asList());
+
+    IndexValue indexValue3 = new IndexValue();
+    indexValue3.setString("test");
+    IndexCriterion criterion3 = new IndexCriterion().setAspect(aspect)
+        .setPathParams(new IndexPathParams().setPath("/path1").setValue(indexValue3).setCondition(Condition.IN));
+
+    IndexCriterionArray indexCriterionArray3 = new IndexCriterionArray(Collections.singletonList(criterion3));
+    final IndexFilter indexFilter3 = new IndexFilter().setCriteria(indexCriterionArray3);
+    assertThrows(IllegalArgumentException.class, () -> dao.listUrns(indexFilter3, null, 5));
+
+    IndexValue indexValue4 = new IndexValue();
+    indexValue4.setArray(new StringArray());
+    IndexCriterion criterion4 = new IndexCriterion().setAspect(aspect)
+        .setPathParams(new IndexPathParams().setPath("/path1").setValue(indexValue4).setCondition(Condition.IN));
+
+    IndexCriterionArray indexCriterionArray4 = new IndexCriterionArray(Collections.singletonList(criterion4));
+    final IndexFilter indexFilter4 = new IndexFilter().setCriteria(indexCriterionArray4);
+    assertThrows(IllegalArgumentException.class, () -> dao.listUrns(indexFilter4, null, 5));
   }
 
   @Test


### PR DESCRIPTION
This change allows users to filter by a string array using the IN operator in SCSI. A user can specify an array and the aspect to filter on.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
