### PR TITLE
feat: add aggregation count to SCSI

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -24,6 +24,7 @@ import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.IndexCriterion;
 import com.linkedin.metadata.query.IndexCriterionArray;
 import com.linkedin.metadata.query.IndexFilter;
+import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
 import java.time.Clock;
 import java.util.Collections;
@@ -753,6 +754,16 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   @Nonnull
   public abstract <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass, int start,
       int pageSize);
+
+  /**
+   *  Gets the count of an aggregation specified by the aspect and field to group on.
+   * @param indexFilter {@link IndexFilter} that defines the filter conditions
+   * @param indexGroupByCriterion {@link IndexGroupByCriterion} that defines the aspect to group by
+   * @return map of the field to the count
+   */
+  @Nonnull
+  public abstract Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter,
+      @Nonnull IndexGroupByCriterion indexGroupByCriterion);
 
   /**
    * Batch retrieves metadata aspects along with {@link ExtraInfo} using multiple {@link AspectKey}s.

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/IndexGroupByCriterion.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/IndexGroupByCriterion.pdl
@@ -1,0 +1,17 @@
+namespace com.linkedin.metadata.query
+
+/**
+ * Aspect and path to group by, to be applied to the results.
+ */
+record IndexGroupByCriterion {
+  /**
+   * FQCN of the aspect class in the index table that this criterion refers to e.g. com.linkedin.common.Status
+   */
+  aspect: string
+
+  /**
+   * Corresponding path column of the index table that this criterion refers to e.g. /removed (corresponding to field "removed" of com.linkedin.common.Status aspect)
+   */
+  path: string
+}
+

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -132,7 +132,7 @@ public class BaseLocalDAOTest {
 
     @Override
     public Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter, @Nonnull IndexGroupByCriterion groupCriterion) {
-      return null;
+      return Collections.emptyMap();
     }
 
     @Override

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -7,6 +7,7 @@ import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.IndexFilter;
+import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.EntityAspectUnion;
@@ -126,6 +127,11 @@ public class BaseLocalDAOTest {
 
     @Override
     public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, int start, int pageSize) {
+      return null;
+    }
+
+    @Override
+    public Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter, @Nonnull IndexGroupByCriterion groupCriterion) {
       return null;
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -980,6 +980,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
+  @Nonnull
   static <ASPECT extends RecordTemplate> String getFieldColumn(@Nonnull String stringPath,
       @Nonnull String stringAspect) {
     final String[] pathSpecArray = RecordUtils.getPathSpecAsArray(stringPath);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1279,9 +1279,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         return result.put(entry.getStringVal(), entry.getTotalCount());
       } else if (entry.getDoubleVal() != null) {
         return result.put(entry.getDoubleVal().toString(), entry.getTotalCount());
-      } else {
+      } else if (entry.getLongVal() != null) {
         return result.put(entry.getLongVal().toString(), entry.getTotalCount());
       }
+      return result;
     }).collect(Collectors.toList());
     return result;
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -981,12 +981,12 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  static <ASPECT extends RecordTemplate> String getFieldColumn(@Nonnull String stringPath,
-      @Nonnull String stringAspect) {
-    final String[] pathSpecArray = RecordUtils.getPathSpecAsArray(stringPath);
+  static <ASPECT extends RecordTemplate> String getFieldColumn(@Nonnull String path,
+      @Nonnull String aspectName) {
+    final String[] pathSpecArray = RecordUtils.getPathSpecAsArray(path);
 
     // get nested field
-    ASPECT aspect = RecordUtils.getAspectFromString(stringAspect);
+    ASPECT aspect = RecordUtils.getAspectFromString(aspectName);
 
     final int pathSize = pathSpecArray.length;
 
@@ -1001,10 +1001,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         aspect = RecordUtils.getAspectFromString(nestedAspectName);
       } else if (dataSchema.getDereferencedType() == DataSchema.Type.ARRAY) {
         throw new UnsupportedOperationException(
-            "Can not sort or group by an array for path: " + stringPath + ", aspect: " + stringAspect);
+            "Can not sort or group by an array for path: " + path + ", aspect: " + aspectName);
       } else {
         throw new IllegalArgumentException(
-            "Invalid path field for aspect in sort or group by path: " + stringPath + ", aspect: " + stringAspect);
+            "Invalid path field for aspect in sort or group by path: " + path + ", aspect: " + aspectName);
       }
     }
 
@@ -1020,8 +1020,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       return EbeanMetadataIndex.STRING_COLUMN;
     } else {
       throw new UnsupportedOperationException(
-          "The type stored in the path field of the aspect can not be sorted or grouped on for path: " + stringPath
-              + ", aspect: " + stringAspect);
+          "The type stored in the path field of the aspect can not be sorted or grouped on for path: " + path
+              + ", aspect: " + aspectName);
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataIndex.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataIndex.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.dao;
 
+import io.ebean.annotation.Aggregation;
 import io.ebean.annotation.Index;
 import io.ebean.Model;
 import javax.persistence.Column;
@@ -79,4 +80,7 @@ public class EbeanMetadataIndex extends Model {
 
   @Column(name = DOUBLE_COLUMN)
   protected Double doubleVal;
+
+  @Aggregation("count(*)")
+  protected Long totalCount;
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -27,6 +27,7 @@ import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.IndexCriterion;
 import com.linkedin.metadata.query.IndexCriterionArray;
 import com.linkedin.metadata.query.IndexFilter;
+import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexPathParams;
 import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.metadata.query.IndexValue;
@@ -850,74 +851,66 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
-  public void testGetSortingColumn() {
+  public void testGetFieldColumn() {
     // 1. string corresponds to string column
     IndexSortCriterion indexSortCriterion1 = new IndexSortCriterion().setAspect(AspectFoo.class.getCanonicalName())
-        .setPath("/value")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn1 = EbeanLocalDAO.getSortingColumn(indexSortCriterion1);
+        .setPath("/value").setOrder(SortOrder.DESCENDING);
+    String sortingColumn1 = EbeanLocalDAO.getFieldColumn(indexSortCriterion1.getPath(), indexSortCriterion1.getAspect());
     assertEquals(sortingColumn1, EbeanMetadataIndex.STRING_COLUMN);
 
     // 2. boolean corresponds to string column
     IndexSortCriterion indexSortCriterion2 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/boolField")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn2 = EbeanLocalDAO.getSortingColumn(indexSortCriterion2);
+        .setPath("/boolField").setOrder(SortOrder.DESCENDING);
+    String sortingColumn2 = EbeanLocalDAO.getFieldColumn(indexSortCriterion2.getPath(), indexSortCriterion2.getAspect());
     assertEquals(sortingColumn2, EbeanMetadataIndex.STRING_COLUMN);
 
     // 3. int corresponds to long column
     IndexSortCriterion indexSortCriterion3 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/intField")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn3 = EbeanLocalDAO.getSortingColumn(indexSortCriterion3);
+        .setPath("/intField").setOrder(SortOrder.DESCENDING);
+    String sortingColumn3 = EbeanLocalDAO.getFieldColumn(indexSortCriterion3.getPath(), indexSortCriterion3.getAspect());
     assertEquals(sortingColumn3, EbeanMetadataIndex.LONG_COLUMN);
 
     // 4. long corresponds to long column
     IndexSortCriterion indexSortCriterion4 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/longField")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn4 = EbeanLocalDAO.getSortingColumn(indexSortCriterion4);
+        .setPath("/longField").setOrder(SortOrder.DESCENDING);
+    String sortingColumn4 = EbeanLocalDAO.getFieldColumn(indexSortCriterion4.getPath(), indexSortCriterion4.getAspect());
     assertEquals(sortingColumn4, EbeanMetadataIndex.LONG_COLUMN);
 
     // 5. double corresponds to double column
     IndexSortCriterion indexSortCriterion5 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/doubleField")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn5 = EbeanLocalDAO.getSortingColumn(indexSortCriterion5);
+        .setPath("/doubleField").setOrder(SortOrder.DESCENDING);
+    String sortingColumn5 = EbeanLocalDAO.getFieldColumn(indexSortCriterion5.getPath(), indexSortCriterion5.getAspect());
     assertEquals(sortingColumn5, EbeanMetadataIndex.DOUBLE_COLUMN);
 
     // 6. float corresponds to double column
     IndexSortCriterion indexSortCriterion6 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/floatField")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn6 = EbeanLocalDAO.getSortingColumn(indexSortCriterion6);
+        .setPath("/floatField").setOrder(SortOrder.DESCENDING);
+    String sortingColumn6 = EbeanLocalDAO.getFieldColumn(indexSortCriterion6.getPath(), indexSortCriterion6.getAspect());
     assertEquals(sortingColumn6, EbeanMetadataIndex.DOUBLE_COLUMN);
 
     // 7. enum corresponds to string column
     IndexSortCriterion indexSortCriterion7 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/enumField")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn7 = EbeanLocalDAO.getSortingColumn(indexSortCriterion7);
+        .setPath("/enumField").setOrder(SortOrder.DESCENDING);
+    String sortingColumn7 = EbeanLocalDAO.getFieldColumn(indexSortCriterion7.getPath(), indexSortCriterion7.getAspect());
     assertEquals(sortingColumn7, EbeanMetadataIndex.STRING_COLUMN);
 
     // 8. nested field
     IndexSortCriterion indexSortCriterion8 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/recordField/value")
-        .setOrder(SortOrder.DESCENDING);
-    String sortingColumn8 = EbeanLocalDAO.getSortingColumn(indexSortCriterion8);
+        .setPath("/recordField/value").setOrder(SortOrder.DESCENDING);
+    String sortingColumn8 = EbeanLocalDAO.getFieldColumn(indexSortCriterion8.getPath(), indexSortCriterion8.getAspect());
     assertEquals(sortingColumn8, EbeanMetadataIndex.STRING_COLUMN);
 
     // 9. invalid type
     IndexSortCriterion indexSortCriterion9 = new IndexSortCriterion().setAspect(AspectBaz.class.getCanonicalName())
-        .setPath("/arrayField")
-        .setOrder(SortOrder.DESCENDING);
-    assertThrows(UnsupportedOperationException.class, () -> EbeanLocalDAO.getSortingColumn(indexSortCriterion9));
+        .setPath("/arrayField").setOrder(SortOrder.DESCENDING);
+    assertThrows(UnsupportedOperationException.class,
+        () -> EbeanLocalDAO.getFieldColumn(indexSortCriterion9.getPath(), indexSortCriterion9.getAspect()));
 
     // 10. array of records is invalid type
     IndexSortCriterion indexSortCriterion10 = new IndexSortCriterion().setAspect(MixedRecord.class.getCanonicalName())
-        .setPath("/recordArray/*/value")
-        .setOrder(SortOrder.DESCENDING);
-    assertThrows(UnsupportedOperationException.class, () -> EbeanLocalDAO.getSortingColumn(indexSortCriterion10));
+        .setPath("/recordArray/*/value").setOrder(SortOrder.DESCENDING);
+    assertThrows(UnsupportedOperationException.class,
+        () -> EbeanLocalDAO.getFieldColumn(indexSortCriterion10.getPath(), indexSortCriterion10.getAspect()));
   }
 
   @Test
@@ -2076,6 +2069,92 @@ public class EbeanLocalDAOTest {
 
     // then
     assertEquals(records.size(), 2);
+  }
+
+  @Test
+  public void testCountAggregate() {
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+    dao.enableLocalSecondaryIndex(true);
+    FooUrn urn1 = makeFooUrn(1);
+    FooUrn urn2 = makeFooUrn(2);
+    FooUrn urn3 = makeFooUrn(3);
+    String aspect1 = AspectFoo.class.getCanonicalName();
+    String aspect2 = AspectBaz.class.getCanonicalName();
+
+    addIndex(urn1, aspect1, "/value", "valB");
+    addIndex(urn1, aspect2, "/longField", 10);
+    addIndex(urn1, aspect2, "/doubleField", 1.2);
+    addIndex(urn1, aspect2, "/recordField/value", "nestedC");
+    addIndex(urn1, FooUrn.class.getCanonicalName(), "/fooId", 1);
+
+    addIndex(urn2, aspect1, "/value", "valB");
+    addIndex(urn2, aspect2, "/longField", 8);
+    addIndex(urn2, aspect2, "/doubleField", 1.2);
+    addIndex(urn2, aspect2, "/recordField/value", "nestedB");
+    addIndex(urn2, FooUrn.class.getCanonicalName(), "/fooId", 2);
+
+    addIndex(urn3, aspect1, "/value", "valA");
+    addIndex(urn3, aspect2, "/longField", 100);
+    addIndex(urn3, aspect2, "/doubleField", 1.2);
+    addIndex(urn3, aspect2, "/recordField/value", "nestedA");
+    addIndex(urn3, FooUrn.class.getCanonicalName(), "/fooId", 3);
+
+    // group by string
+    IndexValue indexValue1 = new IndexValue();
+    indexValue1.setString("val");
+    IndexCriterion criterion1 = new IndexCriterion().setAspect(aspect1)
+        .setPathParams(new IndexPathParams().setPath("/value").setValue(indexValue1).setCondition(Condition.START_WITH));
+
+    IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray(Collections.singletonList(criterion1));
+    final IndexFilter indexFilter1 = new IndexFilter().setCriteria(indexCriterionArray1);
+    IndexGroupByCriterion indexGroupByCriterion1 = new IndexGroupByCriterion().setAspect(AspectFoo.class.getCanonicalName())
+        .setPath("/value");
+
+    Map<String, Long> result = dao.countAggregate(indexFilter1, indexGroupByCriterion1);
+    assertEquals(result.size(), 2);
+    assertEquals(result.get("valB").longValue(), 2);
+    assertEquals(result.get("valA").longValue(), 1);
+
+    // group by string and filter
+    IndexValue indexValue2 = new IndexValue();
+    indexValue2.setInt(10);
+    IndexCriterion criterion2 = new IndexCriterion().setAspect(aspect2)
+        .setPathParams(new IndexPathParams().setPath("/longField").setValue(indexValue2).setCondition(Condition.GREATER_THAN_OR_EQUAL_TO));
+
+    IndexCriterionArray indexCriterionArray2 = new IndexCriterionArray(Collections.singletonList(criterion2));
+    final IndexFilter indexFilter2 = new IndexFilter().setCriteria(indexCriterionArray2);
+    result = dao.countAggregate(indexFilter2, indexGroupByCriterion1);
+    assertEquals(result.size(), 2);
+    assertEquals(result.get("valB").longValue(), 1);
+    assertEquals(result.get("valA").longValue(), 1);
+
+    // group by nested field
+    IndexGroupByCriterion indexGroupByCriterion2 = new IndexGroupByCriterion().setAspect(AspectBaz.class.getCanonicalName())
+        .setPath("/recordField/value");
+
+    result = dao.countAggregate(indexFilter1, indexGroupByCriterion2);
+    assertEquals(result.size(), 3);
+    assertEquals(result.get("nestedA").longValue(), 1);
+    assertEquals(result.get("nestedB").longValue(), 1);
+    assertEquals(result.get("nestedC").longValue(), 1);
+
+    // group by long field
+    IndexGroupByCriterion indexGroupByCriterion3 = new IndexGroupByCriterion().setAspect(AspectBaz.class.getCanonicalName())
+        .setPath("/longField");
+
+    result = dao.countAggregate(indexFilter1, indexGroupByCriterion3);
+    assertEquals(result.size(), 3);
+    assertEquals(result.get("10").longValue(), 1);
+    assertEquals(result.get("8").longValue(), 1);
+    assertEquals(result.get("100").longValue(), 1);
+
+    // group by double field
+    IndexGroupByCriterion indexGroupByCriterion4 = new IndexGroupByCriterion().setAspect(AspectBaz.class.getCanonicalName())
+        .setPath("/doubleField");
+
+    result = dao.countAggregate(indexFilter1, indexGroupByCriterion4);
+    assertEquals(result.size(), 1);
+    assertEquals(result.get("1.2").longValue(), 3);
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -2155,6 +2155,13 @@ public class EbeanLocalDAOTest {
     result = dao.countAggregate(indexFilter1, indexGroupByCriterion4);
     assertEquals(result.size(), 1);
     assertEquals(result.get("1.2").longValue(), 3);
+
+    // group by an aspect and path that the filtered results do not contain
+    IndexGroupByCriterion indexGroupByCriterion5 = new IndexGroupByCriterion().setAspect(AspectBaz.class.getCanonicalName())
+        .setPath("/enumField");
+
+    result = dao.countAggregate(indexFilter1, indexGroupByCriterion5);
+    assertEquals(result.size(), 0);
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -2082,18 +2082,21 @@ public class EbeanLocalDAOTest {
     String aspect2 = AspectBaz.class.getCanonicalName();
 
     addIndex(urn1, aspect1, "/value", "valB");
+    addIndex(urn1, aspect2, "/stringField", "valC");
     addIndex(urn1, aspect2, "/longField", 10);
     addIndex(urn1, aspect2, "/doubleField", 1.2);
     addIndex(urn1, aspect2, "/recordField/value", "nestedC");
     addIndex(urn1, FooUrn.class.getCanonicalName(), "/fooId", 1);
 
     addIndex(urn2, aspect1, "/value", "valB");
+    addIndex(urn2, aspect2, "/stringField", "valC");
     addIndex(urn2, aspect2, "/longField", 8);
     addIndex(urn2, aspect2, "/doubleField", 1.2);
     addIndex(urn2, aspect2, "/recordField/value", "nestedB");
     addIndex(urn2, FooUrn.class.getCanonicalName(), "/fooId", 2);
 
     addIndex(urn3, aspect1, "/value", "valA");
+    addIndex(urn3, aspect2, "/stringField", "valC");
     addIndex(urn3, aspect2, "/longField", 100);
     addIndex(urn3, aspect2, "/doubleField", 1.2);
     addIndex(urn3, aspect2, "/recordField/value", "nestedA");
@@ -2162,6 +2165,24 @@ public class EbeanLocalDAOTest {
 
     result = dao.countAggregate(indexFilter1, indexGroupByCriterion5);
     assertEquals(result.size(), 0);
+
+    // filter by condition that are both strings and group by 1 of them
+    IndexValue indexValue3 = new IndexValue();
+    indexValue3.setString("valC");
+    IndexCriterion criterion3 = new IndexCriterion().setAspect(aspect2)
+        .setPathParams(new IndexPathParams().setPath("/stringField").setValue(indexValue3).setCondition(Condition.START_WITH));
+
+    IndexValue indexValue4 = new IndexValue();
+    indexValue4.setString("valB");
+    IndexCriterion criterion4 = new IndexCriterion().setAspect(aspect1)
+        .setPathParams(new IndexPathParams().setPath("/value").setValue(indexValue4).setCondition(Condition.START_WITH));
+
+    IndexCriterionArray indexCriterionArray3 = new IndexCriterionArray(Arrays.asList(criterion3, criterion4));
+    final IndexFilter indexFilter3 = new IndexFilter().setCriteria(indexCriterionArray3);
+
+    result = dao.countAggregate(indexFilter3, indexGroupByCriterion1);
+    assertEquals(result.size(), 1);
+    assertEquals(result.get("valB").longValue(), 2);
   }
 
   @Test

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -14,6 +14,7 @@ import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.query.IndexCriterion;
 import com.linkedin.metadata.query.IndexCriterionArray;
 import com.linkedin.metadata.query.IndexFilter;
+import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.metadata.query.ListResultMetadata;
 import com.linkedin.parseq.Task;
@@ -548,6 +549,23 @@ public abstract class BaseEntityResource<
         return filterAspects(aspectClasses, filter, indexSortCriterion, pagingContext.getStart(), pagingContext.getCount());
       }
     });
+  }
+
+  /*
+   * Gets the count of an aggregation specified by the aspect and field to group by.
+   * @param indexFilter {@link IndexFilter} that defines the filter conditions
+   * @param indexGroupByCriterion {@link IndexGroupByCriterion} that defines the aspect to group by
+   * @return map of the field to the count
+   */
+  @Action(name = ACTION_COUNT_AGGREGATE)
+  @Nonnull
+  public Task<Map<String, Long>> countAggregate(
+      @QueryParam(PARAM_FILTER) @Optional @Nullable IndexFilter indexFilter,
+      @QueryParam(PARAM_GROUP) IndexGroupByCriterion indexGroupByCriterion
+  ) {
+    final IndexFilter filter = indexFilter == null ? getDefaultIndexFilter() : indexFilter;
+
+    return RestliUtils.toTask(() -> getLocalDAO().countAggregate(indexFilter, indexGroupByCriterion));
   }
 
   @Nonnull

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -11,6 +11,7 @@ public final class RestliConstants {
   public static final String ACTION_BACKFILL_WITH_URNS = "backfillWithUrns";
   public static final String ACTION_BACKFILL_LEGACY = "backfillLegacy";
   public static final String ACTION_BROWSE = "browse";
+  public static final String ACTION_COUNT_AGGREGATE = "countAggregate";
   public static final String ACTION_GET_BROWSE_PATHS = "getBrowsePaths";
   public static final String ACTION_GET_SNAPSHOT = "getSnapshot";
   public static final String ACTION_INGEST = "ingest";
@@ -19,6 +20,7 @@ public final class RestliConstants {
   public static final String PARAM_INPUT = "input";
   public static final String PARAM_ASPECTS = "aspects";
   public static final String PARAM_FILTER = "filter";
+  public static final String PARAM_GROUP = "group";
   public static final String PARAM_SORT = "sort";
   public static final String PARAM_QUERY = "query";
   public static final String PARAM_FIELD = "field";


### PR DESCRIPTION
This change adds a new method to the DAO and resource to count aggregations. The aspect and path to be grouped/aggregated on can be passed in, and the count of the urns for each grouped value is returned. The returned value is a map of the field value to the count.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
