### PR TITLE
fix(field-extraction): supporting string union extraction in record utils

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -471,7 +471,8 @@ public class RecordUtils {
 
   /**
    * Given a {@link RecordTemplate} and {@link com.linkedin.data.schema.PathSpec} this will return value of the path from the record.
-   * This handles only RecordTemplate, fields of which can be primitive types, typeRefs, arrays of primitive types, arrays of records or arrays of primitive union types.
+   * This handles only RecordTemplate, fields of which can be primitive types, typeRefs, arrays of primitive types, arrays of records
+   * or arrays of primitive union types.
    * Fetching of values in a RecordTemplate where the field has a default value will return the field default value.
    * Referencing field corresponding to a particular index or range of indices of an array is not supported.
    * Fields corresponding to 1) multi-dimensional array 2) UnionTemplate 3) AbstractMapTemplate 4) FixedTemplate are currently not supported.

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -413,7 +413,7 @@ public class RecordUtils {
   /**
    * Helper method for referencing array of RecordTemplate objects. Referencing a particular index or range of indices of an array is not supported.
    *
-   * @param reference {@link AbstractArrayTemplate} corresponding to array of {@link RecordTemplate} which needs to be referenced
+   * @param reference {@link AbstractArrayTemplate} corresponding to array of {@link RecordTemplate} or {@link UnionTemplate} which needs to be referenced
    * @param ps {@link PathSpec} for the entire path inside the array that needs to be referenced
    * @return {@link List} of objects from the array, referenced using the PathSpec
    */
@@ -471,7 +471,7 @@ public class RecordUtils {
 
   /**
    * Given a {@link RecordTemplate} and {@link com.linkedin.data.schema.PathSpec} this will return value of the path from the record.
-   * This handles only RecordTemplate, fields of which can be primitive types, typeRefs, arrays of primitive types or array of records.
+   * This handles only RecordTemplate, fields of which can be primitive types, typeRefs, arrays of primitive types, arrays of records or arrays of primitive union types.
    * Fetching of values in a RecordTemplate where the field has a default value will return the field default value.
    * Referencing field corresponding to a particular index or range of indices of an array is not supported.
    * Fields corresponding to 1) multi-dimensional array 2) UnionTemplate 3) AbstractMapTemplate 4) FixedTemplate are currently not supported.

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -15,6 +15,8 @@ import com.linkedin.testing.AspectFooArray;
 import com.linkedin.testing.EntitySnapshot;
 import com.linkedin.testing.EntityValueArray;
 import com.linkedin.testing.MixedRecord;
+import com.linkedin.testing.StringUnion;
+import com.linkedin.testing.StringUnionArray;
 import com.linkedin.testing.singleaspectentity.EntityValue;
 import com.linkedin.testing.urn.FooUrn;
 import java.io.IOException;
@@ -371,6 +373,41 @@ public class RecordUtilsTest {
     PathSpec ps7 = MixedRecord.fields().recordArray().items().value();
     Optional<Object> o7 = RecordUtils.getFieldValue(mixedRecord7, ps7);
     assertFalse(o7.isPresent());
+  }
+
+  @Test(description = "Test getFieldValue() when RecordTemplate has field of type array of primitive unions")
+  public void testGetFieldValueArrayOfPrimitiveUnions() {
+
+    // case 1: array of unions of strings
+    final MixedRecord mixedRecord1 =
+        new MixedRecord().setUnionArray(new StringUnionArray(Arrays.asList(
+            StringUnion.create("val1"),
+            StringUnion.create("val2"),
+            StringUnion.create("val3"),
+            StringUnion.create("val4")
+        )));
+
+    PathSpec ps1 = MixedRecord.fields().unionArray();
+    Object o1 = RecordUtils.getFieldValue(mixedRecord1, ps1).get();
+
+    PathSpec ps2 = MixedRecord.fields().unionArray().items();
+    Object o2 = RecordUtils.getFieldValue(mixedRecord1, ps2).get();
+
+    assertEquals(o1, new StringUnionArray(Arrays.asList(
+        StringUnion.create("val1"),
+        StringUnion.create("val2"),
+        StringUnion.create("val3"),
+        StringUnion.create("val4")
+    )));
+    assertEquals(ps1.toString(), "/unionArray");
+
+    assertEquals(o2, new StringUnionArray(Arrays.asList(
+        StringUnion.create("val1"),
+        StringUnion.create("val2"),
+        StringUnion.create("val3"),
+        StringUnion.create("val4")
+    )));
+    assertEquals(ps2.toString(), "/unionArray/*");
   }
 
   @Test

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
@@ -48,6 +48,11 @@ record MixedRecord {
   /**
    * For unit tests
    */
+  unionArray: optional array[StringUnion]
+
+  /**
+   * For unit tests
+   */
   fooUrn: optional FooUrn
 
   /**

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/StringUnion.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/StringUnion.pdl
@@ -1,0 +1,6 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit testing
+ */
+typeref StringUnion = union[string]


### PR DESCRIPTION
In ChartInfo.pdl, we have an array of unions:

https://github.com/linkedin/datahub/blob/master/metadata-models/src/main/pegasus/com/linkedin/chart/ChartInfo.pdl#L52

However, this was not supported in GMA's extract field utils. This meant that we could not index this field in the graph or search service.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
