### PR TITLE
fix: expose generated data template

### DIFF
--- a/validators/build.gradle
+++ b/validators/build.gradle
@@ -14,3 +14,12 @@ dependencies {
 
   testCompile externalDependency.guava
 }
+
+idea {
+  module {
+    sourceDirs += file('src/main/javaPegasus')
+  }
+}
+
+// Need to compile backing java definitions with the data template.
+sourceSets.mainGeneratedDataTemplate.java.srcDirs('src/main/javaPegasus/')


### PR DESCRIPTION
In PR https://github.com/linkedin/datahub-gma/pull/158 we added a PDL file corresponding to soft deleted aspect in `validators` module. This change ensures we are generating data template for pegasus while building.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
