### PR TITLE
fix: use RecordTemplate instead of String for comparing aspect with deleted aspect metadata

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -73,7 +73,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     extends BaseLocalDAO<ASPECT_UNION, URN> {
 
   // String stored in metadata_aspect table for soft deleted aspect
-  private static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
+  protected static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
   public static final String DELETED_VALUE = RecordUtils.toJsonString(DELETED_METADATA);
 
   private static final int INDEX_QUERY_TIMEOUT_IN_SEC = 5;
@@ -341,7 +341,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
     final ExtraInfo extraInfo = toExtraInfo(latest);
 
-    if (latest.getMetadata().equals(DELETED_VALUE)) {
+    // Convert metadata string to record template object
+    final RecordTemplate metadataRecord = RecordUtils.toRecordTemplate(aspectClass, latest.getMetadata());
+    if (metadataRecord.equals(DELETED_METADATA)) {
       return new AspectEntry<>(null, extraInfo, true);
     }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -2218,8 +2218,9 @@ public class EbeanLocalDAOTest {
 
     // latest version of metadata should be null
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, 0);
-    assertEquals(aspect.getMetadata(), EbeanLocalDAO.DELETED_VALUE);
-    assertEquals(EbeanLocalDAO.DELETED_VALUE, "{\"gma_deleted\":true}");
+    // Convert metadata string to record template object
+    final RecordTemplate metadataRecord = RecordUtils.toRecordTemplate(AspectFoo.class, aspect.getMetadata());
+    assertEquals(metadataRecord, EbeanLocalDAO.DELETED_METADATA);
     Optional<AspectFoo> fooOptional = dao.get(AspectFoo.class, urn);
     assertFalse(fooOptional.isPresent());
 


### PR DESCRIPTION
fix: use RecordTemplate instead of String for comparing aspect with deleted aspect metadata

* cast the string value of the aspect into RecordTemplate object

* use the record template object for comparison to avoid formatting issues associated with string representation of json

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
