### PR TITLE
support for alias in unions for get method

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -330,6 +330,17 @@ public class RecordUtils {
 
     final Method obtainWrapped =
         getProtectedMethod(UnionTemplate.class, "obtainWrapped", DataSchema.class, Class.class, String.class);
+    final List<UnionDataSchema.Member> members = ((UnionDataSchema) unionTemplate.schema()).getMembers();
+    for (UnionDataSchema.Member m : members) {
+      if (m.hasAlias() && m.getType()
+          .getDereferencedDataSchema()
+          .getUnionMemberKey()
+          .equals(clazz.getName())) {
+        return (V) invokeProtectedMethod(unionTemplate, obtainWrapped, dataSchema, clazz,
+            m.getAlias());
+      }
+    }
+
     return (V) invokeProtectedMethod(unionTemplate, obtainWrapped, dataSchema, clazz,
         ((RecordDataSchema) dataSchema).getFullName());
   }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -3,7 +3,9 @@ package com.linkedin.metadata.dao.utils;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.CommonTestAspect;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.testing.DeltaUnionAlias;
 import com.linkedin.testing.EntityAspectUnionAliasArray;
+import com.linkedin.testing.EntityDeltaAlias;
 import com.linkedin.testing.EntityFoo;
 import com.linkedin.testing.EntitySnapshotAlias;
 import com.linkedin.testing.EntityUnion;
@@ -140,9 +142,9 @@ public class ModelUtilsTest {
   @Test
   public void testGetUrnFromDeltaUnionAlias() {
     Urn expected = makeUrn(1);
-    EntityDelta delta = new EntityDelta().setUrn(expected);
-    DeltaUnion deltaUnion = new DeltaUnion();
-    deltaUnion.setEntityDelta(delta);
+    EntityDeltaAlias delta = new EntityDeltaAlias().setUrn(expected);
+    DeltaUnionAlias deltaUnion = new DeltaUnionAlias();
+    deltaUnion.setEntity(delta);
 
     Urn urn = ModelUtils.getUrnFromDeltaUnion(deltaUnion);
     assertEquals(urn, expected);

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -3,9 +3,12 @@ package com.linkedin.metadata.dao.utils;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.CommonTestAspect;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.testing.EntityAspectUnionAliasArray;
 import com.linkedin.testing.EntityFoo;
+import com.linkedin.testing.EntitySnapshotAlias;
 import com.linkedin.testing.EntityUnion;
 import com.linkedin.testing.EntityUnionAlias;
+import com.linkedin.testing.SnapshotUnionAlias;
 import com.linkedin.testing.urn.PizzaUrn;
 import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.data.template.RecordTemplate;
@@ -104,6 +107,17 @@ public class ModelUtilsTest {
   }
 
   @Test
+  public void testGetUrnFromSnapshotUnionAlias() {
+    Urn expected = makeUrn(1);
+    EntitySnapshotAlias snapshot = new EntitySnapshotAlias().setUrn(expected);
+    SnapshotUnionAlias snapshotUnion = new SnapshotUnionAlias();
+    snapshotUnion.setEntity(snapshot);
+
+    Urn urn = ModelUtils.getUrnFromSnapshotUnion(snapshotUnion);
+    assertEquals(urn, expected);
+  }
+
+  @Test
   public void testGetUrnFromDelta() {
     Urn expected = makeUrn(1);
     EntityDelta delta = new EntityDelta().setUrn(expected);
@@ -114,6 +128,17 @@ public class ModelUtilsTest {
 
   @Test
   public void testGetUrnFromDeltaUnion() {
+    Urn expected = makeUrn(1);
+    EntityDelta delta = new EntityDelta().setUrn(expected);
+    DeltaUnion deltaUnion = new DeltaUnion();
+    deltaUnion.setEntityDelta(delta);
+
+    Urn urn = ModelUtils.getUrnFromDeltaUnion(deltaUnion);
+    assertEquals(urn, expected);
+  }
+
+  @Test
+  public void testGetUrnFromDeltaUnionAlias() {
     Urn expected = makeUrn(1);
     EntityDelta delta = new EntityDelta().setUrn(expected);
     DeltaUnion deltaUnion = new DeltaUnion();
@@ -168,6 +193,26 @@ public class ModelUtilsTest {
   }
 
   @Test
+  public void testGetAspectsFromSnapshotAlias() throws IOException {
+    EntitySnapshotAlias snapshot = new EntitySnapshotAlias();
+    snapshot.setAspects(new EntityAspectUnionAliasArray());
+    AspectFoo foo = new AspectFoo();
+    EntityAspectUnionAlias aspect1 = new EntityAspectUnionAlias();
+    aspect1.setFoo(foo);
+    snapshot.getAspects().add(aspect1);
+    AspectBar bar = new AspectBar();
+    EntityAspectUnionAlias aspect2 = new EntityAspectUnionAlias();
+    aspect2.setBar(bar);
+    snapshot.getAspects().add(aspect2);
+
+    List<? extends RecordTemplate> aspects = ModelUtils.getAspectsFromSnapshot(snapshot);
+
+    assertEquals(aspects.size(), 2);
+    assertEquals(aspects.get(0), foo);
+    assertEquals(aspects.get(1), bar);
+  }
+
+  @Test
   public void testGetAspectFromSnapshot() throws IOException {
     EntitySnapshot snapshot = new EntitySnapshot();
     snapshot.setAspects(new EntityAspectUnionArray());
@@ -192,6 +237,22 @@ public class ModelUtilsTest {
     snapshot.getAspects().get(0).setAspectFoo(foo);
     SnapshotUnion snapshotUnion = new SnapshotUnion();
     snapshotUnion.setEntitySnapshot(snapshot);
+
+    List<? extends RecordTemplate> aspects = ModelUtils.getAspectsFromSnapshotUnion(snapshotUnion);
+
+    assertEquals(aspects.size(), 1);
+    assertEquals(aspects.get(0), foo);
+  }
+
+  @Test
+  public void testGetAspectsFromSnapshotUnionAlias() throws IOException {
+    EntitySnapshotAlias snapshot = new EntitySnapshotAlias();
+    snapshot.setAspects(new EntityAspectUnionAliasArray());
+    snapshot.getAspects().add(new EntityAspectUnionAlias());
+    AspectFoo foo = new AspectFoo();
+    snapshot.getAspects().get(0).setFoo(foo);
+    SnapshotUnionAlias snapshotUnion = new SnapshotUnionAlias();
+    snapshotUnion.setEntity(snapshot);
 
     List<? extends RecordTemplate> aspects = ModelUtils.getAspectsFromSnapshotUnion(snapshotUnion);
 

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/DeltaUnionAlias.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/DeltaUnionAlias.pdl
@@ -4,5 +4,5 @@ namespace com.linkedin.testing
  * For unit tests
  */
 typeref DeltaUnionAlias = union[
-  entity: EntityDelta
+  entity: EntityDeltaAlias
 ]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/DeltaUnionAlias.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/DeltaUnionAlias.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+typeref DeltaUnionAlias = union[
+  entity: EntityDelta
+]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDeltaAlias.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDeltaAlias.pdl
@@ -1,0 +1,21 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+record EntityDeltaAlias {
+
+  /**
+   * For unit tests
+   */
+  urn: Urn
+
+  /**
+   * For unit tests
+   */
+  delta: union[
+    foo: AspectFoo
+  ]
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotAlias.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotAlias.pdl
@@ -1,0 +1,19 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+record EntitySnapshotAlias {
+
+  /**
+   * For unit tests
+   */
+  urn: Urn
+
+  /**
+   * For unit tests
+   */
+  aspects: array[EntityAspectUnionAlias]
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/SnapshotUnionAlias.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/SnapshotUnionAlias.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit testing
+ */
+typeref SnapshotUnionAlias = union[
+  entity: EntitySnapshotAlias
+]


### PR DESCRIPTION
## Checklist
Similar to this https://github.com/linkedin/datahub-gma/pull/142, this PR adds support for the get method when union templates have aliases for the different records.

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
