### PR TITLE
feat: add pre-update hooks to BaseLocalDAO

### DIFF
--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -229,6 +229,37 @@ public class BaseLocalDAOTest {
   }
 
   @Test
+  public void testAddSamePreUpdateHookTwice() {
+    BiConsumer<FooUrn, AspectFoo> hook = (urn, foo) -> {
+      // do nothing;
+    };
+
+    _dummyLocalDAO.addPreUpdateHook(AspectFoo.class, hook);
+
+    try {
+      _dummyLocalDAO.addPreUpdateHook(AspectFoo.class, hook);
+    } catch (IllegalArgumentException e) {
+      // expected
+      return;
+    }
+
+    fail("No IllegalArgumentException thrown");
+  }
+
+  @Test
+  public void testPreUpdateHookInvoked() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo foo = new AspectFoo().setValue("foo");
+    BiConsumer<FooUrn, AspectFoo> hook = mock(BiConsumer.class);
+
+    _dummyLocalDAO.addPreUpdateHook(AspectFoo.class, hook);
+    _dummyLocalDAO.add(urn, foo, _dummyAuditStamp);
+
+    verify(hook, times(1)).accept(urn, foo);
+    verifyNoMoreInteractions(hook);
+  }
+
+  @Test
   public void testAddSamePostUpdateHookTwice() {
     BiConsumer<FooUrn, AspectFoo> hook = (urn, foo) -> {
       // do nothing;


### PR DESCRIPTION
Introduce infrastructure for pre-update hooks, motivated by the need for a pre-update hook to remove duplicate elements from certain aspects.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
