### PR TITLE
fix: properly validate that aspects can only be of type record

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/dummy/DummyRecord.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/dummy/DummyRecord.pdl
@@ -3,4 +3,7 @@ namespace com.linkedin.metadata.dummy
 /**
  * Not to be used
  */
-typeref DummyAspect = union[DummyRecord]
+record DummyRecord {
+
+  value: string
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaArrayAspect.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaArrayAspect.pdl
@@ -1,0 +1,5 @@
+namespace com.linkedin.testing
+
+typeref PizzaArrayAspect = union[
+  array[long]
+]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaEnumAspect.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaEnumAspect.pdl
@@ -1,0 +1,5 @@
+namespace com.linkedin.testing
+
+typeref PizzaEnumAspect = union[
+  PizzaSize
+]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaMapAspect.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaMapAspect.pdl
@@ -1,0 +1,5 @@
+namespace com.linkedin.testing
+
+typeref PizzaMapAspect = union[
+  map[string, boolean]
+]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaStringAspect.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/PizzaStringAspect.pdl
@@ -1,0 +1,5 @@
+namespace com.linkedin.testing
+
+typeref PizzaStringAspect = union[
+  string
+]

--- a/validators/build.gradle
+++ b/validators/build.gradle
@@ -12,4 +12,5 @@ dependencies {
   annotationProcessor externalDependency.lombok
 
   testCompile externalDependency.guava
+  testCompile project(':testing:test-models')
 }

--- a/validators/src/main/java/com/linkedin/metadata/validator/AspectValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/AspectValidator.java
@@ -28,7 +28,7 @@ public final class AspectValidator {
    */
   public static void validateAspectUnionSchema(@Nonnull UnionDataSchema schema, @Nonnull String aspectClassName) {
 
-    if (!ValidationUtils.isUnionWithOnlyComplexMembers(schema)) {
+    if (!ValidationUtils.isUnionWithOnlyRecordMembers(schema)) {
       ValidationUtils.invalidSchema("Aspect '%s' must be a union containing only record type members", aspectClassName);
     }
   }
@@ -47,7 +47,7 @@ public final class AspectValidator {
 
   private static boolean isValidMetadataField(RecordDataSchema.Field field) {
     return field.getName().equals("metadata") && !field.getOptional()
-        && field.getType().getType() == DataSchema.Type.UNION && ValidationUtils.isUnionWithOnlyComplexMembers(
+        && field.getType().getType() == DataSchema.Type.UNION && ValidationUtils.isUnionWithOnlyRecordMembers(
         (UnionDataSchema) field.getType());
   }
 }

--- a/validators/src/main/java/com/linkedin/metadata/validator/EntityValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/EntityValidator.java
@@ -89,7 +89,7 @@ public final class EntityValidator {
    */
   public static void validateEntityUnionSchema(@Nonnull UnionDataSchema schema, @Nonnull String entityClassName) {
 
-    if (!ValidationUtils.isUnionWithOnlyComplexMembers(schema)) {
+    if (!ValidationUtils.isUnionWithOnlyRecordMembers(schema)) {
       ValidationUtils.invalidSchema("Entity '%s' must be a union containing only record type members", entityClassName);
     }
   }

--- a/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
@@ -94,7 +94,7 @@ public class RelationshipValidator {
    */
   public static void validateRelationshipUnionSchema(@Nonnull UnionDataSchema schema, @Nonnull String relationshipClassName) {
 
-    if (!ValidationUtils.isUnionWithOnlyComplexMembers(schema)) {
+    if (!ValidationUtils.isUnionWithOnlyRecordMembers(schema)) {
       ValidationUtils.invalidSchema("Relationship '%s' must be a union containing only record type members", relationshipClassName);
     }
   }

--- a/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -157,7 +157,7 @@ public final class ValidationUtils {
         .collect(Collectors.toList());
   }
 
-  public static boolean isUnionWithOnlyComplexMembers(UnionDataSchema unionDataSchema) {
+  public static boolean isUnionWithOnlyRecordMembers(UnionDataSchema unionDataSchema) {
     return unionDataSchema.getMembers().stream().allMatch(member -> member.getType().getDereferencedDataSchema().getType().equals(
         DataSchema.Type.RECORD));
   }

--- a/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -158,7 +158,8 @@ public final class ValidationUtils {
   }
 
   public static boolean isUnionWithOnlyComplexMembers(UnionDataSchema unionDataSchema) {
-    return unionDataSchema.getMembers().stream().allMatch(member -> member.getType().isComplex());
+    return unionDataSchema.getMembers().stream().allMatch(member -> member.getType().getDereferencedDataSchema().getType().equals(
+        DataSchema.Type.RECORD));
   }
 
   @Nonnull

--- a/validators/src/test/java/com/linkedin/metadata/validator/ValidationUtilsTest.java
+++ b/validators/src/test/java/com/linkedin/metadata/validator/ValidationUtilsTest.java
@@ -35,10 +35,4 @@ public class ValidationUtilsTest {
     UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaStringAspect.class);
     assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
   }
-
-  @Test
-  public void testNestedUnion() {
-    UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaUnionAspect.class);
-    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
-  }
 }

--- a/validators/src/test/java/com/linkedin/metadata/validator/ValidationUtilsTest.java
+++ b/validators/src/test/java/com/linkedin/metadata/validator/ValidationUtilsTest.java
@@ -1,0 +1,44 @@
+package com.linkedin.metadata.validator;
+
+import com.linkedin.data.schema.UnionDataSchema;
+import com.linkedin.testing.PizzaArrayAspect;
+import com.linkedin.testing.PizzaEnumAspect;
+import com.linkedin.testing.PizzaMapAspect;
+import com.linkedin.testing.PizzaStringAspect;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class ValidationUtilsTest {
+
+  @Test
+  public void testUnionWithEnums() {
+    UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaEnumAspect.class);
+    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+  }
+
+  @Test
+  public void testUnionWithMaps() {
+    UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaMapAspect.class);
+    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+  }
+
+  @Test
+  public void testUnionWithArrays() {
+    UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaArrayAspect.class);
+    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+  }
+
+  @Test
+  public void testUnionWithPrimitive() {
+    UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaStringAspect.class);
+    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+  }
+
+  @Test
+  public void testNestedUnion() {
+    UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaUnionAspect.class);
+    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+  }
+}

--- a/validators/src/test/java/com/linkedin/metadata/validator/ValidationUtilsTest.java
+++ b/validators/src/test/java/com/linkedin/metadata/validator/ValidationUtilsTest.java
@@ -15,24 +15,24 @@ public class ValidationUtilsTest {
   @Test
   public void testUnionWithEnums() {
     UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaEnumAspect.class);
-    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+    assertFalse(ValidationUtils.isUnionWithOnlyRecordMembers(dataSchema));
   }
 
   @Test
   public void testUnionWithMaps() {
     UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaMapAspect.class);
-    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+    assertFalse(ValidationUtils.isUnionWithOnlyRecordMembers(dataSchema));
   }
 
   @Test
   public void testUnionWithArrays() {
     UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaArrayAspect.class);
-    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+    assertFalse(ValidationUtils.isUnionWithOnlyRecordMembers(dataSchema));
   }
 
   @Test
   public void testUnionWithPrimitive() {
     UnionDataSchema dataSchema = ValidationUtils.getUnionSchema(PizzaStringAspect.class);
-    assertFalse(ValidationUtils.isUnionWithOnlyComplexMembers(dataSchema));
+    assertFalse(ValidationUtils.isUnionWithOnlyRecordMembers(dataSchema));
   }
 }


### PR DESCRIPTION
This change will ensure that aspects, relationships and entities can only be of type record. We assume this in our DAO, but currently don't validate the same.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
