### PR TITLE
feat(scsi): add support for union types in getFieldValue

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -418,11 +418,11 @@ public class RecordUtils {
     final Pattern patternLastPeriod = Pattern.compile("^(.*)\\.");
     final HashMap<String, Method> methodMap = new HashMap<>();
     for (UnionDataSchema.Member member : ((UnionDataSchema) unionTemplate.schema()).getMembers()) {
-      String unionMemberKey = member.getUnionMemberKey();
+      final String unionMemberKey = member.getUnionMemberKey();
       // com.linkedin.foo => Foo
-      String lastPartOfUnionMemberKey = patternLastPeriod.matcher(unionMemberKey).replaceAll("");
-      String capitalizedName = capitalizeFirst(lastPartOfUnionMemberKey);
-      String getMethodName = "get" + capitalizedName;
+      final String lastPartOfUnionMemberKey = patternLastPeriod.matcher(unionMemberKey).replaceAll("");
+      final String capitalizedName = capitalizeFirst(lastPartOfUnionMemberKey);
+      final String getMethodName = "get" + capitalizedName;
       try {
         methodMap.put(unionMemberKey, unionTemplate.getClass().getMethod(getMethodName));
       } catch (NoSuchMethodException e) {

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectBaz.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectBaz.pdl
@@ -48,6 +48,11 @@ record AspectBaz {
   /**
    * For unit tests
    */
+  arrayRecordsField: array[AspectBar]
+
+  /**
+   * For unit tests
+   */
   recordField: AspectFoo
 
   /**

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAspectUnionComplex.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAspectUnionComplex.pdl
@@ -1,0 +1,6 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+typeref EntityAspectUnionComplex = union[AspectFoo, AspectBar, AspectBaz]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
@@ -74,4 +74,9 @@ record MixedRecord {
    * For unit tests
    */
   recordUnion: optional EntityAspectUnion
+
+  /**
+   * For unit tests
+   */
+  recordUnionComplex: optional EntityAspectUnionComplex
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
@@ -64,4 +64,14 @@ record MixedRecord {
    * For unit tests
    */
   recordTypeRef: optional typeref AspectFooTypeRef = AspectFoo
+
+  /**
+   * For unit tests
+   */
+  primitiveUnion: optional StringUnion
+
+  /**
+   * For unit tests
+   */
+  recordUnion: optional EntityAspectUnion
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
@@ -79,4 +79,9 @@ record MixedRecord {
    * For unit tests
    */
   recordUnionComplex: optional EntityAspectUnionComplex
+
+  /**
+   * For unit tests
+   */
+  recordUnionAlias: optional EntityAspectUnionAlias
 }


### PR DESCRIPTION
add support for unions of primitive and non-primitive types already supported by scsi (e.g. typerefs, arrays)

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
