### PR TITLE
feat: add restli delete method to soft delete aspect

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -17,6 +17,7 @@ import com.linkedin.restli.server.CreateKVResponse;
 import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.PagingContext;
 import com.linkedin.restli.server.PathKeys;
+import com.linkedin.restli.server.UpdateResponse;
 import com.linkedin.restli.server.annotations.PagingContextParam;
 import com.linkedin.restli.server.annotations.RestMethod;
 import com.linkedin.restli.server.annotations.ReturnEntity;
@@ -108,6 +109,22 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       getLocalDAO().add(urn, aspect, auditStamp);
       return new CreateResponse(HttpStatus.S_201_CREATED);
+    });
+  }
+
+  /**
+   * Soft deletes the latest version of aspect if it exists.
+   *
+   * @return {@link UpdateResponse} indicating the status code of the response.
+   */
+  @RestMethod.Delete
+  @Nonnull
+  public Task<UpdateResponse> delete() {
+    return RestliUtils.toTask(() -> {
+      final URN urn = getUrn(getContext().getPathKeys());
+      final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
+      getLocalDAO().delete(urn, this._aspectClass, auditStamp);
+      return new UpdateResponse(HttpStatus.S_200_OK);
     });
   }
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseVersionedAspectResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseVersionedAspectResourceTest.java
@@ -113,6 +113,16 @@ public class BaseVersionedAspectResourceTest extends BaseEngineTest {
   }
 
   @Test
+  public void testSoftDelete() {
+
+    runAndWait(_resource.delete());
+
+    // this should test that delete method of DAO is being called once
+    verify(_mockLocalDAO, times(1)).delete(eq(ENTITY_URN), eq(AspectFoo.class), any(AuditStamp.class));
+    verifyNoMoreInteractions(_mockLocalDAO);
+  }
+
+  @Test
   public void testCreateViaLambda() {
     AspectFoo foo = new AspectFoo().setValue("foo");
     Function<Optional<AspectFoo>, AspectFoo> createLambda = (prev) -> foo;


### PR DESCRIPTION
This change adds a Restli delete method to support soft deletion of an aspect. More details on the delete method can be found here https://linkedin.github.io/rest.li/user_guide/restli_server#delete

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
