### PR TITLE
feat(new schema): adjust soft deletion check to support MariaDB syntax

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -132,11 +132,11 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   /**
    * Construct and execute a SQL statement as follows.
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND aspect1 != '{"gma_deleted":true}'
+   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
    * UNION ALL
-   * SELECT urn, aspect2, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND aspect2 != '{"gma_deleted":true}'
+   * SELECT urn, aspect2, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND JSON_EXTRACT(aspect2, '$.gma_deleted') IS NULL
    * UNION ALL
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:2' AND aspect1 != '{"gma_deleted":true}'
+   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:2' AND JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
    * @param aspectKeys a List of keys (urn, aspect pairings) to query for
    * @param keysCount number of keys to query
    * @param position position of the key to start from

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang.StringEscapeUtils;
 
 import static com.linkedin.metadata.dao.utils.EBeanDAOUtils.*;
 import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
+import static com.linkedin.metadata.dao.utils.SQLStatementUtils.SOFT_DELETED_CHECK;
 
 
 /**
@@ -113,8 +114,7 @@ public class SQLIndexFilterUtils {
       }
     }
     // add filters to check that each aspect being queried is not soft deleted
-    // e.g. WHERE a_aspect1 != '{"gma_deleted":true}' AND a_aspect2 != '{"gma_deleted":true}'
-    aspectColumns.forEach(aspect -> sqlFilters.add(String.format("%s != CAST('%s' AS JSON)", aspect, DELETED_VALUE)));
+    aspectColumns.forEach(aspect -> sqlFilters.add(String.format(SOFT_DELETED_CHECK, aspect)));
     if (sqlFilters.isEmpty()) {
       return "";
     } else {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
@@ -40,6 +40,6 @@ public class SQLIndexFilterUtilsTest {
     indexFilter.setCriteria(indexCriterionArray);
 
     String sql = SQLIndexFilterUtils.parseIndexFilter(indexFilter);
-    assertEquals(sql, "WHERE i_aspectfoo$id < 12\nAND a_aspectfoo != CAST('{\"gma_deleted\":true}' AS JSON)");
+    assertEquals(sql, "WHERE i_aspectfoo$id < 12\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL");
   }
 }


### PR DESCRIPTION
- MariaDB does not support "CAST('value' AS JSON)" which we use in the check for soft deleted aspects:
CAST(a_aspect1 AS JSON) != '{"gma_deleted":"true"}'

- Instead, let's use JSON_EXTRACT which is supported in both MySQL and MariaDB syntax, with the same behavior.
JSON_EXTRACT(a_aspect1, '$.gma_deleted') IS NULL

This works since JSON_EXTRACT on a path which does not exist (as is the case of 'gma_deleted' when the aspect has not been soft deleted) returns NULL.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
