### PR TITLE
fix: move ChangeType model to dao-api

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/ChangeType.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/ChangeType.pdl
@@ -1,4 +1,4 @@
-namespace com.linkedin.common
+namespace com.linkedin.metadata.events
 
 /**
  * Descriptor for a change action. For every type, a new version of metadata will be created

--- a/gradle-plugins/metadata-annotations-schema/build.gradle
+++ b/gradle-plugins/metadata-annotations-schema/build.gradle
@@ -8,4 +8,5 @@ apply from: "$rootDir/gradle/java-publishing.gradle"
 
 dependencies {
   dataModel project(':core-models')
+  dataModel project(':dao-api')
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -5,7 +5,7 @@
 namespace com.linkedin.mxe@(nameSpace)
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.common.ChangeType
+import com.linkedin.metadata.events.ChangeType
 import @entityUrn
 import @eventSpec.getFullValueType()
 

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
@@ -5,7 +5,7 @@
 namespace com.linkedin.mxe@(nameSpace)
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.common.ChangeType
+import com.linkedin.metadata.events.ChangeType
 import @entityUrn
 import @eventSpec.getFullValueType()
 

--- a/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -1,7 +1,7 @@
 namespace com.linkedin.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.common.ChangeType
+import com.linkedin.metadata.events.ChangeType
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 

--- a/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/resources/expectedSchemas/pegasus/com/linkedin/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
@@ -1,7 +1,7 @@
 namespace com.linkedin.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.common.ChangeType
+import com.linkedin.metadata.events.ChangeType
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -94,7 +94,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
       namespace com.linkedin.mxe.foo.testAspect
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-      import com.linkedin.common.ChangeType
+      import com.linkedin.metadata.events.ChangeType
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestAspect
 
@@ -129,7 +129,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
       namespace com.linkedin.mxe.foo.testAspect
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-      import com.linkedin.common.ChangeType
+      import com.linkedin.metadata.events.ChangeType
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestAspect
 

--- a/testing/test-models/build.gradle
+++ b/testing/test-models/build.gradle
@@ -4,7 +4,9 @@ apply from: "$rootDir/gradle/java-publishing.gradle"
 
 dependencies {
   compile project(':core-models')
+  compile project(':dao-api')
   dataModel project(':core-models')
+  dataModel project(':dao-api')
 
   compile spec.product.pegasus.restliCommon
 }


### PR DESCRIPTION
`ChangeType` model needed for MCE and MAE was added in `core-models` which is not the right place since core-models store urn related models. This change moves `ChangeType.pdl` to appropriate folder in `dao-api` module.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
