### PR TITLE
feat(util): Added util functions in SchemaGeneratorUtil to get the na…

### DIFF
--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorUtil.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorUtil.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.generator;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import com.linkedin.data.schema.RecordDataSchema;
 import java.io.File;
 import java.io.IOException;
 import javax.annotation.Nonnull;
@@ -80,5 +81,30 @@ public class SchemaGeneratorUtil {
       throw new IOException(String.format("%s cannot be created.", directory));
     }
     return directory;
+  }
+
+  /**
+   * Strip the namespace to the valueType.
+   *
+   * @param fqcn the namespace of the entity.
+   * @return the valueType of the namespace.
+   */
+  @Nonnull
+  static String getNamespace(@Nonnull String fqcn) {
+    final int index = fqcn.lastIndexOf('.');
+    if (index != -1) {
+      // index == -1 (dot not found) || 0 <= index < length -1 (namespace is not ended with dot)
+      return fqcn.substring(0, index);
+    }
+    throw new IllegalArgumentException();
+  }
+
+  /**
+   * Given a schema return if it's a GMA snapshot schema.
+   * @param schema A schema
+   * @return if the input schema is a GMA snapshot schema
+   */
+  static boolean isSnapshotSchema(RecordDataSchema schema) {
+    return schema.getName().endsWith("Snapshot");
   }
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestSchemaGeneratorUtil.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestSchemaGeneratorUtil.java
@@ -1,9 +1,12 @@
 package com.linkedin.metadata.generator;
 
+import com.linkedin.data.schema.Name;
+import com.linkedin.data.schema.RecordDataSchema;
 import org.junit.jupiter.api.Test;
 
 import static com.linkedin.metadata.generator.SchemaGeneratorUtil.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class TestSchemaGeneratorUtil {
@@ -28,5 +31,19 @@ public class TestSchemaGeneratorUtil {
   @Test
   public void testStripIllegalNamespace() {
     assertThatThrownBy(() -> stripNamespace(TEST_NAME + ".")).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldGetNamespace() {
+    assertEquals(SchemaGeneratorUtil.getNamespace("com.a.b.A"), "com.a.b");
+  }
+
+  @Test
+  public void testIsSnapshotSchema() {
+    assertTrue(SchemaGeneratorUtil.isSnapshotSchema(new RecordDataSchema(new Name("XYZSnapshot"),
+        RecordDataSchema.RecordType.RECORD)));
+
+    assertFalse(SchemaGeneratorUtil.isSnapshotSchema(new RecordDataSchema(new Name("XYZ"),
+        RecordDataSchema.RecordType.RECORD)));
   }
 }


### PR DESCRIPTION
…mspace of a FQCN and determine if a GMA schema is a snaphot schema

Added the following two methods to SchemaGeneratorUtil:
(1) getNamespace, which returns the namespace of a given FQCN of a schema
(2) isSnapshotSchema, which returns if a given schema is a GMA snapshot schema

## Checklist

- [ x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
