### PR TITLE
fix: do not include hits in groups aggregation

### DIFF
--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
@@ -120,7 +120,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
     final SearchRequest searchRequest = new SearchRequest(_config.getIndexName());
     final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     searchSourceBuilder.trackTotalHitsUpTo(_lowerBoundHits);
-
+    searchSourceBuilder.size(0);
     searchSourceBuilder.query(buildQueryString(path, requestMap, true));
     searchSourceBuilder.aggregation(buildAggregations(path));
     searchRequest.source(searchSourceBuilder);


### PR DESCRIPTION
Hitted documents in groups aggregation are not used in any way but they compose the majority of payload from ES. Set size to 0 will only include total hits count without actual hitted documents. Verified with a snapshot version locally.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
