### PR TITLE
fix: add default value of null to changeType field in MCE and MAE

### DIFF
--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -38,5 +38,5 @@ record MetadataAuditEvent {
   /**
    * Change type.
    */
-  changeType: optional ChangeType
+  changeType: optional union[null, ChangeType] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
@@ -33,5 +33,5 @@ record MetadataChangeEvent {
   /**
    * Change type.
    */
-  changeType: optional ChangeType
+  changeType: optional union[null, ChangeType] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -34,5 +34,5 @@ record MetadataAuditEvent {
   /**
    * Change type.
    */
-  changeType: optional ChangeType
+  changeType: optional union[null, ChangeType] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
@@ -29,5 +29,5 @@ record MetadataChangeEvent {
   /**
    * Change type.
    */
-  changeType: optional ChangeType
+  changeType: optional union[null, ChangeType] = null
 }

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -122,7 +122,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Change type.
          */
-        changeType: optional ChangeType
+        changeType: optional union[null, ChangeType] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testAspect/MetadataAuditEvent.pdl').text == '''\
@@ -162,7 +162,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Change type.
          */
-        changeType: optional ChangeType
+        changeType: optional union[null, ChangeType] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testAspect/FailedMetadataChangeEvent.pdl').text == '''\


### PR DESCRIPTION
Adding a new field is backwards compatible if a default value is provided. The reader will substitute that default for missing data in records written with an older schema. At LinkedIn, we require that this new field be of a type that contains a union with null and that null be the default to allow readers to identify clearly records where the data is missing.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
