### PR TITLE
fix: use DELETED string literal for null metadata

### DIFF
--- a/dao-impl/ebean-dao/gma-create-all.sql
+++ b/dao-impl/ebean-dao/gma-create-all.sql
@@ -8,7 +8,7 @@ create table metadata_aspect (
   urn                           varchar(500) not null,
   aspect                        varchar(200) not null,
   version                       bigint not null,
-  metadata                      clob,
+  metadata                      clob not null,
   createdon                     timestamp not null,
   createdby                     varchar(255) not null,
   createdfor                    varchar(255),

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -71,6 +71,8 @@ import static com.linkedin.metadata.dao.EbeanMetadataAspect.*;
 public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     extends BaseLocalDAO<ASPECT_UNION, URN> {
 
+  public static final String NULL_VALUE = "NULL";
+
   private static final int INDEX_QUERY_TIMEOUT_IN_SEC = 5;
   private static final String EBEAN_MODEL_PACKAGE = EbeanMetadataAspect.class.getPackage().getName();
   private static final String EBEAN_INDEX_PACKAGE = EbeanMetadataIndex.class.getPackage().getName();
@@ -353,7 +355,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (value != null) {
       aspect.setMetadata(RecordUtils.toJsonString(value));
     } else {
-      aspect.setMetadata(null);
+      aspect.setMetadata(NULL_VALUE);
     }
     aspect.setCreatedOn(new Timestamp(auditStamp.getTime()));
     aspect.setCreatedBy(auditStamp.getActor().toString());
@@ -835,7 +837,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   private static <ASPECT extends RecordTemplate> Optional<ASPECT> toRecordTemplate(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull EbeanMetadataAspect aspect) {
-    if (aspect.getMetadata() == null) {
+    if (aspect.getMetadata().equals(NULL_VALUE)) {
       return Optional.empty();
     }
     return Optional.of(RecordUtils.toRecordTemplate(aspectClass, aspect.getMetadata()));
@@ -872,7 +874,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Nonnull
   private static Optional<ExtraInfo> toExtraInfo(@Nonnull EbeanMetadataAspect aspect) {
-    if (aspect.getMetadata() == null) {
+    if (aspect.getMetadata().equals(NULL_VALUE)) {
       return Optional.empty();
     }
     final ExtraInfo extraInfo = new ExtraInfo();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -71,7 +71,8 @@ import static com.linkedin.metadata.dao.EbeanMetadataAspect.*;
 public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     extends BaseLocalDAO<ASPECT_UNION, URN> {
 
-  public static final String NULL_VALUE = "NULL";
+  // String literal stored in metadata_aspect table for soft deleted aspect
+  public static final String DELETED_VALUE = "DELETED";
 
   private static final int INDEX_QUERY_TIMEOUT_IN_SEC = 5;
   private static final String EBEAN_MODEL_PACKAGE = EbeanMetadataAspect.class.getPackage().getName();
@@ -355,7 +356,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (value != null) {
       aspect.setMetadata(RecordUtils.toJsonString(value));
     } else {
-      aspect.setMetadata(NULL_VALUE);
+      aspect.setMetadata(DELETED_VALUE);
     }
     aspect.setCreatedOn(new Timestamp(auditStamp.getTime()));
     aspect.setCreatedBy(auditStamp.getActor().toString());
@@ -837,7 +838,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   private static <ASPECT extends RecordTemplate> Optional<ASPECT> toRecordTemplate(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull EbeanMetadataAspect aspect) {
-    if (aspect.getMetadata().equals(NULL_VALUE)) {
+    if (aspect.getMetadata().equals(DELETED_VALUE)) {
       return Optional.empty();
     }
     return Optional.of(RecordUtils.toRecordTemplate(aspectClass, aspect.getMetadata()));
@@ -874,7 +875,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Nonnull
   private static Optional<ExtraInfo> toExtraInfo(@Nonnull EbeanMetadataAspect aspect) {
-    if (aspect.getMetadata().equals(NULL_VALUE)) {
+    if (aspect.getMetadata().equals(DELETED_VALUE)) {
       return Optional.empty();
     }
     final ExtraInfo extraInfo = new ExtraInfo();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataAspect.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataAspect.java
@@ -71,7 +71,7 @@ public class EbeanMetadataAspect extends Model {
   protected PrimaryKey key;
 
   @Lob
-  @Column(name = METADATA_COLUMN, nullable = true)
+  @Column(name = METADATA_COLUMN, nullable = false)
   protected String metadata;
 
   @NonNull

--- a/dao-impl/ebean-dao/src/main/resources/gma-create-all.sql
+++ b/dao-impl/ebean-dao/src/main/resources/gma-create-all.sql
@@ -2,7 +2,7 @@ create table metadata_aspect (
   urn                           varchar(500) not null,
   aspect                        varchar(200) not null,
   version                       bigint not null,
-  metadata                      clob,
+  metadata                      clob not null,
   createdon                     timestamp not null,
   createdby                     varchar(255) not null,
   createdfor                    varchar(255),

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -228,7 +228,7 @@ public class EbeanLocalDAOTest {
 
     // latest version of metadata should be null
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, 0);
-    assertNull(aspect.getMetadata());
+    assertEquals(aspect.getMetadata(), EbeanLocalDAO.NULL_VALUE);
 
     aspect = getMetadata(urn, aspectName, 1);
     AspectFoo actual = RecordUtils.toRecordTemplate(AspectFoo.class, aspect.getMetadata());
@@ -2465,6 +2465,8 @@ public class EbeanLocalDAOTest {
     aspect.setKey(new EbeanMetadataAspect.PrimaryKey(urn.toString(), aspectName, version));
     if (metadata != null) {
       aspect.setMetadata(RecordUtils.toJsonString(metadata));
+    } else {
+      aspect.setMetadata(EbeanLocalDAO.NULL_VALUE);
     }
     aspect.setCreatedOn(new Timestamp(1234));
     aspect.setCreatedBy("urn:li:test:foo");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -228,7 +228,7 @@ public class EbeanLocalDAOTest {
 
     // latest version of metadata should be null
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, 0);
-    assertEquals(aspect.getMetadata(), EbeanLocalDAO.NULL_VALUE);
+    assertEquals(aspect.getMetadata(), EbeanLocalDAO.DELETED_VALUE);
 
     aspect = getMetadata(urn, aspectName, 1);
     AspectFoo actual = RecordUtils.toRecordTemplate(AspectFoo.class, aspect.getMetadata());
@@ -2466,7 +2466,7 @@ public class EbeanLocalDAOTest {
     if (metadata != null) {
       aspect.setMetadata(RecordUtils.toJsonString(metadata));
     } else {
-      aspect.setMetadata(EbeanLocalDAO.NULL_VALUE);
+      aspect.setMetadata(EbeanLocalDAO.DELETED_VALUE);
     }
     aspect.setCreatedOn(new Timestamp(1234));
     aspect.setCreatedBy("urn:li:test:foo");


### PR DESCRIPTION
In the PR https://github.com/linkedin/datahub-gma/pull/130, we made the `metadata` column nullable to support soft deletion of aspects. Since changing/altering a column in MySQL to make it nullable entails a good amount of downtime (for large sized tables), we will rather use a placeholder string `DELETED` in this case to denote a soft deleted aspect. All APIs/interfaces in DAO will stay the same, only while saving in DB via EbeanLocalDAO we will store `DELETED` string when inserting a `null` metadata. Similarly while retrieving `DELETED` string from DB, we will interpret it as `null` metadata.
 
## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
