### PR TITLE
fix: generate data template in validators

### DIFF
--- a/validators/build.gradle
+++ b/validators/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'pegasus'
 
+// Don't publish the "normal" jar since it'd be empty anyway
+project.ext.publications = ['dataTemplate']
+
 apply from: "$rootDir/gradle/java-publishing.gradle"
 
 dependencies {


### PR DESCRIPTION
An extension to https://github.com/linkedin/datahub-gma/pull/160 this change ensures that data template files are generated and exposed

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
