### PR TITLE
use default max retry

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -473,17 +473,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     final EbeanMetadataAspect aspect = buildMetadataAspectBean(urn, value, aspectClass, auditStamp, version);
 
-    if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY || _schemaConfig == SchemaConfig.DUAL_SCHEMA) {
-      if (version == LATEST_VERSION) {
-        // insert() could be called when updating log table (moving current versions into new history version)
-        // the metadata entity tables shouldn't been updated.
-        runInTransactionWithRetry(() -> {
-          _localAccess.add(urn, (ASPECT) value, aspectClass, auditStamp);
-          _server.insert(aspect);
-          return null; // Unused.
-        }, 1);
-        return;
-      }
+    if (_schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY && version == LATEST_VERSION) {
+      // insert() could be called when updating log table (moving current versions into new history version)
+      // the metadata entity tables shouldn't been updated.
+      _localAccess.add(urn, (ASPECT) value, aspectClass, auditStamp);
     }
 
     _server.insert(aspect);


### PR DESCRIPTION
Current code wrap db calls in one transaction with one retry. It prevents new / dual schema from using the default max retry (which is 3). Below are different ways to reach `insert` method. They should all use the default max retry.

addMany (runInTransaction, 3 retries) -> aspectUpdateHelper -> addCommon -> saveLatest -> insert
add (runInTransaction, 3 retries) -> aspectUpdateHelper -> addCommon -> saveLatest -> insert
delete (runInTransaction, 3 retries) -> addCommon -> saveLatest -> insert


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
