### PR TITLE
feat: add filter for offset pagination

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -393,6 +393,7 @@ public abstract class BaseEntityResource<
    * takes in a start offset and returns a list result with pagination information.
    *
    * @param start defining the paging start
+   * @param count defining the maximum number of values returned
    * @return a {@link ListResult} containing a list of version numbers and other pagination information
    */
   @Nonnull
@@ -442,6 +443,7 @@ public abstract class BaseEntityResource<
    * takes in a start offset and returns a list result with pagination information.
    *
    * @param start defining the paging start
+   * @param count defining the maximum number of values returned
    * @return a {@link ListResult} containing an ordered list of values of multiple entities and other pagination information
    */
   @Nonnull

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -8,6 +8,7 @@ import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.backfill.BackfillMode;
 import com.linkedin.metadata.dao.AspectKey;
 import com.linkedin.metadata.dao.BaseLocalDAO;
+import com.linkedin.metadata.dao.ListResult;
 import com.linkedin.metadata.dao.UrnAspectEntry;
 import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.query.IndexCriterion;
@@ -336,26 +337,13 @@ public abstract class BaseEntityResource<
   }
 
   /**
-   * Returns ordered list of values of multiple entities obtained after filtering urns
-   * from local secondary index. The returned list is ordered by the sort criterion but defaults to sorting
-   * lexicographically by the string representation of the URN.
-   * The list of values is in the same order as the list of urns contained in {@link ListResultMetadata}.
+   * Returns a list of values of multiple entities from urn aspect entries.
    *
-   * @param aspectClasses set of aspect classes that needs to be populated in the values
-   * @param filter {@link IndexFilter} that defines the filter conditions
-   * @param indexSortCriterion {@link IndexSortCriterion} that defines the sort conditions
-   * @param lastUrn last urn of the previous fetched page. For the first page, this should be set as NULL
-   * @param count defining the maximum number of values returned
+   * @param urnAspectEntries entries used to make values
    * @return ordered list of values of multiple entities
    */
   @Nonnull
-  private List<VALUE> filterAspects(
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull IndexFilter filter,
-      @Nullable IndexSortCriterion indexSortCriterion, @Nullable String lastUrn, int count) {
-
-    final List<UrnAspectEntry<URN>> urnAspectEntries =
-        getLocalDAO().getAspects(aspectClasses, filter, indexSortCriterion, parseUrnParam(lastUrn), count);
-
+  private List<VALUE> getUrnAspectValues(List<UrnAspectEntry<URN>> urnAspectEntries) {
     final Map<URN, List<UnionTemplate>> urnAspectsMap = new LinkedHashMap<>();
     for (UrnAspectEntry<URN> entry : urnAspectEntries) {
       urnAspectsMap.compute(entry.getUrn(), (k, v) -> {
@@ -378,6 +366,58 @@ public abstract class BaseEntityResource<
 
   /**
    * Returns ordered list of values of multiple entities obtained after filtering urns
+   * from local secondary index. The returned list is ordered by the sort criterion but defaults to sorting
+   * lexicographically by the string representation of the URN.
+   * The list of values is in the same order as the list of urns contained in {@link ListResultMetadata}.
+   *
+   * @param aspectClasses set of aspect classes that needs to be populated in the values
+   * @param filter {@link IndexFilter} that defines the filter conditions
+   * @param indexSortCriterion {@link IndexSortCriterion} that defines the sort conditions
+   * @param lastUrn last urn of the previous fetched page. For the first page, this should be set as NULL
+   * @param count defining the maximum number of values returned
+   * @return ordered list of values of multiple entities
+   */
+  @Nonnull
+  private List<VALUE> filterAspects(
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull IndexFilter filter,
+      @Nullable IndexSortCriterion indexSortCriterion, @Nullable String lastUrn, int count) {
+
+    final List<UrnAspectEntry<URN>> urnAspectEntries =
+        getLocalDAO().getAspects(aspectClasses, filter, indexSortCriterion, parseUrnParam(lastUrn), count);
+
+    return getUrnAspectValues(urnAspectEntries);
+  }
+
+  /**
+   * Similar to {@link #filterAspects(Set, IndexFilter, IndexSortCriterion, String, int)} but
+   * takes in a paging context and returns a list result with pagination information.
+   *
+   * @param pagingContext {@link PagingContext} defines the paging start and count
+   * @return a {@link ListResult} containing a list of version numbers and other pagination information
+   */
+  @Nonnull
+  private ListResult<VALUE> filterAspects(
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull IndexFilter filter,
+      @Nullable IndexSortCriterion indexSortCriterion, @Nonnull PagingContext pagingContext) {
+
+    final ListResult<UrnAspectEntry<URN>> listResult =
+        getLocalDAO().getAspects(aspectClasses, filter, indexSortCriterion, pagingContext.getStart(), pagingContext.getCount());
+    final List<UrnAspectEntry<URN>> urnAspectEntries = listResult.getValues();
+    final List<VALUE> values = getUrnAspectValues(urnAspectEntries);
+
+    return ListResult.<VALUE>builder()
+        .values(values)
+        .metadata(listResult.getMetadata())
+        .nextStart(listResult.getNextStart())
+        .havingMore(listResult.isHavingMore())
+        .totalCount(listResult.getTotalCount())
+        .totalPageCount(listResult.getTotalPageCount())
+        .pageSize(listResult.getPageSize())
+        .build();
+  }
+
+  /**
+   * Returns ordered list of values of multiple entities obtained after filtering urns
    * from local secondary index. The returned list is ordered by the sort criterion but defaults to
    * being ordered lexicographically by the string representation of the URN.
    * The values returned do not contain any metadata aspect, only parts of the urn (if applicable).
@@ -395,6 +435,33 @@ public abstract class BaseEntityResource<
 
     final List<URN> urns = getLocalDAO().listUrns(filter, indexSortCriterion, parseUrnParam(lastUrn), count);
     return urns.stream().map(urn -> toValue(newSnapshot(urn))).collect(Collectors.toList());
+  }
+
+  /**
+   * Similar to {@link #filterUrns(IndexFilter, IndexSortCriterion, String, int)} but
+   * takes in a paging context and returns a list result with pagination information.
+   *
+   * @param pagingContext {@link PagingContext} defines the paging start and count
+   * @return a {@link ListResult} containing an ordered list of values of multiple entities and other pagination information
+   */
+  @Nonnull
+  private ListResult<VALUE> filterUrns(@Nonnull IndexFilter filter, @Nullable IndexSortCriterion indexSortCriterion,
+      @Nonnull PagingContext pagingContext) {
+
+    final ListResult<URN> listResult = getLocalDAO()
+        .listUrns(filter, indexSortCriterion, pagingContext.getStart(), pagingContext.getCount());
+    final List<URN> urns = listResult.getValues();
+    final List<VALUE> urnValues = urns.stream().map(urn -> toValue(newSnapshot(urn))).collect(Collectors.toList());
+
+    return ListResult.<VALUE>builder()
+        .values(urnValues)
+        .metadata(listResult.getMetadata())
+        .nextStart(listResult.getNextStart())
+        .havingMore(listResult.isHavingMore())
+        .totalCount(listResult.getTotalCount())
+        .totalPageCount(listResult.getTotalPageCount())
+        .pageSize(listResult.getPageSize())
+        .build();
   }
 
   /**
@@ -450,6 +517,34 @@ public abstract class BaseEntityResource<
       @QueryParam(PARAM_URN) @Optional @Nullable String lastUrn,
       @PagingContextParam @Nonnull PagingContext pagingContext) {
     return filter(indexFilter, null, aspectNames, lastUrn, pagingContext.getCount());
+  }
+
+  /**
+   * Similar to {@link #filter(IndexFilter, IndexSortCriterion, String[], String, int)} but
+   * returns a list result with pagination information.
+   *
+   * @param pagingContext {@link PagingContext} defines the paging start and count
+   * @return {@link ListResult} containing values along with the associated urns in {@link ListResultMetadata} and
+   *        pagination information
+   */
+  @Finder(FINDER_FILTER_OFFSET_PAGINATION)
+  @Nonnull
+  public Task<ListResult<VALUE>> filter(
+      @QueryParam(PARAM_FILTER) @Optional @Nullable IndexFilter indexFilter,
+      @QueryParam(PARAM_SORT) @Optional @Nullable IndexSortCriterion indexSortCriterion,
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
+      @PagingContextParam @Nonnull PagingContext pagingContext) {
+
+    final IndexFilter filter = indexFilter == null ? getDefaultIndexFilter() : indexFilter;
+
+    return RestliUtils.toTask(() -> {
+      final Set<Class<? extends RecordTemplate>> aspectClasses = parseAspectsParam(aspectNames);
+      if (aspectClasses.isEmpty()) {
+        return filterUrns(filter, indexSortCriterion, pagingContext);
+      } else {
+        return filterAspects(aspectClasses, filter, indexSortCriterion, pagingContext);
+      }
+    });
   }
 
   @Nonnull

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -527,7 +527,7 @@ public abstract class BaseEntityResource<
    * @return {@link ListResult} containing values along with the associated urns in {@link ListResultMetadata} and
    *        pagination information
    */
-  @Finder(FINDER_FILTER_OFFSET_PAGINATION)
+  @Finder(FINDER_FILTER_OFFSET)
   @Nonnull
   public Task<ListResult<VALUE>> filter(
       @QueryParam(PARAM_FILTER) @Optional @Nullable IndexFilter indexFilter,

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -5,7 +5,7 @@ public final class RestliConstants {
 
   public static final String FINDER_SEARCH = "search";
   public static final String FINDER_FILTER = "filter";
-  public static final String FINDER_FILTER_OFFSET_PAGINATION = "filterOffsetPagination";
+  public static final String FINDER_FILTER_OFFSET = "filterOffset";
 
   public static final String ACTION_AUTOCOMPLETE = "autocomplete";
   public static final String ACTION_BACKFILL = "backfill";

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -5,6 +5,7 @@ public final class RestliConstants {
 
   public static final String FINDER_SEARCH = "search";
   public static final String FINDER_FILTER = "filter";
+  public static final String FINDER_FILTER_OFFSET_PAGINATION = "filterOffsetPagination";
 
   public static final String ACTION_AUTOCOMPLETE = "autocomplete";
   public static final String ACTION_BACKFILL = "backfill";

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -5,7 +5,6 @@ public final class RestliConstants {
 
   public static final String FINDER_SEARCH = "search";
   public static final String FINDER_FILTER = "filter";
-  public static final String FINDER_FILTER_OFFSET = "filterOffset";
 
   public static final String ACTION_AUTOCOMPLETE = "autocomplete";
   public static final String ACTION_BACKFILL = "backfill";

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -569,6 +569,33 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual3.size(), 2);
     assertEquals(actual3.get(0), new EntityValue().setFoo(foo2).setBar(bar2));
     assertEquals(actual3.get(1), new EntityValue().setFoo(foo1).setBar(bar1));
+
+    // case 4: offset pagination
+    ListResult<UrnAspectEntry<FooUrn>> urnsListResult = ListResult.<UrnAspectEntry<FooUrn>>builder()
+        .values(Arrays.asList(entry2, entry1))
+        .metadata(null)
+        .nextStart(ListResult.INVALID_NEXT_START)
+        .havingMore(false)
+        .totalCount(2)
+        .totalPageCount(1)
+        .pageSize(2)
+        .build();
+
+    when(_mockLocalDAO.getAspects(ImmutableSet.of(AspectFoo.class, AspectBar.class), indexFilter, indexSortCriterion, 0, 2))
+        .thenReturn(urnsListResult);
+
+    ListResult<EntityValue> actual4 =
+        runAndWait(_resource.filter(indexFilter, indexSortCriterion, aspectNames, new PagingContext(0, 2)));
+
+    List<EntityValue> actualValues = actual4.getValues();
+    assertEquals(actualValues.size(), 2);
+    assertEquals(actualValues.get(0), new EntityValue().setFoo(foo2).setBar(bar2));
+    assertEquals(actualValues.get(1), new EntityValue().setFoo(foo1).setBar(bar1));
+    assertEquals(actual4.getNextStart(), urnsListResult.getNextStart());
+    assertEquals(actual4.isHavingMore(), urnsListResult.isHavingMore());
+    assertEquals(actual4.getTotalCount(), urnsListResult.getTotalCount());
+    assertEquals(actual4.getTotalPageCount(), urnsListResult.getTotalPageCount());
+    assertEquals(actual4.getPageSize(), urnsListResult.getPageSize());
   }
 
   @Test

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -6,6 +6,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.backfill.BackfillMode;
 import com.linkedin.metadata.dao.AspectKey;
 import com.linkedin.metadata.dao.BaseLocalDAO;
+import com.linkedin.metadata.dao.ListResult;
 import com.linkedin.metadata.dao.UrnAspectEntry;
 import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.dao.utils.RecordUtils;
@@ -488,6 +489,29 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual.size(), 2);
     assertEquals(actual.get(0), new EntityValue());
     assertEquals(actual.get(1), new EntityValue());
+
+    // case 4: offset pagination
+    ListResult<FooUrn> urnsListResult = ListResult.<FooUrn>builder()
+        .values(urns3)
+        .metadata(null)
+        .nextStart(ListResult.INVALID_NEXT_START)
+        .havingMore(false)
+        .totalCount(2)
+        .totalPageCount(1)
+        .pageSize(2)
+        .build();
+    when(_mockLocalDAO.listUrns(indexFilter2, indexSortCriterion, 0, 2)).thenReturn(urnsListResult);
+    ListResult<EntityValue>
+        listResultActual = runAndWait(_resource.filter(null, indexSortCriterion, new String[0], new PagingContext(0, 2)));
+    List<EntityValue> actualValues = listResultActual.getValues();
+    assertEquals(actualValues.size(), 2);
+    assertEquals(actualValues.get(0), new EntityValue());
+    assertEquals(actualValues.get(1), new EntityValue());
+    assertEquals(listResultActual.getNextStart(), urnsListResult.getNextStart());
+    assertEquals(listResultActual.isHavingMore(), urnsListResult.isHavingMore());
+    assertEquals(listResultActual.getTotalCount(), urnsListResult.getTotalCount());
+    assertEquals(listResultActual.getTotalPageCount(), urnsListResult.getTotalPageCount());
+    assertEquals(listResultActual.getPageSize(), urnsListResult.getPageSize());
   }
 
   @Test


### PR DESCRIPTION
This change adds a new filter method for offset pagination in BaseEntityResource. It is a follow-up to https://github.com/linkedin/datahub-gma/pull/110. 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
