### PR TITLE
fix: use json to store deleted aspect metadata

### DIFF
--- a/dao-api/build.gradle
+++ b/dao-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   compile externalDependency.commonsLang
 
   dataModel project(':core-models')
+  dataModel project(':validators')
 
   compileOnly externalDependency.lombok
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao.utils;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.CommonTestAspect;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.testing.AspectUnionWithSoftDeletedAspect;
 import com.linkedin.testing.DeltaUnionAlias;
 import com.linkedin.testing.EntityAspectUnionAliasArray;
 import com.linkedin.testing.EntityDeltaAlias;
@@ -77,6 +78,12 @@ public class ModelUtilsTest {
     Set<Class<? extends RecordTemplate>> validTypes = ModelUtils.getValidAspectTypes(EntityAspectUnion.class);
 
     assertEquals(validTypes, ImmutableSet.of(AspectFoo.class, AspectBar.class));
+  }
+
+  @Test
+  public void testSoftDeletedAspect() {
+    assertThrows(InvalidSchemaException.class,
+        () -> ModelUtils.getValidAspectTypes(AspectUnionWithSoftDeletedAspect.class));
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -7,6 +7,7 @@ import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.aspect.SoftDeletedAspect;
 import com.linkedin.metadata.dao.exception.ModelConversionException;
 import com.linkedin.metadata.dao.exception.RetryLimitReached;
 import com.linkedin.metadata.dao.producer.BaseMetadataEventProducer;
@@ -61,7 +62,6 @@ import javax.persistence.OptimisticLockException;
 import javax.persistence.RollbackException;
 import javax.persistence.Table;
 import lombok.Value;
-import org.json.simple.JSONObject;
 
 import static com.linkedin.metadata.dao.EbeanMetadataAspect.*;
 
@@ -72,11 +72,9 @@ import static com.linkedin.metadata.dao.EbeanMetadataAspect.*;
 public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     extends BaseLocalDAO<ASPECT_UNION, URN> {
 
-  // String literal stored in metadata_aspect table for soft deleted aspect
-  private static final Map<String, Boolean> DELETED_METADATA = new HashMap<String, Boolean>() {{
-    put("GMA_DELETED", true);
-  }};
-  public static final String DELETED_VALUE = new JSONObject(DELETED_METADATA).toString();
+  // String stored in metadata_aspect table for soft deleted aspect
+  private static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
+  public static final String DELETED_VALUE = RecordUtils.toJsonString(DELETED_METADATA);
 
   private static final int INDEX_QUERY_TIMEOUT_IN_SEC = 5;
   private static final String EBEAN_MODEL_PACKAGE = EbeanMetadataAspect.class.getPackage().getName();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -61,6 +61,7 @@ import javax.persistence.OptimisticLockException;
 import javax.persistence.RollbackException;
 import javax.persistence.Table;
 import lombok.Value;
+import org.json.simple.JSONObject;
 
 import static com.linkedin.metadata.dao.EbeanMetadataAspect.*;
 
@@ -72,7 +73,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     extends BaseLocalDAO<ASPECT_UNION, URN> {
 
   // String literal stored in metadata_aspect table for soft deleted aspect
-  public static final String DELETED_VALUE = "DELETED";
+  private static final Map<String, Boolean> DELETED_METADATA = new HashMap<String, Boolean>() {{
+    put("GMA_DELETED", true);
+  }};
+  public static final String DELETED_VALUE = new JSONObject(DELETED_METADATA).toString();
 
   private static final int INDEX_QUERY_TIMEOUT_IN_SEC = 5;
   private static final String EBEAN_MODEL_PACKAGE = EbeanMetadataAspect.class.getPackage().getName();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -2219,6 +2219,7 @@ public class EbeanLocalDAOTest {
     // latest version of metadata should be null
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, 0);
     assertEquals(aspect.getMetadata(), EbeanLocalDAO.DELETED_VALUE);
+    assertEquals(EbeanLocalDAO.DELETED_VALUE, "{\"GMA_DELETED\":true}");
     Optional<AspectFoo> fooOptional = dao.get(AspectFoo.class, urn);
     assertFalse(fooOptional.isPresent());
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -2219,7 +2219,7 @@ public class EbeanLocalDAOTest {
     // latest version of metadata should be null
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, 0);
     assertEquals(aspect.getMetadata(), EbeanLocalDAO.DELETED_VALUE);
-    assertEquals(EbeanLocalDAO.DELETED_VALUE, "{\"GMA_DELETED\":true}");
+    assertEquals(EbeanLocalDAO.DELETED_VALUE, "{\"gma_deleted\":true}");
     Optional<AspectFoo> fooOptional = dao.get(AspectFoo.class, urn);
     assertFalse(fooOptional.isPresent());
 

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectUnionWithSoftDeletedAspect.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectUnionWithSoftDeletedAspect.pdl
@@ -1,0 +1,6 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+typeref AspectUnionWithSoftDeletedAspect = union[AspectFoo, AspectBar, SoftDeletedAspectCopy]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
@@ -1,0 +1,12 @@
+namespace com.linkedin.testing
+
+/**
+ * A tuple of a specific metadata aspect and its version.
+ */
+record SoftDeletedAspectCopy {
+
+  /**
+   * flag to indicate if the aspect is soft deleted in GMA
+   */
+  gma_deleted: boolean
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
@@ -1,7 +1,7 @@
 namespace com.linkedin.testing
 
 /**
- * A tuple of a specific metadata aspect and its version.
+ * Captures metadata on soft deleted aspect. This is a copy of SoftDeletedAspect.
  */
 record SoftDeletedAspectCopy {
 

--- a/validators/build.gradle
+++ b/validators/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'pegasus'
 
 apply from: "$rootDir/gradle/java-publishing.gradle"
 

--- a/validators/src/main/java/com/linkedin/metadata/validator/AspectValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/AspectValidator.java
@@ -31,6 +31,10 @@ public final class AspectValidator {
     if (!ValidationUtils.isUnionWithOnlyComplexMembers(schema)) {
       ValidationUtils.invalidSchema("Aspect '%s' must be a union containing only record type members", aspectClassName);
     }
+
+    if (ValidationUtils.isUnionWithSoftDeletedAspect(schema)) {
+      ValidationUtils.invalidSchema("Aspect '%s' cannot be a union of a soft deleted aspect", aspectClassName);
+    }
   }
 
   /**

--- a/validators/src/main/pegasus/com/linkedin/metadata/aspect/SoftDeletedAspect.pdl
+++ b/validators/src/main/pegasus/com/linkedin/metadata/aspect/SoftDeletedAspect.pdl
@@ -1,0 +1,12 @@
+namespace com.linkedin.metadata.aspect
+
+/**
+ * Captures metadata on soft deleted aspect.
+ */
+record SoftDeletedAspect {
+
+  /**
+   * Flag to indicate if the aspect is soft deleted in GMA
+   */
+  gma_deleted: boolean
+}


### PR DESCRIPTION
## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

Instead of storing a simple text/reserved keyword to represent soft deleted aspect, let us use json to represent the same.