### PR TITLE
make JSONParser thread safe

### DIFF
--- a/dao-impl/ebean-dao/build.gradle
+++ b/dao-impl/ebean-dao/build.gradle
@@ -30,6 +30,16 @@ dependencies {
   enhance externalDependency.ebeanAgent
 }
 
+test {
+  if (!project.hasProperty('test-ebean-dao')) {
+    exclude '**/EbeanLocalAccessTest.class'
+    exclude '**/EbeanLocalDAOTest.class'
+    exclude '**/EbeanLocalRelationshipWriterDAOTest.class'
+    exclude '**/EbeanLocalRelationshipQueryDAOTest.class'
+    exclude '**/FlywaySchemaEvolutionManagerTest.class'
+  }
+}
+
 project.compileJava {
   doLast {
     ant.taskdef(name: 'ebean', classname: 'io.ebean.enhance.ant.AntEnhanceTask',

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -1,6 +1,5 @@
 package com.linkedin.metadata.dao;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -421,8 +421,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    * @return A string which can be deserialized into Aspect object.
    */
   @Nullable
-  @VisibleForTesting
-  public String extractAspectJsonString(@Nonnull final String auditedAspect) {
+  private String extractAspectJsonString(@Nonnull final String auditedAspect) {
     try {
       JSONParser jsonParser = new JSONParser();
       JSONObject map = (JSONObject) jsonParser.parse(auditedAspect);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -88,7 +88,6 @@ public interface IEbeanLocalAccess<URN extends Urn> {
   Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion);
 
-
   /**
    * Paginates over all URNs for entities that have a specific aspect. This does not include the urn(s) for which the
    * aspect is soft deleted in the latest version.

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -48,9 +48,9 @@ import static org.testng.AssertJUnit.*;
 
 public class EbeanLocalAccessTest {
   private static EbeanServer _server;
-  private static IEbeanLocalAccess<FooUrn> _ebeanLocalAccessFoo;
-  private static IEbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
-  private static IEbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
+  private static EbeanLocalAccess<FooUrn> _ebeanLocalAccessFoo;
+  private static EbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
+  private static EbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
   private static long _now;
   private static final Filter EMPTY_FILTER = new Filter().setCriteria(new CriterionArray());
 
@@ -268,7 +268,7 @@ public class EbeanLocalAccessTest {
     String toJson = EbeanLocalAccess.toJsonString(auditedAspect);
 
     assertEquals("{\"lastmodifiedby\":\"0\",\"lastmodifiedon\":\"1\",\"aspect\":{\"value\":\"test\"}}", toJson);
-    assertNotNull(RecordUtils.toRecordTemplate(AspectFoo.class, EbeanLocalAccess.extractAspectJsonString(toJson)));
+    assertNotNull(RecordUtils.toRecordTemplate(AspectFoo.class, _ebeanLocalAccessFoo.extractAspectJsonString(toJson)));
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -33,6 +33,8 @@ import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.SqlRow;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -48,9 +50,9 @@ import static org.testng.AssertJUnit.*;
 
 public class EbeanLocalAccessTest {
   private static EbeanServer _server;
-  private static EbeanLocalAccess<FooUrn> _ebeanLocalAccessFoo;
-  private static EbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
-  private static EbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
+  private static IEbeanLocalAccess<FooUrn> _ebeanLocalAccessFoo;
+  private static IEbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
+  private static IEbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
   private static long _now;
   private static final Filter EMPTY_FILTER = new Filter().setCriteria(new CriterionArray());
 
@@ -257,7 +259,7 @@ public class EbeanLocalAccessTest {
   }
 
   @Test
-  public void testToAndFromJson() {
+  public void testToAndFromJson() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     AspectFoo aspectFoo = new AspectFoo();
     aspectFoo.setValue("test");
     AuditedAspect auditedAspect = new AuditedAspect();
@@ -267,8 +269,9 @@ public class EbeanLocalAccessTest {
     auditedAspect.setAspect(RecordUtils.toJsonString(aspectFoo));
     String toJson = EbeanLocalAccess.toJsonString(auditedAspect);
 
+    Method extractAspectJsonString = EbeanLocalAccess.class.getDeclaredMethod("extractAspectJsonString", String.class);
     assertEquals("{\"lastmodifiedby\":\"0\",\"lastmodifiedon\":\"1\",\"aspect\":{\"value\":\"test\"}}", toJson);
-    assertNotNull(RecordUtils.toRecordTemplate(AspectFoo.class, _ebeanLocalAccessFoo.extractAspectJsonString(toJson)));
+    assertNotNull(RecordUtils.toRecordTemplate(AspectFoo.class, (String) extractAspectJsonString.invoke(_ebeanLocalAccessFoo, toJson)));
   }
 
   @Test


### PR DESCRIPTION
JSONParser is not thread-safe: `Please note that JSONParser is NOT thread-safe.` http://miamarti.github.io/HorusFramework/javadoc/org/json/simple/parser/JSONParser.html

To make it thread safe, create new JSONParser in non-static method.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
