### PR TITLE
fix: issue with commas in filters of search queries with ES7

### DIFF
--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
@@ -63,6 +63,13 @@ public class ESUtils {
     final Condition condition = criterion.getCondition();
     if (condition == Condition.EQUAL) {
       BoolQueryBuilder filters = new BoolQueryBuilder();
+
+      // TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using
+      // delimiters like comma. This is a hack to support equals with URN that has a comma in it.
+      if (SearchUtils.isUrn(criterion.getValue())) {
+        filters.should(QueryBuilders.matchQuery(criterion.getField(), criterion.getValue().trim()));
+        return filters;
+      }
       Arrays.stream(criterion.getValue().trim().split("\\s*,\\s*"))
           .forEach(elem -> filters.should(QueryBuilders.matchQuery(criterion.getField(), elem)));
       return filters;

--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -44,6 +44,13 @@ public class SearchUtils {
     return requestParams.getCriteria().stream().collect(Collectors.toMap(Criterion::getField, Criterion::getValue));
   }
 
+  static boolean isUrn(@Nonnull String value) {
+    // TODO(https://github.com/linkedin/datahub-gma/issues/51): This method is a bit of a hack to support searching for
+    // URNs that have commas in them, while also using commas a delimiter for search. We should stop supporting commas
+    // as delimiter, and then we can stop using this hack.
+    return value.startsWith("urn:li:");
+  }
+
   /**
    * Builds search query given a {@link Criterion}, containing field, value and association/condition between the two.
    *
@@ -70,7 +77,9 @@ public class SearchUtils {
   public static QueryBuilder getQueryBuilderFromCriterion(@Nonnull Criterion criterion) {
     final Condition condition = criterion.getCondition();
     if (condition == Condition.EQUAL) {
-      if (criterion.getValue().startsWith("urn:li:")) {
+      // TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using
+      // delimiters like comma. This is a hack to support equals with URN that has a comma in it.
+      if (isUrn(criterion.getValue())) {
         return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim());
       }
       return QueryBuilders.termsQuery(criterion.getField(), criterion.getValue().trim().split("\\s*,\\s*"));


### PR DESCRIPTION
## Checklist

Similar fix was done for ES5 was made here https://github.com/linkedin/datahub-gma/pull/57
 
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
