### PR TITLE
always use current time when setting row-level lastmodifiedon

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -81,14 +81,13 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   public <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp) {
 
-    final long timestamp = auditStamp.hasTime() ? auditStamp.getTime() : System.currentTimeMillis();
     final String actor = auditStamp.hasActor() ? auditStamp.getActor().toString() : DEFAULT_ACTOR;
     final String impersonator = auditStamp.hasImpersonator() ? auditStamp.getImpersonator().toString() : null;
     final boolean urnExtraction = _urnPathExtractor != null && !(_urnPathExtractor instanceof EmptyPathExtractor);
 
     final SqlUpdate sqlUpdate = _server.createSqlUpdate(SQLStatementUtils.createAspectUpsertSql(urn, aspectClass, urnExtraction))
         .setParameter("urn", urn.toString())
-        .setParameter("lastmodifiedon", new Timestamp(timestamp).toString())
+        .setParameter("lastmodifiedon", new Timestamp(System.currentTimeMillis()).toString())
         .setParameter("lastmodifiedby", actor);
 
     // If a non-default UrnPathExtractor is provided, the user MUST specify in their schema generation scripts
@@ -117,6 +116,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
     // Add local relationships if builder is provided.
     addRelationships(urn, newValue, aspectClass);
+
+    final long timestamp = auditStamp.hasTime() ? auditStamp.getTime() : System.currentTimeMillis();
 
     AuditedAspect auditedAspect = new AuditedAspect()
         .setAspect(RecordUtils.toJsonString(newValue))


### PR DESCRIPTION
We have two `lastmodifiedon` timestamps. One is in the aspect json column (a_aspect) and the other one is on row level. Current entity table backfill method will populate the row level `lastmodifiedon` using same timestamp as in  a_aspect. In this example below, during the backfill the row level `lastmodifiedon` could be set as 2021-01-01.
```
a_aspectfoo 2021-01-01
a_aspectbar 2023-01-01
```
The row level `lastmodifiedon` on entity table should always use current time whenever the row is modified.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
