### PR TITLE
(new schema): EbeanLocalDAO SCSI query timeout increased from 5s -> 10s

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -76,7 +76,7 @@ import static com.linkedin.metadata.dao.utils.EbeanServerUtils.*;
 public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     extends BaseLocalDAO<ASPECT_UNION, URN> {
 
-  private static final int INDEX_QUERY_TIMEOUT_IN_SEC = 5;
+  private static final int INDEX_QUERY_TIMEOUT_IN_SEC = 10;
 
   protected final EbeanServer _server;
   protected final Class<URN> _urnClass;


### PR DESCRIPTION
We want to increase the timeout allowed for SCSI queries so that we can gather meaningful performance baseline numbers for the old schema. With the 5 seconds timeout currently, we are not able to get a full grasp of how slowly SCSI is performing.

For example, in the old schema, a query could timeout in 5s. In the new schema, it could succeed in 4s. Does that mean the new schema is 25% better than the old schema? Not necessarily. If we had let the old schema query run to completion, it could have taken 15s for all we know. This would be a 275% improvement. 

We don't want to increase the timeout too high though since we don't want to overload the DB. So 10s should be a good middle ground.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
