### PR TITLE
feat: add support for sub fields in ES Browse query

### DIFF
--- a/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
+++ b/dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
@@ -122,8 +122,9 @@ public class ESBrowseDAO extends BaseBrowseDAO {
    * @param isGroupQuery true if it's group query false otherwise
    * @return {@link QueryBuilder}
    */
+  @VisibleForTesting
   @Nonnull
-  private QueryBuilder buildQueryString(@Nonnull String path, @Nonnull Map<String, String> requestMap,
+   QueryBuilder buildQueryString(@Nonnull String path, @Nonnull Map<String, String> requestMap,
       boolean isGroupQuery) {
     final String browsePathFieldName = _config.getBrowsePathFieldName();
     final String browseDepthFieldName = _config.getBrowseDepthFieldName();
@@ -145,7 +146,8 @@ public class ESBrowseDAO extends BaseBrowseDAO {
     }
 
     requestMap.forEach((field, val) -> {
-      if (_config.hasFieldInSchema(field)) {
+      String[] fieldParts = field.split("\\.");
+      if (_config.hasFieldInSchema(fieldParts[0])) {
         queryBuilder.filter(QueryBuilders.termQuery(field, val));
       }
     });


### PR DESCRIPTION
This is add support for filtering on subfield, which may have a different analyzer.
For example - filter `browsePaths.edge_search = value` will now be possible as
`browsePaths` is available in model but not `browsePaths.edge_search`.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
