### PR TITLE
fix: update all soft deletion comparisons using json string to use object comparison

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -3,6 +3,8 @@ package com.linkedin.metadata.dao.utils;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.dao.EbeanMetadataAspect;
 import com.linkedin.metadata.dao.ListResult;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.aspect.SoftDeletedAspect;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -22,6 +24,9 @@ public class EBeanDAOUtils {
 
   public static final String DIFFERENT_RESULTS_TEMPLATE = "The results of %s from the new schema table and old schema table are not equal."
       + "Defaulting to using the value(s) from the old schema table.";
+  // String stored in metadata_aspect table for soft deleted aspect
+  private static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
+  public static final String DELETED_VALUE = RecordUtils.toJsonString(DELETED_METADATA);
 
   private EBeanDAOUtils() {
 
@@ -103,5 +108,19 @@ public class EBeanDAOUtils {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Checks whether the aspect record has been soft deleted.
+   *
+   * @param aspect aspect value
+   * @param aspectClass the type of the aspect
+   * @return boolean representing whether the aspect record has been soft deleted
+   */
+  public static <ASPECT extends RecordTemplate> boolean isSoftDeletedAspect(@Nonnull EbeanMetadataAspect aspect,
+      @Nonnull Class<ASPECT> aspectClass) {
+    // Convert metadata string to record template object
+    final RecordTemplate metadataRecord = RecordUtils.toRecordTemplate(aspectClass, aspect.getMetadata());
+    return metadataRecord.equals(DELETED_METADATA);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -76,6 +76,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import static com.linkedin.common.AuditStamps.*;
+import static com.linkedin.metadata.dao.utils.EBeanDAOUtils.*;
 import static com.linkedin.testing.TestUtils.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
@@ -2274,9 +2275,7 @@ public class EbeanLocalDAOTest {
 
     // latest version of metadata should be null
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, 0);
-    // Convert metadata string to record template object
-    final RecordTemplate metadataRecord = RecordUtils.toRecordTemplate(AspectFoo.class, aspect.getMetadata());
-    assertEquals(metadataRecord, EbeanLocalDAO.DELETED_METADATA);
+    assertTrue(isSoftDeletedAspect(aspect, AspectFoo.class));
     Optional<AspectFoo> fooOptional = dao.get(AspectFoo.class, urn);
     assertFalse(fooOptional.isPresent());
 
@@ -2447,7 +2446,7 @@ public class EbeanLocalDAOTest {
 
     // version=3 should correspond to soft deleted metadata
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, 3);
-    assertEquals(aspect.getMetadata(), EbeanLocalDAO.DELETED_VALUE);
+    assertTrue(isSoftDeletedAspect(aspect, AspectFoo.class));
     fooOptional = dao.get(AspectFoo.class, urn, 3);
     assertFalse(fooOptional.isPresent());
 
@@ -2784,7 +2783,7 @@ public class EbeanLocalDAOTest {
     if (metadata != null) {
       aspect.setMetadata(RecordUtils.toJsonString(metadata));
     } else {
-      aspect.setMetadata(EbeanLocalDAO.DELETED_VALUE);
+      aspect.setMetadata(DELETED_VALUE);
     }
     aspect.setCreatedOn(new Timestamp(1234));
     aspect.setCreatedBy("urn:li:test:foo");


### PR DESCRIPTION
fix: update all soft deletion comparisons using json string to use object comparison

* add new method for identifying soft deleted aspect

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
