### PR TITLE
fix: support old constructor of AspectEntry class

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -45,7 +45,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Value;
 
 
@@ -66,8 +68,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
    */
-  @Value
+  @Data
   @Builder
+  @AllArgsConstructor
   static class AspectEntry<ASPECT extends RecordTemplate> {
     @Nullable
     ASPECT aspect;
@@ -77,6 +80,12 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     @Builder.Default
     boolean isSoftDeleted = false;
+
+    public AspectEntry(@Nullable ASPECT aspect, @Nullable ExtraInfo extraInfo) {
+      this.aspect = aspect;
+      this.extraInfo = extraInfo;
+      this.isSoftDeleted = false;
+    }
   }
 
   @Value

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -180,7 +180,7 @@ public class BaseLocalDAOTest {
     if (auditStamp != null) {
       extraInfo = new ExtraInfo().setAudit(auditStamp);
     }
-    return new BaseLocalDAO.AspectEntry<>(aspect, extraInfo, false);
+    return new BaseLocalDAO.AspectEntry<>(aspect, extraInfo);
   }
 
   private <T extends RecordTemplate> void expectGetLatest(FooUrn urn, Class<T> aspectClass,

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -335,7 +335,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     final PrimaryKey key = new PrimaryKey(urn.toString(), ModelUtils.getAspectName(aspectClass), 0L);
     final EbeanMetadataAspect latest = _server.find(EbeanMetadataAspect.class, key);
     if (latest == null) {
-      return new AspectEntry<>(null, null, false);
+      return new AspectEntry<>(null, null);
     }
     final ExtraInfo extraInfo = toExtraInfo(latest);
 
@@ -343,7 +343,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       return new AspectEntry<>(null, extraInfo, true);
     }
 
-    return new AspectEntry<>(RecordUtils.toRecordTemplate(aspectClass, latest.getMetadata()), extraInfo, false);
+    return new AspectEntry<>(RecordUtils.toRecordTemplate(aspectClass, latest.getMetadata()), extraInfo);
   }
 
   @Nonnull


### PR DESCRIPTION
## Checklist
We added a new field to `AspectEntry` in https://github.com/linkedin/datahub-gma/pull/139. Even though it has a default value, we need to ensure that the _old_ way of instantiating `AspectEntry` using `new` and without `isSoftDeleted` parameter, still works.

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
