### PR TITLE
(feat) Update multiple aspects in one transaction

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
@@ -25,6 +25,10 @@ public abstract class BaseMetadataEventProducer<SNAPSHOT extends RecordTemplate,
     _aspectUnionClass = aspectUnionClass;
   }
 
+  public Class<ASPECT_UNION> getAspectUnionClass() {
+    return _aspectUnionClass;
+  }
+
   /**
    * Produces a Metadata Change Event (MCE) with a snapshot-base metadata change proposal.
    *


### PR DESCRIPTION
This PR adds an option to enable multiple aspects to be updated within a single transaction in the `BaseLocalDao`. This allows for atomic creation/updates of entities.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
