### PR TITLE
feat: reconfig ebean dao unit tests

### DIFF
--- a/dao-impl/ebean-dao/build.gradle
+++ b/dao-impl/ebean-dao/build.gradle
@@ -26,9 +26,20 @@ dependencies {
 
   enhance externalDependency.ebeanAgent
 }
+
+// Some unit tests require advanced MySQL syntax such as 'generated column' which is not supported by most in-memory DB.
+// Therefore, these tests require connections to a full-fledged MySQL DB.
+//
+// If you would like to run these tests, please first establish a connection to a dev MySQL instance by running:
+// ssh -L 3309:makto-db-313.corp.linkedin.com:3306 [your-username]-ld3.linkedin.biz
+// Then run: ./gradlew build -Ptest-ebean-dao
 test {
-  exclude '**/EBeanLocalAccessTest.class'
+  if (!project.hasProperty('test-ebean-dao')) {
+    exclude '**/EBeanLocalAccessTest.class'
+    exclude '**/EbeanLocalDAOTest.class'
+  }
 }
+
 project.compileJava {
   doLast {
     ant.taskdef(name: 'ebean', classname: 'io.ebean.enhance.ant.AntEnhanceTask',

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EBeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EBeanLocalAccessTest.java
@@ -42,9 +42,9 @@ import static org.testng.AssertJUnit.*;
  * 2. Set DB_USER, DB_PASS, DB_SCHEMA
  */
 public class EBeanLocalAccessTest {
-  private static final String DB_USER = "tester";
-  private static final String DB_PASS = "tester";
-  private static final String DB_SCHEMA = "ebeanlocaldaotest";
+  private static final String DB_USER = "gma";
+  private static final String DB_PASS = "Password_1";
+  private static final String DB_SCHEMA = "gma_dev";
 
   private static EbeanServer _server;
   private static IEBeanLocalAccess _IEBeanLocalAccess;
@@ -55,7 +55,7 @@ public class EBeanLocalAccessTest {
     DataSourceConfig dataSourceConfig = new DataSourceConfig();
     dataSourceConfig.setUsername(DB_USER);
     dataSourceConfig.setPassword(DB_PASS);
-    dataSourceConfig.setUrl(String.format("jdbc:mysql://localhost:3306/%s?allowMultiQueries=true", DB_SCHEMA));
+    dataSourceConfig.setUrl(String.format("jdbc:mysql://localhost:3309/%s?allowMultiQueries=true", DB_SCHEMA));
     dataSourceConfig.setDriver("com.mysql.cj.jdbc.Driver");
 
     ServerConfig serverConfig = new ServerConfig();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -97,9 +97,9 @@ public class EbeanLocalDAOTest {
 
   // ONLY SET THIS TO FALSE IF YOU WANT TO TEST NEW_SCHEMA_ONLY OR DUAL_READ EbeanLocalDAO SchemaConfig values.
   private static final boolean NEW_SCHEMA_DISABLED = true;
-  private static final String DB_USER = "tester";
-  private static final String DB_PASS = "tester";
-  private static final String DB_SCHEMA = "ebeanlocaldaotest";
+  private static final String DB_USER = "gma";
+  private static final String DB_PASS = "Password_1";
+  private static final String DB_SCHEMA = "gma_dev";
 
   private EbeanServer _server;
   private BaseMetadataEventProducer _mockProducer;
@@ -154,7 +154,7 @@ public class EbeanLocalDAOTest {
     DataSourceConfig dataSourceConfig = new DataSourceConfig();
     dataSourceConfig.setUsername(DB_USER);
     dataSourceConfig.setPassword(DB_PASS);
-    dataSourceConfig.setUrl(String.format("jdbc:mysql://localhost:3306/%s?allowMultiQueries=true", DB_SCHEMA));
+    dataSourceConfig.setUrl(String.format("jdbc:mysql://localhost:3309/%s?allowMultiQueries=true", DB_SCHEMA));
     dataSourceConfig.setDriver("com.mysql.cj.jdbc.Driver");
 
     ServerConfig serverConfig = new ServerConfig();


### PR DESCRIPTION
Some unit tests require advanced MySQL syntax such as 'generated column' which is not supported by most in-memory DB. Therefore, these tests require connections to a full-fledged MySQL DB.

If you would like to run these tests, please first establish a connection to a dev MySQL instance by running:
`ssh -L 3309:makto-db-313.corp.linkedin.com:3306 [your-username]-ld3.linkedin.biz`
Then run: `./gradlew build -Ptest-ebean-dao`

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
