### PR TITLE
fix(browse): fix browse query to include must clause for removed field

### DIFF
--- a/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
+++ b/dao-impl/elasticsearch-dao-7/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
@@ -191,7 +191,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
 
     final BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
 
-    queryBuilder.mustNot(QueryBuilders.termQuery(removedFieldName, "true"));
+    queryBuilder.must(QueryBuilders.termQuery(removedFieldName, "false"));
 
     if (!path.isEmpty()) {
       queryBuilder.filter(QueryBuilders.termQuery(browsePathFieldName, path));

--- a/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/browse/BrowseDAOTest.java
+++ b/dao-impl/elasticsearch-dao-7/src/test/java/com/linkedin/metadata/dao/browse/BrowseDAOTest.java
@@ -1,15 +1,19 @@
 package com.linkedin.metadata.dao.browse;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.dao.utils.SearchUtils;
 import com.linkedin.testing.TestUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.testng.annotations.BeforeMethod;
@@ -99,5 +103,18 @@ public class BrowseDAOTest {
     when(_mockClient.search(any(), eq(RequestOptions.DEFAULT))).thenReturn(mockSearchResponse);
     assertEquals(_browseDAO.getBrowsePaths(dummyUrn).size(), 1);
     assertEquals(_browseDAO.getBrowsePaths(dummyUrn).get(0), "foo");
+  }
+
+  @Test
+  public void testBrowseQueryMustClause() {
+    // given
+    SearchRequest searchRequest = _browseDAO.constructEntitiesSearchRequest("", SearchUtils.getRequestMap(null), 0, 0);
+    BoolQueryBuilder queryBuilder = (BoolQueryBuilder) searchRequest.source().query();
+
+    // then
+    assertTrue(queryBuilder.hasClauses());
+    assertEquals(queryBuilder.must().size(), 1);
+    assertTrue(StringUtils.contains(queryBuilder.must().get(0).toString(), "removed"));
+    assertTrue(StringUtils.contains(queryBuilder.must().get(0).toString(), "false"));
   }
 }


### PR DESCRIPTION
## Context
Currently, ESBrowseDAO uses a `must_not` clause in its query to filter active datasets by the `removed` _(boolean)_ field. 
This is the clause:
```
"must_not": { "term": { "removed": "true" } }
```

This causes an issue wherein those entities for which the **removed** field itself is missing from their corresponding search documents would also get surfaced in the results. 
This is also in contrast to the **search** query results, wherein the queries primarily have a '**must**' clause for '**removed = false**'.
Changes in this PR are to fix this issue in the browse behaviour. This change will make sure that only entities successfully marked _(indexed)_ as `removed = false` would surface in the results.

### List of changes:
- Update the 'buildQueryString' method in ESBrowseDAO
- Added corresponding unit test

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
