### PR TITLE
fix(new schema): use static toJSONString instead of JSONObject constructor

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -410,8 +410,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   @Nonnull
   private String toJsonString(@Nonnull URN urn) {
     final Map<String, Object> pathValueMap = _urnPathExtractor.extractPaths(urn);
-    final JSONObject jsonObject = new JSONObject(pathValueMap);
-    return jsonObject.toJSONString();
+    return JSONObject.toJSONString(pathValueMap);
   }
 
   /**


### PR DESCRIPTION
- original code was causing some weird issues in a downstream service where the JSONObject(<Map>) constructor could not be found
- verified using EbeanLocalDAO and EbeanLocalAccess unit tests that this new implementation behaves the same as before

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
