### PR TITLE
fix(new schema): fix backfill api + minor bug fixes

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
@@ -16,12 +16,7 @@ enum BackfillMode {
   MAE_ONLY
 
   /**
-   * Backfill only new entity tables
-   */
-  ENTITY_TABLES_ONLY
-
-  /**
-   * Backfill all secondary stores, excluding ENTITY_TABLES_ONLY
+   * Backfill all secondary stores
    */
   BACKFILL_ALL
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -68,7 +68,7 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull FooUrn urn, @Nullable ASPECT latestValue) {
+    public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull FooUrn urn, @Nonnull Class<ASPECT> aspectClass) {
 
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -87,6 +87,12 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
         .setParameter("lastmodifiedon", new Timestamp(timestamp).toString())
         .setParameter("lastmodifiedby", actor);
 
+    // If a non-default UrnPathExtractor is provided, the user MUST specify in their schema generation scripts
+    // 'ALTER TABLE <table> ADD COLUMN a_urn JSON'.
+    if (urnExtraction) {
+      sqlUpdate.setParameter("a_urn", toJsonString(urn));
+    }
+
     // newValue is null if aspect is to be soft-deleted.
     if (newValue == null) {
 
@@ -104,12 +110,6 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
       }
 
       return sqlUpdate.setParameter("metadata", DELETED_VALUE).execute();
-    }
-
-    // If a non-default UrnPathExtractor is provided, the user MUST specify in their schema generation scripts
-    // 'ALTER TABLE table ADD COLUMN a_urn JSON'.
-    if (urnExtraction) {
-      sqlUpdate.setParameter("a_urn", toJsonString(urn));
     }
 
     // Add local relationships if builder is provided.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -326,12 +326,12 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull URN urn, @Nonnull ASPECT latestValue) {
+  public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass) {
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("The DAO is set to use the OLD_SCHEMA_ONLY. Please check that the schemaConfig"
           + "parameter is properly set to NEW_SCHEMA_ONLY or DUAL_SCHEMA if you wish to use entity tables.");
     }
-    PrimaryKey key = new PrimaryKey(urn.toString(), ModelUtils.getAspectName(latestValue.getClass()), LATEST_VERSION);
+    PrimaryKey key = new PrimaryKey(urn.toString(), aspectClass.getCanonicalName(), LATEST_VERSION);
     runInTransactionWithRetry(() -> {
       // use forUpdate() to lock the row during this transaction so that we can guarantee a consistent update
       EbeanMetadataAspect result = _server.createQuery(EbeanMetadataAspect.class).setId(key).forUpdate().findOne();
@@ -339,7 +339,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         return null; // return value not used
       }
       AuditStamp auditStamp = makeAuditStamp(result);
-      _localAccess.add(urn, latestValue, (Class<ASPECT>) latestValue.getClass(), auditStamp);
+      _localAccess.add(urn, toRecordTemplate(aspectClass, result).orElse(null), aspectClass, auditStamp);
       return null; // return value not used
     }, 1);
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -55,6 +55,7 @@ public class EbeanLocalAccessTest {
   private static EbeanServer _server;
   private static IEbeanLocalAccess<FooUrn> _ebeanLocalAccessFoo;
   private static IEbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
+  private static long _now;
   private static final Filter EMPTY_FILTER = new Filter().setCriteria(new CriterionArray());
 
   @BeforeClass
@@ -63,6 +64,7 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessFoo = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, FooUrn.class, new FooUrnPathExtractor());
     _ebeanLocalAccessBar = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, BarUrn.class, new BarUrnPathExtractor());
     _ebeanLocalAccessFoo.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
+    _now = System.currentTimeMillis();
   }
 
   @BeforeMethod
@@ -323,7 +325,7 @@ public class EbeanLocalAccessTest {
   public void testUrnExtraction() {
     FooUrn urn1 = makeFooUrn(1);
     AspectFoo foo1 = new AspectFoo().setValue("foo");
-    _ebeanLocalAccessFoo.add(urn1, foo1, AspectFoo.class, makeAuditStamp("actor", 1234L));
+    _ebeanLocalAccessFoo.add(urn1, foo1, AspectFoo.class, makeAuditStamp("actor", _now));
 
     // get content of virtual column
     List<SqlRow> results = _server.createSqlQuery("SELECT i_urn$fooId as id FROM metadata_entity_foo").findList();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -8,8 +8,7 @@ import com.linkedin.metadata.dao.EbeanLocalAccess;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipWriterDAO;
 import com.linkedin.metadata.dao.IEbeanLocalAccess;
-import com.linkedin.metadata.dao.utils.BarUrnPathExtractor;
-import com.linkedin.metadata.dao.utils.FooUrnPathExtractor;
+import com.linkedin.metadata.dao.scsi.EmptyPathExtractor;
 import com.linkedin.metadata.dao.utils.MysqlDevInstance;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
@@ -55,8 +54,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _server = MysqlDevInstance.getServer();
     _localRelationshipWriterDAO = new EbeanLocalRelationshipWriterDAO(_server);
     _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);
-    _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, FooUrn.class, new FooUrnPathExtractor());
-    _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, BarUrn.class, new BarUrnPathExtractor());
+    _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, FooUrn.class, new EmptyPathExtractor<>());
+    _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, MysqlDevInstance.SERVER_CONFIG, BarUrn.class, new EmptyPathExtractor<>());
   }
 
   @BeforeMethod

--- a/dao-impl/ebean-dao/src/test/resources/schema-evolution-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/schema-evolution-create-all.sql
@@ -11,7 +11,7 @@ CREATE TABLE metadata_id (
 );
 
 CREATE TABLE metadata_aspect (
-    urn VARCHAR(1000) NOT NULL,
+    urn VARCHAR(500) NOT NULL,
     aspect VARCHAR(200) NOT NULL,
     version BIGINT NOT NULL,
     metadata JSON NOT NULL,

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -271,7 +271,7 @@ public abstract class BaseEntityResource<
 
     return RestliUtils.toTask(() -> {
       final Set<URN> urnSet = Arrays.stream(urns).map(urnString -> parseUrnParam(urnString)).collect(Collectors.toSet());
-      return RestliUtils.buildBackfillResult(getLocalDAO().backfill(BackfillMode.ENTITY_TABLES_ONLY, parseAspectsParam(aspectNames), urnSet));
+      return RestliUtils.buildBackfillResult(getLocalDAO().backfillEntityTables(parseAspectsParam(aspectNames), urnSet));
     });
   }
 


### PR DESCRIPTION
bug before:
backfill method calls get() to get aspects to backfill. however, for the new schema, this get() will try to get from the new schema tables, which won't have the existing data in it (hence the whole point of needing to backfill). 

solution:
create separate backfill method that circumvents existing backfill logic.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
