### PR TITLE
fix(new schema): fix filter sql bug

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -40,6 +40,7 @@ import org.json.simple.parser.ParseException;
 
 import static com.linkedin.metadata.dao.utils.EBeanDAOUtils.*;
 import static com.linkedin.metadata.dao.utils.SQLIndexFilterUtils.*;
+import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
 
 
 /**
@@ -265,7 +266,11 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
     // append last urn where condition
     if (lastUrn != null) {
-      filterSql.append(" AND urn > '");
+      // because createFilterSql will only include a WHERE clause if there are non-urn filters, we need to make sure
+      // that we add a WHERE if it wasn't added already.
+      final boolean filterOnlyOnUrns = indexFilter.getCriteria().stream().allMatch(criteria -> isUrn(criteria.getAspect()));
+      filterSql.append(filterOnlyOnUrns ? " WHERE " : " AND ");
+      filterSql.append("urn > '");
       filterSql.append(lastUrn);
       filterSql.append("'");
     }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -173,11 +173,23 @@ public class EbeanLocalAccessTest {
     FooUrn lastUrn = new FooUrn(29);
 
     // When: list out results with lastUrn = 'urn:li:foo:29' and pageSize = 5
-    List<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5);
+    List<FooUrn> result1 = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5);
 
     // Expect: 5 rows are returns (30~34) and the first element is 'urn:li:foo:30'
-    assertEquals(5, listUrns.size());
-    assertEquals("30", listUrns.get(0).getId());
+    assertEquals(5, result1.size());
+    assertEquals("30", result1.get(0).getId());
+
+    lastUrn = result1.get(result1.size() - 1);
+
+    // When: list out results with lastUrn = 'urn:li:foo:34' and pageSize = 5, but with only a filter on the aspect
+    IndexCriterion indexCriterion3 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
+    indexCriterionArray = new IndexCriterionArray(Collections.singleton(indexCriterion3));
+    IndexFilter filter = new IndexFilter().setCriteria(indexCriterionArray);
+    List<FooUrn> result2 = _ebeanLocalAccessFoo.listUrns(filter, indexSortCriterion, lastUrn, 5);
+
+    // Expect: 5 rows are returns (35~39) and the first element is 'urn:li:foo:35'
+    assertEquals(5, result2.size());
+    assertEquals("35", result2.get(0).getId());
   }
 
   @Test
@@ -270,6 +282,7 @@ public class EbeanLocalAccessTest {
     String toJson = EbeanLocalAccess.toJsonString(auditedAspect);
 
     Method extractAspectJsonString = EbeanLocalAccess.class.getDeclaredMethod("extractAspectJsonString", String.class);
+    extractAspectJsonString.setAccessible(true);
     assertEquals("{\"lastmodifiedby\":\"0\",\"lastmodifiedon\":\"1\",\"aspect\":{\"value\":\"test\"}}", toJson);
     assertNotNull(RecordUtils.toRecordTemplate(AspectFoo.class, (String) extractAspectJsonString.invoke(_ebeanLocalAccessFoo, toJson)));
   }


### PR DESCRIPTION
Was seeing errors such as 

```
com.linkedin.restli.client.RestLiResponseException: Response status 500, serviceErrorMessage: 
javax.persistence.PersistenceException: Query threw SQLException:
You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'AND urn > 'urn:li:dataset:(urn:li:dataPlatform:espresso,mDataA1669941550060,D...' at line 2 
Query was:SELECT *, (SELECT COUNT(urn) FROM metadata_entity_dataset ) as _total_count FROM metadata_entity_dataset
     AND urn > 'urn:li:dataset:(urn:li:dataPlatform:espresso,mDataA1669941550060,DEV)' LIMIT 100 OFFSET 0
```

The problem is that we were assuming that when using parameter `lastUrn` for `listUrns()`, we will already have a `WHERE` clause to append `AND urn > ...` to. But actually, there isn't always a `WHERE` as in the case of having only filters on Urn-type aspects.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
