### PR TITLE
add deleted_ts is null check

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -63,7 +63,8 @@ public class SQLStatementUtils {
 
   private static final String DELETE_BY_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination AND deleted_ts IS NULL";
 
-  private static final String DELETE_BY_SOURCE_AND_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination AND source = :source AND deleted_ts IS NULL";
+  private static final String DELETE_BY_SOURCE_AND_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination"
+      + " AND source = :source AND deleted_ts IS NULL";
 
   /**
    *  Filter query has pagination params in the existing APIs. To accommodate this, we use subquery to include total result counts in the query response.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -59,11 +59,11 @@ public class SQLStatementUtils {
       + "destination_type, lastmodifiedon, lastmodifiedby) VALUE (:metadata, :source, :destination, :source_type,"
       + " :destination_type, :lastmodifiedon, :lastmodifiedby)";
 
-  private static final String DELETE_BY_SOURCE = "UPDATE %s SET deleted_ts=NOW() WHERE source = :source";
+  private static final String DELETE_BY_SOURCE = "UPDATE %s SET deleted_ts=NOW() WHERE source = :source AND deleted_ts IS NULL";
 
-  private static final String DELETE_BY_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination";
+  private static final String DELETE_BY_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination AND deleted_ts IS NULL";
 
-  private static final String DELETE_BY_SOURCE_AND_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination AND source = :source";
+  private static final String DELETE_BY_SOURCE_AND_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination AND source = :source AND deleted_ts IS NULL";
 
   /**
    *  Filter query has pagination params in the existing APIs. To accommodate this, we use subquery to include total result counts in the query response.


### PR DESCRIPTION
## Summary

We're seeing over more then 2T binlog stacked in mysql db in one day which exhausted disk space. After examining the content of binlog, majority of the data is from soft deletion of local relationship table. Existing SQL will update all the rows (thousands) even it's already soft deleted. We should only update the ones that's NOT softed deleted yet.