### PR TITLE
Revert "fix: generate data template in validators"

### DIFF
--- a/validators/build.gradle
+++ b/validators/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'pegasus'
 
-// Don't publish the "normal" jar since it'd be empty anyway
-project.ext.publications = ['dataTemplate']
-
 apply from: "$rootDir/gradle/java-publishing.gradle"
 
 dependencies {


### PR DESCRIPTION
Reverts linkedin/datahub-gma#162. We need to publish the normal jar as well. 