### PR TITLE
fix: Minor fixes on SQL syntax in test scripts

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -43,18 +43,6 @@ public interface IEbeanLocalAccess<URN extends Urn> {
       int keysCount, int position);
 
   /**
-   * Get read aspects from entity table. This a new schema implementation for batchGetOr() in {@link EbeanLocalDAO}
-   * @param keys {@link AspectKey} to retrieve aspect metadata
-   * @param keysCount pagination key count limit
-   * @param position starting position of pagination
-   * @return a list of {@link EbeanMetadataAspect} as get response
-   */
-  @Nonnull
-  <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> batchGetOr(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
-      int keysCount, int position);
-
-
-  /**
    * Returns list of urns that satisfy the given filter conditions.
    *
    * <p>Results are ordered by the order criterion but defaults to sorting lexicographically by the string
@@ -68,7 +56,6 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    */
   List<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       @Nullable URN lastUrn, int pageSize);
-
 
   /**
    * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int)} but returns a list result with pagination

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -106,7 +106,7 @@ public class SQLIndexFilterUtils {
         final String indexColumn = getGeneratedColumnName(indexCriterion.getAspect(), path);
         sqlFilters.add(
             indexColumn + parseConditionExpr(condition, indexCriterion.getPathParams().getValue(GetMode.NULL)));
-      } else if (!isUrn(indexCriterion.getAspect())) {
+      } else if (!isUrn(aspect)) {
         // if not given a path and condition, assume we are checking if the aspect exists.
         final String aspectColumn = getAspectColumnName(indexCriterion.getAspect());
         sqlFilters.add(aspectColumn + " IS NOT NULL");
@@ -114,7 +114,7 @@ public class SQLIndexFilterUtils {
     }
     // add filters to check that each aspect being queried is not soft deleted
     // e.g. WHERE a_aspect1 != '{"gma_deleted":true}' AND a_aspect2 != '{"gma_deleted":true}'
-    aspectColumns.forEach(aspect -> sqlFilters.add(String.format("%s != '%s'", aspect, DELETED_VALUE)));
+    aspectColumns.forEach(aspect -> sqlFilters.add(String.format("%s != CAST('%s' AS JSON)", aspect, DELETED_VALUE)));
     if (sqlFilters.isEmpty()) {
       return "";
     } else {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -34,7 +34,7 @@ public class SQLStatementUtils {
           + "ON DUPLICATE KEY UPDATE %s = :metadata;";
 
   private static final String SQL_READ_ASPECT_TEMPLATE =
-      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby FROM %%s WHERE urn = '%%s' AND %%s != '%s'", DELETED_VALUE);
+      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby FROM %%s WHERE urn = '%%s' AND %%s != CAST('%s' AS JSON)", DELETED_VALUE);
 
   private static final String INDEX_GROUP_BY_CRITERION = "SELECT count(*) as COUNT, %s FROM %s";
   private static final String SQL_GROUP_BY_COLUMN_EXISTS_TEMPLATE =
@@ -63,7 +63,7 @@ public class SQLStatementUtils {
   private static final String SQL_FILTER_TEMPLATE = "SELECT *, (%s) as _total_count FROM %s";
   private static final String SQL_BROWSE_ASPECT_TEMPLATE =
       String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby, (SELECT COUNT(urn) FROM %%s) as _total_count "
-          + "FROM %%s WHERE %%s != '%s' LIMIT %%d OFFSET %%d", DELETED_VALUE);
+          + "FROM %%s WHERE %%s != CAST('%s' AS JSON) LIMIT %%d OFFSET %%d", DELETED_VALUE);
 
   private SQLStatementUtils() {
     // Util class
@@ -104,7 +104,7 @@ public class SQLStatementUtils {
     StringBuilder stringBuilder = new StringBuilder();
     List<String> selectStatements = urns.stream().map(urn -> {
           final String tableName = getTableName(urn);
-          return String.format(SQL_READ_ASPECT_TEMPLATE, columnName, tableName, urn.toString(), columnName);
+          return String.format(SQL_READ_ASPECT_TEMPLATE, columnName, tableName, urn, columnName);
         }).collect(Collectors.toList());
     stringBuilder.append(String.join(" UNION ALL ", selectStatements));
     return stringBuilder.toString();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -56,7 +56,7 @@ public class EbeanLocalAccessTest {
   private static final Filter EMPTY_FILTER = new Filter().setCriteria(new CriterionArray());
 
   @BeforeClass
-  public void init() throws IOException {
+  public void init() {
     _server = MysqlDevInstance.getServer();
     _ebeanLocalAccessFoo = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, FooUrn.class);
     _ebeanLocalAccessBar = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, BarUrn.class);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManagerTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManagerTest.java
@@ -31,7 +31,7 @@ public class FlywaySchemaEvolutionManagerTest {
   }
 
   @Test
-  public void testSchemaUpToDate() throws IOException {
+  public void testSchemaUpToDate() {
     _schemaEvolutionManager.clean();
 
     // make sure table did not exists

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -163,7 +163,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
 
   private String insertRelationships(String table, String sourceUrn, String sourceType, String destinationUrn, String destinationType) {
     String insertTemplate = "INSERT INTO %s (metadata, source, source_type, destination, destination_type, lastmodifiedon, lastmodifiedby)"
-        + " VALUES ('metadata', '%s', '%s', '%s', '%s', '1970-01-01 00:00:01', 'unknown')";
+        + " VALUES ('{\"metadata\": true}', '%s', '%s', '%s', '%s', '1970-01-01 00:00:01', 'unknown')";
     return String.format(insertTemplate, table, sourceUrn, sourceType, destinationUrn, destinationType);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
@@ -40,6 +40,6 @@ public class SQLIndexFilterUtilsTest {
     indexFilter.setCriteria(indexCriterionArray);
 
     String sql = SQLIndexFilterUtils.parseIndexFilter(indexFilter);
-    assertEquals(sql, "WHERE i_aspectfoo$id < 12\nAND a_aspectfoo != '{\"gma_deleted\":true}'");
+    assertEquals(sql, "WHERE i_aspectfoo$id < 12\nAND a_aspectfoo != CAST('{\"gma_deleted\":true}' AS JSON)");
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -44,8 +44,8 @@ public class SQLStatementUtilsTest {
     set.add(fooUrn2);
     String expectedSql =
         "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:li:foo:1' "
-            + "AND a_aspectfoo != '{\"gma_deleted\":true}' UNION ALL SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
-            + "FROM metadata_entity_foo WHERE urn = 'urn:li:foo:2' AND a_aspectfoo != '{\"gma_deleted\":true}'";
+            + "AND a_aspectfoo != CAST('{\"gma_deleted\":true}' AS JSON) UNION ALL SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
+            + "FROM metadata_entity_foo WHERE urn = 'urn:li:foo:2' AND a_aspectfoo != CAST('{\"gma_deleted\":true}' AS JSON)";
     assertEquals(SQLStatementUtils.createAspectReadSql(AspectFoo.class, set), expectedSql);
   }
 
@@ -69,9 +69,9 @@ public class SQLStatementUtilsTest {
         SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING));
     String expectedSql = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE i_aspectfoo$value >= 25\n"
         + "AND i_aspectfoo$value < 50\n"
-        + "AND a_aspectfoo != '{\"gma_deleted\":true}') as _total_count FROM metadata_entity_foo\n"
+        + "AND a_aspectfoo != CAST('{\"gma_deleted\":true}' AS JSON)) as _total_count FROM metadata_entity_foo\n"
         + "WHERE i_aspectfoo$value >= 25\n" + "AND i_aspectfoo$value < 50\n"
-        + "AND a_aspectfoo != '{\"gma_deleted\":true}'";
+        + "AND a_aspectfoo != CAST('{\"gma_deleted\":true}' AS JSON)";
 
     assertEquals(sql, expectedSql);
   }
@@ -98,7 +98,7 @@ public class SQLStatementUtilsTest {
     String sql = SQLStatementUtils.createGroupBySql("metadata_entity_foo", indexFilter, indexGroupByCriterion);
     assertEquals(sql, "SELECT count(*) as COUNT, i_aspectfoo$value FROM metadata_entity_foo\n"
         + "WHERE i_aspectfoo$value >= 25\nAND i_aspectfoo$value < 50\n"
-        + "AND a_aspectfoo != '{\"gma_deleted\":true}'\nGROUP BY i_aspectfoo$value");
+        + "AND a_aspectfoo != CAST('{\"gma_deleted\":true}' AS JSON)\nGROUP BY i_aspectfoo$value");
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -8,28 +8,28 @@ DROP TABLE IF EXISTS metadata_index;
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     urn VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn)
+    CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
 );
 
 -- initialize bar entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     urn VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn)
+    CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
 );
 
 -- initialize bar entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     urn VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn)
+    CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
 );
 
 CREATE TABLE metadata_id (
@@ -46,7 +46,7 @@ CREATE TABLE metadata_aspect (
     createdon DATETIME(6) NOT NULL,
     createdby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect_ PRIMARY KEY (urn,aspect,version)
+    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn,aspect,version)
 );
 
 CREATE TABLE metadata_index (
@@ -61,13 +61,13 @@ CREATE TABLE metadata_index (
 );
 
 -- add foo aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectfoo LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectfoo JSON;
 
 -- add bar aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectbar LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
 
 -- add baz aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectbaz LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectbaz JSON;
 
 -- add baz aspect to burger entity
-ALTER TABLE metadata_entity_burger ADD a_aspectfoo LONGTEXT;
+ALTER TABLE metadata_entity_burger ADD a_aspectfoo JSON;

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -8,47 +8,47 @@ DROP TABLE IF EXISTS metadata_entity_bar;
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata LONGTEXT NOT NULL,
-    source VARCHAR(255) NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
-    destination VARCHAR(255) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
     id BIGINT NOT NULL AUTO_INCREMENT,
-    metadata LONGTEXT NOT NULL,
-    source VARCHAR(255) NOT NULL,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
-    destination VARCHAR(255) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_pairswith (
     id BIGINT NOT NULL AUTO_INCREMENT,
-    metadata LONGTEXT NOT NULL,
-    source VARCHAR(255) NOT NULL,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
-    destination VARCHAR(255) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_versionof (
     id BIGINT NOT NULL AUTO_INCREMENT,
-    metadata LONGTEXT NOT NULL,
-    source VARCHAR(255) NOT NULL,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
-    destination VARCHAR(255) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
 );
@@ -56,17 +56,26 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_versionof (
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     urn VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn)
+    CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
+);
+
+-- initialize foo entity table
+CREATE TABLE IF NOT EXISTS metadata_entity_bar (
+    urn VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    createdfor VARCHAR(255),
+    CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
 );
 
 -- add foo aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectfoo LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectfoo JSON;
 
 -- add foo aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectbar LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
 
 -- add new index virtual column 'value'
 ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectfoo$value VARCHAR(255)
@@ -76,17 +85,8 @@ ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectfoo$value VARCHAR(255)
 ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectbar$value VARCHAR(255)
     GENERATED ALWAYS AS (a_aspectbar ->> '$.aspect.value') VIRTUAL;
 
--- initialize foo entity table
-CREATE TABLE IF NOT EXISTS metadata_entity_bar (
-    urn VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
-    lastmodifiedby VARCHAR(255) NOT NULL,
-    createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn)
-);
-
 -- add foo aspect to bar entity
-ALTER TABLE metadata_entity_bar ADD a_aspectfoo LONGTEXT;
+ALTER TABLE metadata_entity_bar ADD a_aspectfoo JSON;
 
 -- add new index virtual column 'value'
 ALTER TABLE metadata_entity_bar ADD COLUMN i_aspectfoo$value VARCHAR(255)

--- a/dao-impl/ebean-dao/src/test/resources/metadata-schema-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/metadata-schema-create-all.sql
@@ -8,79 +8,80 @@ DROP TABLE IF EXISTS metadata_relationship_belongsto;
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     urn VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn)
+    CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
 );
 
 -- initialize bar entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     urn VARCHAR(100) NOT NULL,
-    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
-    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn)
+    CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
 );
 
 CREATE TABLE metadata_id (
-                             namespace                     VARCHAR(255) NOT NULL,
-                             id                            BIGINT NOT NULL,
-                             CONSTRAINT uq_metadata_id_namespace_id UNIQUE (namespace,id)
+    namespace VARCHAR(255) NOT NULL,
+    id BIGINT NOT NULL,
+    CONSTRAINT uq_metadata_id_namespace_id UNIQUE (namespace,id)
 );
 
 CREATE TABLE metadata_aspect (
-                                 urn                           VARCHAR(500) NOT NULL,
-                                 aspect                        VARCHAR(200) NOT NULL,
-                                 version                       BIGINT NOT NULL,
-                                 metadata                      VARCHAR(500) NOT NULL,
-                                 createdon                     DATETIME(6) NOT NULL,
-                                 createdby                     VARCHAR(255) NOT NULL,
-                                 createdfor                    VARCHAR(255),
-                                 CONSTRAINT pk_metadata_aspect_ PRIMARY KEY (urn,aspect,version)
+    urn VARCHAR(100) NOT NULL,
+    aspect VARCHAR(200) NOT NULL,
+    version BIGINT NOT NULL,
+    metadata VARCHAR(500) NOT NULL,
+    createdon DATETIME(6) NOT NULL,
+    createdby VARCHAR(255) NOT NULL,
+    createdfor VARCHAR(255),
+    CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn,aspect,version)
 );
 
 CREATE TABLE metadata_index (
-                                id                            BIGINT AUTO_INCREMENT NOT NULL,
-                                urn                           VARCHAR(500) NOT NULL,
-                                aspect                        VARCHAR(200) NOT NULL,
-                                path                          VARCHAR(200) NOT NULL,
-                                longval                       BIGINT,
-                                stringval                     VARCHAR(500),
-                                doubleval                     DOUBLE,
-                                CONSTRAINT pk_metadata_index PRIMARY KEY (id)
+   id BIGINT AUTO_INCREMENT NOT NULL,
+   urn VARCHAR(1000) NOT NULL,
+   aspect VARCHAR(200) NOT NULL,
+   path VARCHAR(200) NOT NULL,
+   longval BIGINT,
+   stringval VARCHAR(500),
+   doubleval DOUBLE,
+   CONSTRAINT pk_metadata_index PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     id BIGINT NOT NULL AUTO_INCREMENT,
-    metadata LONGTEXT NOT NULL,
-    source VARCHAR(255) NOT NULL,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
-    destination VARCHAR(255) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon DATETIME(6) NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
 );
--- add foo aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectfoo LONGTEXT;
-
--- add new index virtual column 'value'
-ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectfoo$value VARCHAR(255)
-    GENERATED ALWAYS AS (a_aspectfoo ->> '$.aspect.value') VIRTUAL;
 
 -- add foo aspect to foo entity
-ALTER TABLE metadata_entity_bar ADD a_aspectfoo LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectfoo JSON;
+
+-- add foo aspect to foo entity
+ALTER TABLE metadata_entity_bar ADD a_aspectfoo JSON;
 
 -- add bar aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectbar LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
 
 -- add foobar aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectfoobar LONGTEXT;
+ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
 
 -- add new index virtual column 'value'
 ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectbar$value VARCHAR(255)
     GENERATED ALWAYS AS (a_aspectbar ->> '$.aspect.value') VIRTUAL;
+
+-- add new index virtual column 'value'
+ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectfoo$value VARCHAR(255)
+    GENERATED ALWAYS AS (a_aspectfoo ->> '$.aspect.value') VIRTUAL;
 
 -- create index for index column
 CREATE INDEX i_aspectfoo$value ON metadata_entity_foo (urn(50), i_aspectfoo$value);

--- a/dao-impl/ebean-dao/src/test/resources/schema-evolution-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/schema-evolution-create-all.sql
@@ -11,11 +11,11 @@ CREATE TABLE metadata_id (
 );
 
 CREATE TABLE metadata_aspect (
-    urn VARCHAR(500) NOT NULL,
+    urn VARCHAR(1000) NOT NULL,
     aspect VARCHAR(200) NOT NULL,
     version BIGINT NOT NULL,
-    metadata VARCHAR(500) NOT NULL,
-    createdon DATETIME(6) NOT NULL,
+    metadata JSON NOT NULL,
+    createdon TIMESTAMP NOT NULL,
     createdby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
     CONSTRAINT pk_metadata_aspect_ PRIMARY KEY (urn,aspect,version)


### PR DESCRIPTION
Changed `LONGTEXT` to `JSON` type for storing metadata. 
According to MySQL manual:
```
The JSON data type provides these advantages over storing JSON-format strings in a string column:

Automatic validation of JSON documents stored in JSON columns. Invalid documents produce an error.

Optimized storage format. JSON documents stored in JSON columns are converted to an internal format that permits quick read access to document elements. When the server later must read a JSON value stored in this binary format, the value need not be parsed from a text representation. The binary format is structured to enable the server to look up subobjects or nested values directly by key or array index without reading all values before or after them in the document.
```

All existing unit tests passed.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
