### PR TITLE
feat(new schema): add method to backfill local relationships from entity tables

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -628,6 +628,17 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   public abstract <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass);
 
   /**
+   * Backfill local relationships from the new schema entity tables. This method is new/dual schema only. It should NOT
+   * be used to add local relationships under normal circumstances and should ONLY be used in the case where the aspects
+   * exist in the entity tables but the relationships don't exist in the local relationship tables (e.g. if the local
+   * relationship tables got dropped or if they were set up after data was already ingested into entity tables).
+   *
+   * @param urn the URN for the entity the aspect (which the local relationship is derived from) is attached to
+   * @param aspectClass class of the aspect to backfill
+   */
+  public abstract <ASPECT extends RecordTemplate> void backfillLocalRelationshipsFromEntityTables(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass);
+
+  /**
    * Returns list of urns from local secondary index that satisfy the given filter conditions.
    *
    * <p>Results are ordered by the order criterion but defaults to sorting lexicographically by the string

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -72,6 +72,11 @@ public class BaseLocalDAOTest {
 
     }
 
+    @Override
+    public <ASPECT extends RecordTemplate> void backfillLocalRelationshipsFromEntityTables(@Nonnull FooUrn urn, @Nonnull Class<ASPECT> aspectClass) {
+
+    }
+
     @Nonnull
     @Override
     protected <T> T runInTransactionWithRetry(Supplier<T> block, int maxTransactionRetry) {

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -17,6 +17,7 @@ import com.linkedin.testing.PizzaInfo;
 import com.linkedin.testing.PizzaOrder;
 import com.linkedin.testing.SnapshotUnionAlias;
 import com.linkedin.testing.TyperefPizzaAspect;
+import com.linkedin.testing.localrelationship.AspectFooBar;
 import com.linkedin.testing.urn.PizzaUrn;
 import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.data.template.RecordTemplate;
@@ -79,7 +80,7 @@ public class ModelUtilsTest {
   public void testGetValidAspectTypes() {
     Set<Class<? extends RecordTemplate>> validTypes = ModelUtils.getValidAspectTypes(EntityAspectUnion.class);
 
-    assertEquals(validTypes, ImmutableSet.of(AspectFoo.class, AspectBar.class, AspectAttributes.class));
+    assertEquals(validTypes, ImmutableSet.of(AspectFoo.class, AspectBar.class, AspectFooBar.class, AspectAttributes.class));
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -18,20 +18,27 @@ import javax.annotation.Nullable;
  */
 public interface IEbeanLocalAccess<URN extends Urn> {
 
-   void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor);
+  void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor);
 
   /**
    * Upsert aspect into entity table.
    * @param urn entity urn
    * @param newValue aspect value in {@link RecordTemplate}
+   * @param aspectClass class of the aspect
    * @param auditStamp audit timestamp
    * @param <ASPECT> metadata aspect value
    * @return number of rows inserted or updated
    */
-  @Nonnull
-   <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+  <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp);
 
+  /**
+   * Upsert relationships to the local relationship table(s).
+   * @param urn urn associated with the relationships
+   * @param relationship aspect from which the relationships are derived from
+   * @param aspectClass class of the aspect
+   */
+  <ASPECT extends RecordTemplate> void addRelationships(@Nonnull URN urn, @Nonnull ASPECT relationship, @Nonnull Class<ASPECT> aspectClass);
 
   /**
    * Get read aspects from entity table. This a new schema implementation for batchGetUnion() in {@link EbeanLocalDAO}
@@ -104,6 +111,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
   /**
    * Provide a local relationship builder registry. Local relationships will be built based on the builders during data ingestion.
    * @param localRelationshipBuilderRegistry All local relationship builders should be registered in this registry.
+   *                                         Can be set to null to turn off local relationship ingestion.
    */
-  void setLocalRelationshipBuilderRegistry(@Nonnull LocalRelationshipBuilderRegistry localRelationshipBuilderRegistry);
+  void setLocalRelationshipBuilderRegistry(@Nullable LocalRelationshipBuilderRegistry localRelationshipBuilderRegistry);
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -26,7 +26,7 @@ import org.json.simple.parser.ParseException;
 @Slf4j
 public class EBeanDAOUtils {
 
-  public static final String DIFFERENT_RESULTS_TEMPLATE = "The results of %s from the new schema table and old schema table are not equal. Reason: %s."
+  public static final String DIFFERENT_RESULTS_TEMPLATE = "The results of %s from the new schema table and old schema table are not equal. Reason: %s. "
       + "Defaulting to using the value(s) from the old schema table.";
   // String stored in metadata_aspect table for soft deleted aspect
   private static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
@@ -79,13 +79,13 @@ public class EBeanDAOUtils {
     }
     if (resultOld == null || resultNew == null) {
       final String message = resultOld == null
-          ? "The old schema result was null while the new schema result wasn't."
-          : "The new schema result was null while the old schema result wasn't.";
+          ? "The old schema result was null while the new schema result wasn't"
+          : "The new schema result was null while the old schema result wasn't";
       log.warn(String.format(DIFFERENT_RESULTS_TEMPLATE, methodName, message));
       return false;
     }
     if (resultOld.size() != resultNew.size()) {
-      final String message = String.format("The old schema returned %d result(s) while the new schema returned %d result(s).",
+      final String message = String.format("The old schema returned %d result(s) while the new schema returned %d result(s)",
           resultOld.size(), resultNew.size());
       log.warn(String.format(DIFFERENT_RESULTS_TEMPLATE, methodName, message));
       return false;
@@ -119,15 +119,15 @@ public class EBeanDAOUtils {
     }
     if (resultOld == null || resultNew == null) {
       final String message = resultOld == null
-          ? "The old schema result was null while the new schema result wasn't."
-          : "The new schema result was null while the old schema result wasn't.";
+          ? "The old schema result was null while the new schema result wasn't"
+          : "The new schema result was null while the old schema result wasn't";
       log.warn(String.format(DIFFERENT_RESULTS_TEMPLATE, methodName, message));
       return false;
     }
     if (resultOld.equals(resultNew)) {
       return true;
     }
-    log.warn(String.format(DIFFERENT_RESULTS_TEMPLATE, methodName, "Check preceding WARN logs for the reason that the ListResults are not equal"));
+    log.warn("Check preceding WARN logs for the reason that the ListResults are not equal");
     return false;
   }
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -32,6 +32,18 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
 );
 
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+
 CREATE TABLE metadata_id (
     namespace VARCHAR(255) NOT NULL,
     id BIGINT NOT NULL,
@@ -68,6 +80,9 @@ ALTER TABLE metadata_entity_foo ADD a_aspectfoo JSON;
 
 -- add bar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
+
+-- add foobar aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
 
 -- add array aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectattributes JSON;

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
@@ -16,10 +16,13 @@ import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.testing.AspectAttributes;
 import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.BarUrnArray;
 import com.linkedin.testing.EntityAspectUnion;
 import com.linkedin.testing.EntityAspectUnionArray;
 import com.linkedin.testing.EntitySnapshot;
 import com.linkedin.testing.EntityValue;
+import com.linkedin.testing.localrelationship.AspectFooBar;
+import com.linkedin.testing.urn.BarUrn;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,10 +60,11 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectKey<Urn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     AspectKey<Urn, AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
-    AspectKey<Urn, AspectAttributes> aspect3Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
+    AspectKey<Urn, AspectFooBar> aspect3Key = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
+    AspectKey<Urn, AspectAttributes> aspect4Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
-    when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key))))
+    when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key, aspect4Key))))
         .thenReturn(Collections.singletonMap(aspect1Key, Optional.of(foo)));
 
     EntityValue value = runAndWait(_resource.get(id, null));
@@ -152,10 +156,13 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     AspectKey<Urn, AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
     AspectKey<Urn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
     AspectKey<Urn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
+    AspectKey<Urn, AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
+    AspectKey<Urn, AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
     AspectKey<Urn, AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
     AspectKey<Urn, AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
 
-    when(_mockLocalDAO.get(ImmutableSet.of(aspectFooKey1, aspectBarKey1, aspectAttKey1, aspectFooKey2, aspectBarKey2, aspectAttKey2))).thenReturn(
+    when(_mockLocalDAO.get(ImmutableSet.of(aspectFooKey1, aspectBarKey1, aspectAttKey1, aspectFooKey2, aspectBarKey2,
+        aspectAttKey2, aspectFooBarKey1, aspectFooBarKey2))).thenReturn(
         ImmutableMap.of(aspectFooKey1, Optional.of(foo), aspectFooKey2, Optional.of(bar)));
 
     Map<Long, EntityValue> keyValueMap = runAndWait(_resource.batchGet(ImmutableSet.of(id1, id2), null))
@@ -223,19 +230,22 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     Urn urn = makeUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
+    AspectFooBar fooBar = new AspectFooBar().setBars(new BarUrnArray(new BarUrn(1)));
     AspectAttributes att = new AspectAttributes().setAttributes(new StringArray("a"));
     AspectKey<Urn, ? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     AspectKey<Urn, ? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<Urn, ? extends RecordTemplate> fooBarKey = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
     AspectKey<Urn, ? extends RecordTemplate> attKey = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
-    Set<AspectKey<Urn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, attKey);
-    when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo), barKey, Optional.of(bar), attKey, Optional.of(att)));
+    Set<AspectKey<Urn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, attKey);
+    when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo), barKey, Optional.of(bar),
+        fooBarKey, Optional.of(fooBar), attKey, Optional.of(att)));
 
     EntitySnapshot snapshot = runAndWait(_resource.getSnapshot(urn.toString(), null));
 
     assertEquals(snapshot.getUrn(), urn);
 
     Set<RecordTemplate> aspects = snapshot.getAspects().stream().map(RecordUtils::getSelectedRecordTemplateFromUnion).collect(Collectors.toSet());
-    assertEquals(aspects, ImmutableSet.of(foo, bar, att));
+    assertEquals(aspects, ImmutableSet.of(foo, bar, fooBar, att));
   }
 
   @Test

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAspectUnion.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAspectUnion.pdl
@@ -1,6 +1,7 @@
 namespace com.linkedin.testing
 
+import com.linkedin.testing.localrelationship.AspectFooBar
 /**
  * For unit tests
  */
-typeref EntityAspectUnion = union[AspectFoo, AspectBar, AspectAttributes]
+typeref EntityAspectUnion = union[AspectFoo, AspectBar, AspectFooBar, AspectAttributes]


### PR DESCRIPTION
This method should only be used in cases where data has already been ingested into the entity tables but not the local relationship tables. For example, this can happen when the entity tables were set up before the local relationship tables.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
