### PR TITLE
feat(eventGeneration): Add Union Aspect event generation allowing for MCE V5's that can cont…

### DIFF
--- a/gradle-plugins/metadata-annotations-lib/src/test/java/com/linkedin/metadata/annotations/GmaAnnotationParserTest.java
+++ b/gradle-plugins/metadata-annotations-lib/src/test/java/com/linkedin/metadata/annotations/GmaAnnotationParserTest.java
@@ -5,6 +5,7 @@ import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.testing.AnnotatedAspectBar;
 import com.linkedin.testing.AnnotatedAspectFoo;
+import com.linkedin.testing.BarAspect;
 import com.linkedin.testing.CommonAspect;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,15 @@ public class GmaAnnotationParserTest {
     assertThat(gma).contains(new GmaAnnotation().setAspect(
         new AspectAnnotation().setEntity(new AspectEntityAnnotation().setUrn("com.linkedin.testing.BarUrn"))
             .setColumn(new ColumnNameAnnotation().setName("barurn"))));
+  }
+
+  @Test
+  public void parseBarAspect() {
+    // has both @gma.aspect.entity.urn and @gma.aspect.column.name annotations
+    final Optional<GmaAnnotation> gma =
+            new GmaAnnotationParser().parse(DataTemplateUtil.getTyperefInfo(BarAspect.class).getSchema());
+    assertThat(gma).contains(new GmaAnnotation().setAspect(
+            new AspectAnnotation().setEntity(new AspectEntityAnnotation().setUrn("com.linkedin.testing.BarUrn"))));
   }
 
   @Test

--- a/gradle-plugins/metadata-annotations-test-models/build.gradle
+++ b/gradle-plugins/metadata-annotations-test-models/build.gradle
@@ -6,8 +6,11 @@ project.ext.publications = ['dataTemplate']
 
 apply from: "$rootDir/gradle/java-publishing.gradle"
 
+pegasus.main.generationModes = [PegasusGenerationMode.PEGASUS, PegasusGenerationMode.AVRO]
+
 dependencies {
   dataModel project(':core-models')
+  dataModel project(':dao-api')
 
   testCompile externalDependency.assertJ
 
@@ -35,3 +38,8 @@ sourceSets {
 }
 
 sourceSets.mainGeneratedDataTemplate.java.srcDirs('src/main/java/com/linkedin/testing/urn')
+
+clean {
+  project.delete("mainGeneratedAvroSchema")
+  project.delete("mainGeneratedDataTemplate")
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnotherAspectBar.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnotherAspectBar.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+record AnotherAspectBar {
+  /** For unit tests */
+  stringField: string
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/BarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/BarAspect.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.testing
+
+@gma.aspect.entity = {
+  "urn": "com.linkedin.testing.BarUrn"
+}
+typeref BarAspect = union[
+  AnnotatedAspectBar,
+  AnotherAspectBar
+]

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/FailedMCEBarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/FailedMCEBarAspect.pdl
@@ -6,7 +6,7 @@ import com.linkedin.avro2pegasus.events.KafkaAuditHeader
  * Failed MetadataChangeEvent for aspects of BarUrn.
  */
 @FailedMetadataChangeEvent
-record FailedMCE_BarAspect {
+record FailedMCEBarAspect {
 
   /**
    * Kafka audit header. See go/kafkaauditheader for more info.
@@ -16,7 +16,7 @@ record FailedMCE_BarAspect {
   /**
    * The event that failed to be processed.
    */
-  metadataChangeEvent: MCE_BarAspect
+  metadataChangeEvent: MCEBarAspect
 
   /**
    * The error message or the stacktrace for the failure.

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/FailedMCE_BarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/FailedMCE_BarAspect.pdl
@@ -1,25 +1,26 @@
-namespace com.linkedin.mxe.bar.annotatedAspectBar
+namespace com.linkedin.testing.mxe.bar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 
 /**
- * FailedMetadataChangeEvent for the BarUrn with AnnotatedAspectBar aspect.
+ * Failed MetadataChangeEvent for aspects of BarUrn.
  */
 @FailedMetadataChangeEvent
-record FailedMetadataChangeEvent {
+record FailedMCE_BarAspect {
 
   /**
-   * Kafka event for capturing a failure to process a MetadataChangeEvent.
+   * Kafka audit header. See go/kafkaauditheader for more info.
    */
   auditHeader: optional KafkaAuditHeader
 
   /**
    * The event that failed to be processed.
    */
-  metadataChangeEvent: MetadataChangeEvent
+  metadataChangeEvent: MCE_BarAspect
 
   /**
    * The error message or the stacktrace for the failure.
    */
   error: string
+
 }

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
@@ -10,7 +10,7 @@ import com.linkedin.testing.AnotherAspectBar
  * MetadataChangeEvent for aspects of BarUrn.
  */
 @MetadataChangeEvent
-record MCE_BarAspect {
+record MCEBarAspect {
 
   /**
    * Kafka audit header. See go/kafkaauditheader for more info.

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCE_BarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCE_BarAspect.pdl
@@ -1,0 +1,39 @@
+namespace com.linkedin.testing.mxe.bar
+
+import com.linkedin.avro2pegasus.events.KafkaAuditHeader
+import com.linkedin.metadata.events.ChangeType
+import com.linkedin.testing.BarUrn
+import com.linkedin.testing.AnnotatedAspectBar
+import com.linkedin.testing.AnotherAspectBar
+
+/**
+ * MetadataChangeEvent for aspects of BarUrn.
+ */
+@MetadataChangeEvent
+record MCE_BarAspect {
+
+  /**
+   * Kafka audit header. See go/kafkaauditheader for more info.
+   */
+  auditHeader: optional KafkaAuditHeader
+
+  /**
+   * BarUrn as the key for the MetadataChangeEvent.
+   */
+  urn: BarUrn
+
+  /**
+   * The proposed aspect values for this entity.
+   */
+  proposedValues: array[union[
+    record ProposedAnnotatedAspectBar {
+      proposed: optional AnnotatedAspectBar
+      changeType: ChangeType = "UPSERT"
+    }
+    record ProposedAnotherAspectBar {
+      proposed: optional AnotherAspectBar
+      changeType: ChangeType = "UPSERT"
+    }
+  ]]
+
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/FailedMetadataChangeEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/FailedMetadataChangeEvent.pdl
@@ -1,14 +1,11 @@
-@import com.linkedin.metadata.generator.SingleAspectEventSpec;
-@import com.linkedin.metadata.generator.SchemaGeneratorUtil;
-@args SingleAspectEventSpec eventSpec
-namespace @(eventSpec.getNamespace())
+namespace com.linkedin.testing.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 
 /**
- * FailedMetadataChangeEvent for the @(eventSpec.getShortUrn()) with @(eventSpec.getShortValueType()) aspect.
+ * FailedMetadataChangeEvent for the BarUrn with AnnotatedAspectBar aspect.
  */
-@@FailedMetadataChangeEvent
+@FailedMetadataChangeEvent
 record FailedMetadataChangeEvent {
 
   /**

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -1,4 +1,4 @@
-namespace com.linkedin.mxe.bar.annotatedAspectBar
+namespace com.linkedin.testing.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
@@ -1,4 +1,4 @@
-namespace com.linkedin.mxe.bar.annotatedAspectBar
+namespace com.linkedin.testing.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType

--- a/gradle-plugins/metadata-annotations-test-models/src/test/java/com/linkedin/metadata/annotations/testing/UnionAspectTest.java
+++ b/gradle-plugins/metadata-annotations-test-models/src/test/java/com/linkedin/metadata/annotations/testing/UnionAspectTest.java
@@ -3,8 +3,8 @@ package com.linkedin.metadata.annotations.testing;
 import com.linkedin.metadata.events.ChangeType;
 import com.linkedin.testing.AnnotatedAspectBar;
 import com.linkedin.testing.AnotherAspectBar;
-import com.linkedin.testing.mxe.bar.FailedMCE_BarAspect;
-import com.linkedin.testing.mxe.bar.MCE_BarAspect;
+import com.linkedin.testing.mxe.bar.FailedMCEBarAspect;
+import com.linkedin.testing.mxe.bar.MCEBarAspect;
 import com.linkedin.testing.mxe.bar.ProposedAnnotatedAspectBar;
 import com.linkedin.testing.mxe.bar.ProposedAnotherAspectBar;
 import com.linkedin.testing.urn.BarUrn;
@@ -16,7 +16,7 @@ public class UnionAspectTest {
   // to ensure event building is reasonable.
   @Test
   public void test() throws Exception {
-    MCE_BarAspect unionAspect = new MCE_BarAspect().setUrn(new BarUrn(123));
+    MCEBarAspect unionAspect = new MCEBarAspect().setUrn(new BarUrn(123));
 
     AnnotatedAspectBar bar = new AnnotatedAspectBar().setBoolField(true);
     ProposedAnnotatedAspectBar proposedBar = new ProposedAnnotatedAspectBar().setProposed(bar);
@@ -25,11 +25,11 @@ public class UnionAspectTest {
     ProposedAnotherAspectBar proposedAnotherBar =
             new ProposedAnotherAspectBar().setProposed(anotherBar).setChangeType(ChangeType.DELETE);
 
-    unionAspect.setProposedValues(new MCE_BarAspect.ProposedValuesArray(
-            MCE_BarAspect.ProposedValues.create(proposedBar),
-            MCE_BarAspect.ProposedValues.create(proposedAnotherBar)));
+    unionAspect.setProposedValues(new MCEBarAspect.ProposedValuesArray(
+            MCEBarAspect.ProposedValues.create(proposedBar),
+            MCEBarAspect.ProposedValues.create(proposedAnotherBar)));
 
-    FailedMCE_BarAspect failedAspect = new FailedMCE_BarAspect();
+    FailedMCEBarAspect failedAspect = new FailedMCEBarAspect();
     failedAspect.setMetadataChangeEvent(unionAspect);
     failedAspect.setError("test");
   }

--- a/gradle-plugins/metadata-annotations-test-models/src/test/java/com/linkedin/metadata/annotations/testing/UnionAspectTest.java
+++ b/gradle-plugins/metadata-annotations-test-models/src/test/java/com/linkedin/metadata/annotations/testing/UnionAspectTest.java
@@ -1,0 +1,37 @@
+package com.linkedin.metadata.annotations.testing;
+
+import com.linkedin.metadata.events.ChangeType;
+import com.linkedin.testing.AnnotatedAspectBar;
+import com.linkedin.testing.AnotherAspectBar;
+import com.linkedin.testing.mxe.bar.FailedMCE_BarAspect;
+import com.linkedin.testing.mxe.bar.MCE_BarAspect;
+import com.linkedin.testing.mxe.bar.ProposedAnnotatedAspectBar;
+import com.linkedin.testing.mxe.bar.ProposedAnotherAspectBar;
+import com.linkedin.testing.urn.BarUrn;
+import org.junit.jupiter.api.Test;
+
+public class UnionAspectTest {
+
+  // This test is meant to show that we can successfully build UnionAspect events. It serves as a testing ground
+  // to ensure event building is reasonable.
+  @Test
+  public void test() throws Exception {
+    MCE_BarAspect unionAspect = new MCE_BarAspect().setUrn(new BarUrn(123));
+
+    AnnotatedAspectBar bar = new AnnotatedAspectBar().setBoolField(true);
+    ProposedAnnotatedAspectBar proposedBar = new ProposedAnnotatedAspectBar().setProposed(bar);
+
+    AnotherAspectBar anotherBar = new AnotherAspectBar().setStringField("foo");
+    ProposedAnotherAspectBar proposedAnotherBar =
+            new ProposedAnotherAspectBar().setProposed(anotherBar).setChangeType(ChangeType.DELETE);
+
+    unionAspect.setProposedValues(new MCE_BarAspect.ProposedValuesArray(
+            MCE_BarAspect.ProposedValues.create(proposedBar),
+            MCE_BarAspect.ProposedValues.create(proposedAnotherBar)));
+
+    FailedMCE_BarAspect failedAspect = new FailedMCE_BarAspect();
+    failedAspect.setMetadataChangeEvent(unionAspect);
+    failedAspect.setError("test");
+  }
+
+}

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/AspectUnionEventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/AspectUnionEventSpec.java
@@ -1,0 +1,38 @@
+package com.linkedin.metadata.generator;
+
+import com.google.common.collect.Lists;
+import lombok.Getter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * An {@link EventSpec} to handle aspect unions, generating MCEs that can contain an array of aspects related to the
+ * same URN.
+ */
+@Getter
+public class AspectUnionEventSpec extends EventSpec {
+
+  private final String typerefName;
+  private final Collection<String> valueTypes;
+  private final String shortTyperefName;
+
+  public AspectUnionEventSpec(String urnType, String typerefName, Collection<String> valueTypes, String baseNamespace) {
+    super(urnType, baseNamespace);
+    this.typerefName = typerefName;
+    this.valueTypes = valueTypes;
+    this.shortTyperefName = SchemaGeneratorUtil.stripNamespace(this.typerefName);
+  }
+
+  @Override
+  Collection<File> renderEventSchemas(File baseDirectory) throws IOException {
+    File subdirectory = new File(baseDirectory, SchemaGeneratorUtil.deCapitalize(getEntityName()));
+    return Lists.newArrayList(
+            renderFile(new File(subdirectory, "MCE_" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
+                    "AspectUnionEvent.rythm"),
+            renderFile(new File(subdirectory, "FailedMCE_" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
+                    "FailedAspectUnionEvent.rythm")
+    );
+  }
+}

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/AspectUnionEventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/AspectUnionEventSpec.java
@@ -29,9 +29,9 @@ public class AspectUnionEventSpec extends EventSpec {
   Collection<File> renderEventSchemas(File baseDirectory) throws IOException {
     File subdirectory = new File(baseDirectory, SchemaGeneratorUtil.deCapitalize(getEntityName()));
     return Lists.newArrayList(
-            renderFile(new File(subdirectory, "MCE_" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
+            renderFile(new File(subdirectory, "MCE" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
                     "AspectUnionEvent.rythm"),
-            renderFile(new File(subdirectory, "FailedMCE_" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
+            renderFile(new File(subdirectory, "FailedMCE" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
                     "FailedAspectUnionEvent.rythm")
     );
   }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/EventSchemaComposer.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/EventSchemaComposer.java
@@ -9,9 +9,6 @@ import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.rythmengine.Rythm;
 
-import static com.linkedin.metadata.generator.SchemaGeneratorConstants.*;
-import static com.linkedin.metadata.generator.SchemaGeneratorUtil.*;
-
 
 /**
  * Render the property annotations to the MXE pdl schema.
@@ -20,43 +17,20 @@ import static com.linkedin.metadata.generator.SchemaGeneratorUtil.*;
 public class EventSchemaComposer extends RythmGenerator {
 
   public void render(@Nonnull List<EventSpec> eventSpecs, @Nonnull String mainOutput) {
-    eventSpecs.forEach(eventSpec -> {
-      switch (eventSpec.getEventType()) {
-        case CHANGE:
-        case AUDIT:
-        case FAILED_CHANGE:
-          processRecord(eventSpec, mainOutput);
-          break;
-        default:
-          throw new IllegalArgumentException(
-              String.format("Unrecognized event type %s to be rendered.", eventSpec.getEventType()));
-      }
-    });
+    eventSpecs.forEach(eventSpec -> processRecord(eventSpec, mainOutput));
   }
 
   private void processRecord(@Nonnull EventSpec eventSpec, @Nonnull String mainOutput) {
     try {
-      generateResultFile(eventSpec.getEventType(), eventSpec.getUrn(), eventSpec, mainOutput);
+      eventSpec.renderEventSchemas(new File(mainOutput));
     } catch (IOException ex) {
       log.error(String.format("Generate result file failed due to %s.", ex.getCause()));
     }
   }
 
-  private void generateResultFile(@Nonnull MetadataEventType eventType, @Nonnull String entityUrn,
-      @Nonnull EventSpec eventSpec, @Nonnull String mainOutput) throws IOException {
-    final String entityName = deCapitalize(getEntityName(entityUrn));
-    final String aspectName = deCapitalize(eventSpec.getValueType());
-    final File directory = createOutputFolder(mainOutput + File.separator + entityName + File.separator + aspectName);
-    final String namespace = String.format(".%s.%s", entityName, aspectName);
-
-    writeToFile(new File(directory, eventType.getName() + PDL_SUFFIX),
-        renderToString(eventSpec, entityUrn, namespace, EVENT_TEMPLATES.get(eventType)));
-  }
-
   @Nonnull
-  private String renderToString(@Nullable EventSpec eventSpec, @Nonnull String entityUrn, @Nonnull String namespace,
-      @Nonnull String template) throws IOException {
-    final String result = Rythm.renderIfTemplateExists(template, entityUrn, namespace, eventSpec);
+  static String renderToString(@Nullable EventSpec eventSpec, @Nonnull String template) throws IOException {
+    final String result = Rythm.renderIfTemplateExists(template, eventSpec);
     if (result.isEmpty()) {
       throw new IOException(String.format("Template does not exist: %s.", template));
     }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/EventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/EventSpec.java
@@ -16,10 +16,14 @@ public abstract class EventSpec {
   /** Entity that this aspect refers to, such as: com.linkedin.common.CorpuserUrn. */
   private final String urnType;
 
-  /** Short name without namespace for the {@link #urnType}. */
+  /**
+   * Short name without namespace for the {@link #urnType}.
+   */
   private final String shortUrn;
 
-  /** {@link #shortUrn} without Urn ending. */
+  /**
+   * {@link #shortUrn} without Urn ending.
+   */
   private final String entityName;
 
   /** Base namespace where rendered events will be created. */

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/EventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/EventSpec.java
@@ -1,29 +1,53 @@
 package com.linkedin.metadata.generator;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import lombok.Getter;
 
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
 
 /**
- * Getter and setter class for schema event metadata.
+ * Contains event metadata for rendering events.
  */
-@Data
-@RequiredArgsConstructor
-@Builder(toBuilder = true)
-public final class EventSpec {
-  // fullValueType of the model, such as: com.linkedin.identity.CorpUserInfo.
-  private final String fullValueType;
+@Getter
+public abstract class EventSpec {
 
-  // namespace of the model, such as: com.linkedin.identity.
-  private final String namespace;
+  /** Entity that this aspect refers to, such as: com.linkedin.common.CorpuserUrn. */
+  private final String urnType;
 
-  // specType of the model, such as: MetadataChangeEvent.
-  private final SchemaGeneratorConstants.MetadataEventType eventType;
+  /** Short name without namespace for the {@link #urnType}. */
+  private final String shortUrn;
 
-  // entity that this aspect refers to, such as: com.linkedin.common.CorpuserUrn.
-  private final String urn;
+  /** {@link #shortUrn} without Urn ending. */
+  private final String entityName;
 
-  // valueType of the model, such as: CorpUserInfo.
-  private final String valueType;
+  /** Base namespace where rendered events will be created. */
+  private final String baseNamespace;
+
+  public EventSpec(String urnType, @Nullable String baseNamespace) {
+    this.urnType = urnType;
+    this.shortUrn = SchemaGeneratorUtil.stripNamespace(urnType);
+    this.entityName = SchemaGeneratorUtil.getEntityName(urnType);
+    this.baseNamespace = baseNamespace == null ? "com.linkedin.mxe" : baseNamespace;
+  }
+
+  /**
+   * Render all events related to this spec.
+   */
+  abstract Collection<File> renderEventSchemas(File baseDirectory) throws IOException;
+
+  /** namespace of the model, such as: com.linkedin.identity. */
+  public String getNamespace() {
+    return String.format("%s.%s", this.baseNamespace, SchemaGeneratorUtil.deCapitalize(this.getEntityName()));
+  }
+
+  /** Render a single event file with the given template. */
+  File renderFile(File file, String templateName) throws IOException {
+    SchemaGeneratorUtil.createOutputFolder(file.getParentFile());
+    SchemaGeneratorUtil.writeToFile(file,
+            EventSchemaComposer.renderToString(this, templateName));
+    return file;
+  }
+
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaAnnotationRetriever.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaAnnotationRetriever.java
@@ -1,6 +1,5 @@
 package com.linkedin.metadata.generator;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.metadata.annotations.AspectEntityAnnotation;

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGenerator.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGenerator.java
@@ -33,7 +33,7 @@ public class SchemaGenerator {
   public void generate(@Nonnull Collection<String> resolverPaths, @Nonnull Collection<String> sourcePaths,
       @Nonnull String generatedFileOutput, @Nonnull GmaEntitiesAnnotationAllowList allowList) throws IOException {
     generate(sourcePaths, generatedFileOutput,
-        new SchemaAnnotationRetriever(resolverPaths.stream().collect(Collectors.joining(":")), allowList));
+        new SchemaAnnotationRetriever(resolverPaths.stream().collect(Collectors.joining(":")), allowList, null));
   }
 
   /**

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorConstants.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorConstants.java
@@ -1,7 +1,5 @@
 package com.linkedin.metadata.generator;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
 import javax.annotation.Nonnull;
 
 
@@ -12,27 +10,34 @@ public class SchemaGeneratorConstants {
   private SchemaGeneratorConstants() {
   }
 
+  // used in EventSchemaComposer
+  static final String PDL_SUFFIX = ".pdl";
+
   public enum MetadataEventType {
-    CHANGE("MetadataChangeEvent"), AUDIT("MetadataAuditEvent"), FAILED_CHANGE("FailedMetadataChangeEvent");
+    CHANGE("MetadataChangeEvent", "MetadataChangeEvent.rythm"),
+    AUDIT("MetadataAuditEvent", "MetadataAuditEvent.rythm"),
+    FAILED_CHANGE("FailedMetadataChangeEvent", "FailedMetadataChangeEvent.rythm");
 
     private final String _name;
+    private final String _templateName;
 
-    MetadataEventType(@Nonnull String name) {
+    MetadataEventType(@Nonnull String name, @Nonnull String templateName) {
       _name = name;
+      _templateName = templateName;
     }
 
     @Nonnull
     public String getName() {
       return _name;
     }
+
+    public String getTemplateName() {
+      return _templateName;
+    }
+
+    public String getDefaultFileName() {
+      return _name + PDL_SUFFIX;
+    }
   }
 
-  // used in EventSchemaComposer
-  static final String PDL_SUFFIX = ".pdl";
-  static final Map<MetadataEventType, String> EVENT_TEMPLATES =
-      ImmutableMap.<MetadataEventType, String>builder().put(MetadataEventType.FAILED_CHANGE,
-          "FailedMetadataChangeEvent.rythm")
-          .put(MetadataEventType.AUDIT, "MetadataAuditEvent.rythm")
-          .put(MetadataEventType.CHANGE, "MetadataChangeEvent.rythm")
-          .build();
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorUtil.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorUtil.java
@@ -72,11 +72,10 @@ public class SchemaGeneratorUtil {
   /**
    * Create event schema output folder.
    *
-   * @param eventSchemaOutput the output path for the rendered schemas.
+   * @param directory the output path for the rendered schemas.
    * @return the directory of the output path.
    */
-  public static File createOutputFolder(@Nonnull String eventSchemaOutput) throws IOException {
-    final File directory = new File(eventSchemaOutput);
+  public static File createOutputFolder(@Nonnull File directory) throws IOException {
     if (!directory.mkdirs() && !directory.exists()) {
       throw new IOException(String.format("%s cannot be created.", directory));
     }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SingleAspectEventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SingleAspectEventSpec.java
@@ -32,7 +32,7 @@ public class SingleAspectEventSpec extends EventSpec {
 
   @Override
   public Collection<File> renderEventSchemas(File baseDirectory) throws IOException {
-    File subdirectory = new File (new File(baseDirectory, SchemaGeneratorUtil.deCapitalize(getEntityName())),
+    File subdirectory = new File(new File(baseDirectory, SchemaGeneratorUtil.deCapitalize(getEntityName())),
             SchemaGeneratorUtil.deCapitalize(this.getShortValueType()));
     return Lists.newArrayList(
             renderFile(new File(subdirectory, SchemaGeneratorConstants.MetadataEventType.CHANGE.getDefaultFileName()),

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SingleAspectEventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SingleAspectEventSpec.java
@@ -1,0 +1,46 @@
+package com.linkedin.metadata.generator;
+
+import com.google.common.collect.Lists;
+import lombok.Getter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * An {@link EventSpec} to create events for submissions of single urn, single aspect.
+ */
+@Getter
+public class SingleAspectEventSpec extends EventSpec {
+
+  // fullValueType of the model, such as: com.linkedin.identity.CorpUserInfo.
+  private final String fullValueType;
+
+  // valueType of the model, such as: CorpUserInfo.
+  private final String shortValueType;
+
+  public SingleAspectEventSpec(String fullValueType, String urnType, String baseNamespace) {
+    super(urnType, baseNamespace);
+    this.fullValueType = fullValueType;
+    this.shortValueType = SchemaGeneratorUtil.stripNamespace(fullValueType);
+  }
+
+  @Override
+  public String getNamespace() {
+    return String.format("%s.%s", super.getNamespace(), SchemaGeneratorUtil.deCapitalize(this.shortValueType));
+  }
+
+  @Override
+  public Collection<File> renderEventSchemas(File baseDirectory) throws IOException {
+    File subdirectory = new File (new File(baseDirectory, SchemaGeneratorUtil.deCapitalize(getEntityName())),
+            SchemaGeneratorUtil.deCapitalize(this.getShortValueType()));
+    return Lists.newArrayList(
+            renderFile(new File(subdirectory, SchemaGeneratorConstants.MetadataEventType.CHANGE.getDefaultFileName()),
+                    SchemaGeneratorConstants.MetadataEventType.CHANGE.getTemplateName()),
+            renderFile(new File(subdirectory, SchemaGeneratorConstants.MetadataEventType.AUDIT.getDefaultFileName()),
+                    SchemaGeneratorConstants.MetadataEventType.AUDIT.getTemplateName()),
+            renderFile(new File(subdirectory, SchemaGeneratorConstants.MetadataEventType.FAILED_CHANGE.getDefaultFileName()),
+                    SchemaGeneratorConstants.MetadataEventType.FAILED_CHANGE.getTemplateName())
+    );
+  }
+}

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
@@ -1,0 +1,41 @@
+@import com.linkedin.metadata.generator.AspectUnionEventSpec;
+@import com.linkedin.metadata.generator.SchemaGeneratorUtil;
+@args AspectUnionEventSpec eventSpec
+namespace @(eventSpec.getNamespace())
+
+import com.linkedin.avro2pegasus.events.KafkaAuditHeader
+import com.linkedin.metadata.events.ChangeType
+import @eventSpec.getUrnType()
+@for (String valueType: eventSpec.getValueTypes()) {
+import @valueType
+}
+
+/**
+ * MetadataChangeEvent for aspects of @(eventSpec.getShortUrn()).
+ */
+@@MetadataChangeEvent
+record MCE_@(eventSpec.getShortTyperefName()) {
+
+  /**
+   * Kafka audit header. See go/kafkaauditheader for more info.
+   */
+  auditHeader: optional KafkaAuditHeader
+
+  /**
+   * @(eventSpec.getShortUrn()) as the key for the MetadataChangeEvent.
+   */
+  urn: @(eventSpec.getShortUrn())
+
+  /**
+   * The proposed aspect values for this entity.
+   */
+  proposedValues: array[union[
+  @for (String valueType: eventSpec.getValueTypes()) {
+    record Proposed@(SchemaGeneratorUtil.stripNamespace(valueType)) {
+      proposed: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
+      changeType: ChangeType = "UPSERT"
+    }
+  }
+  ]]
+
+}

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
@@ -14,7 +14,7 @@ import @valueType
  * MetadataChangeEvent for aspects of @(eventSpec.getShortUrn()).
  */
 @@MetadataChangeEvent
-record MCE_@(eventSpec.getShortTyperefName()) {
+record MCE@(eventSpec.getShortTyperefName()) {
 
   /**
    * Kafka audit header. See go/kafkaauditheader for more info.

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/FailedAspectUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/FailedAspectUnionEvent.rythm
@@ -9,7 +9,7 @@ import com.linkedin.avro2pegasus.events.KafkaAuditHeader
  * Failed MetadataChangeEvent for aspects of @(eventSpec.getShortUrn()).
  */
 @@FailedMetadataChangeEvent
-record FailedMCE_@(eventSpec.getShortTyperefName()) {
+record FailedMCE@(eventSpec.getShortTyperefName()) {
 
   /**
    * Kafka audit header. See go/kafkaauditheader for more info.
@@ -19,7 +19,7 @@ record FailedMCE_@(eventSpec.getShortTyperefName()) {
   /**
    * The event that failed to be processed.
    */
-  metadataChangeEvent: MCE_@(eventSpec.getShortTyperefName())
+  metadataChangeEvent: MCE@(eventSpec.getShortTyperefName())
 
   /**
    * The error message or the stacktrace for the failure.

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/FailedAspectUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/FailedAspectUnionEvent.rythm
@@ -1,28 +1,29 @@
-@import com.linkedin.metadata.generator.SingleAspectEventSpec;
+@import com.linkedin.metadata.generator.AspectUnionEventSpec;
 @import com.linkedin.metadata.generator.SchemaGeneratorUtil;
-@args SingleAspectEventSpec eventSpec
+@args AspectUnionEventSpec eventSpec
 namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 
 /**
- * FailedMetadataChangeEvent for the @(eventSpec.getShortUrn()) with @(eventSpec.getShortValueType()) aspect.
+ * Failed MetadataChangeEvent for aspects of @(eventSpec.getShortUrn()).
  */
 @@FailedMetadataChangeEvent
-record FailedMetadataChangeEvent {
+record FailedMCE_@(eventSpec.getShortTyperefName()) {
 
   /**
-   * Kafka event for capturing a failure to process a MetadataChangeEvent.
+   * Kafka audit header. See go/kafkaauditheader for more info.
    */
   auditHeader: optional KafkaAuditHeader
 
   /**
    * The event that failed to be processed.
    */
-  metadataChangeEvent: MetadataChangeEvent
+  metadataChangeEvent: MCE_@(eventSpec.getShortTyperefName())
 
   /**
    * The error message or the stacktrace for the failure.
    */
   error: string
+
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -1,16 +1,15 @@
-@import com.linkedin.metadata.generator.EventSpec;
+@import com.linkedin.metadata.generator.SingleAspectEventSpec;
 @import com.linkedin.metadata.generator.SchemaGeneratorUtil;
-@args String entityUrn, String nameSpace EventSpec eventSpec
-@assign (entityName) {@SchemaGeneratorUtil.getEntityName(entityUrn)}
-namespace com.linkedin.mxe@(nameSpace)
+@args SingleAspectEventSpec eventSpec
+namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
-import @entityUrn
+import @eventSpec.getUrnType()
 import @eventSpec.getFullValueType()
 
 /**
- * MetadataAuditEvent for the @(entityName)Urn with @(eventSpec.getValueType()) aspect.
+ * MetadataAuditEvent for the @(eventSpec.getShortUrn()) with @(eventSpec.getShortValueType()) aspect.
  */
 @@MetadataAuditEvent
 record MetadataAuditEvent {
@@ -21,19 +20,19 @@ record MetadataAuditEvent {
   auditHeader: optional KafkaAuditHeader
 
   /**
-   * @(entityName)Urn as the key for the MetadataAuditEvent.
+   * @(eventSpec.getShortUrn()) as the key for the MetadataAuditEvent.
    */
-  urn: @(entityName)Urn
+  urn: @(eventSpec.getShortUrn())
 
   /**
-   * Aspect of the @eventSpec.getValueType() before the update.
+   * Aspect of the @eventSpec.getShortValueType() before the update.
    */
-  oldValue: optional @eventSpec.getValueType()
+  oldValue: optional @eventSpec.getShortValueType()
 
   /**
-   * Aspect of the @eventSpec.getValueType() after the update.
+   * Aspect of the @eventSpec.getShortValueType() after the update.
    */
-  newValue: @eventSpec.getValueType()
+  newValue: @eventSpec.getShortValueType()
 
   /**
    * Change type.

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
@@ -1,16 +1,15 @@
-@import com.linkedin.metadata.generator.EventSpec;
+@import com.linkedin.metadata.generator.SingleAspectEventSpec;
 @import com.linkedin.metadata.generator.SchemaGeneratorUtil;
-@args String entityUrn, String nameSpace EventSpec eventSpec
-@assign (entityName) {@SchemaGeneratorUtil.getEntityName(entityUrn)}
-namespace com.linkedin.mxe@(nameSpace)
+@args SingleAspectEventSpec eventSpec
+namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
-import @entityUrn
+import @eventSpec.getUrnType()
 import @eventSpec.getFullValueType()
 
 /**
- * MetadataChangeEvent for the @(entityName)Urn with @(eventSpec.getValueType()) aspect.
+ * MetadataChangeEvent for the @(eventSpec.getShortUrn()) with @(eventSpec.getShortValueType()) aspect.
  */
 @@MetadataChangeEvent
 record MetadataChangeEvent {
@@ -21,14 +20,14 @@ record MetadataChangeEvent {
   auditHeader: optional KafkaAuditHeader
 
   /**
-   * @(entityName)Urn as the key for the MetadataChangeEvent.
+   * @(eventSpec.getShortUrn()) as the key for the MetadataChangeEvent.
    */
-  urn: @(entityName)Urn
+  urn: @(eventSpec.getShortUrn())
 
   /**
-   * Value of the proposed @eventSpec.getValueType() change.
+   * Value of the proposed @eventSpec.getShortValueType() change.
    */
-  proposedValue: optional @eventSpec.getValueType()
+  proposedValue: optional @eventSpec.getShortValueType()
 
   /**
    * Change type.

--- a/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
@@ -72,7 +72,7 @@ public class TestEventSchemaComposer {
     DataSchemaParser.ParseResult result = outputParser.parseSources(new String[]{outputDir.getPath()});
 
     Set<String> outputs = result.getSchemaAndLocations().keySet().stream().filter(schema -> schema.getType() == DataSchema.Type.RECORD)
-            .map(s -> (RecordDataSchema)s).map(RecordDataSchema::getFullName).collect(Collectors.toSet());
+            .map(s -> (RecordDataSchema) s).map(RecordDataSchema::getFullName).collect(Collectors.toSet());
     assertThat(outputs).contains(
             "com.linkedin.testing.mxe.bar.annotatedAspectBar.MetadataChangeEvent",
             "com.linkedin.testing.mxe.bar.annotatedAspectBar.FailedMetadataChangeEvent",
@@ -86,7 +86,7 @@ public class TestEventSchemaComposer {
     File outputPath = baseOutputDir.toPath().resolve(relativeFilePath.toPath()).toFile();
     assertThat(outputPath).exists();
 
-    try(InputStream expected = this.getClass().getClassLoader().getResourceAsStream(relativeFilePath.toString());
+    try (InputStream expected = this.getClass().getClassLoader().getResourceAsStream(relativeFilePath.toString());
         InputStream actual = FileUtils.openInputStream(outputPath)) {
       assertThat(expected).hasSameContentAs(actual);
     }

--- a/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
@@ -77,8 +77,8 @@ public class TestEventSchemaComposer {
             "com.linkedin.testing.mxe.bar.annotatedAspectBar.MetadataChangeEvent",
             "com.linkedin.testing.mxe.bar.annotatedAspectBar.FailedMetadataChangeEvent",
             "com.linkedin.testing.mxe.bar.annotatedAspectBar.MetadataAuditEvent",
-            "com.linkedin.testing.mxe.bar.MCE_BarAspect",
-            "com.linkedin.testing.mxe.bar.FailedMCE_BarAspect"
+            "com.linkedin.testing.mxe.bar.MCEBarAspect",
+            "com.linkedin.testing.mxe.bar.FailedMCEBarAspect"
     );
   }
 
@@ -112,7 +112,7 @@ public class TestEventSchemaComposer {
 
   @Test
   public void testUnionSchemaRender() throws Exception {
-    assertSame(outputDir, new File("com/linkedin/testing/mxe/bar/MCE_BarAspect.pdl"));
-    assertSame(outputDir, new File("com/linkedin/testing/mxe/bar/FailedMCE_BarAspect.pdl"));
+    assertSame(outputDir, new File("com/linkedin/testing/mxe/bar/MCEBarAspect.pdl"));
+    assertSame(outputDir, new File("com/linkedin/testing/mxe/bar/FailedMCEBarAspect.pdl"));
   }
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSpec.java
@@ -36,11 +36,13 @@ public class TestEventSpec {
     assertThat(eventSpecMap.asMap()).containsOnlyKeys("com.linkedin.testing.FooUrn", "com.linkedin.testing.BarUrn");
     assertThat(eventSpecMap.get("com.linkedin.testing.FooUrn")
         .stream()
-        .map(EventSpec::getValueType)
+        .map(s -> (SingleAspectEventSpec)s)
+        .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("AnnotatedAspectFoo", "AnnotatedAspectOtherFoo");
     assertThat(eventSpecMap.get("com.linkedin.testing.BarUrn")
         .stream()
-        .map(EventSpec::getValueType)
+        .map(s -> (SingleAspectEventSpec)s)
+        .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("AnnotatedAspectBar");
   }
 
@@ -51,7 +53,7 @@ public class TestEventSpec {
         inputDir.toPath().resolve("com/linkedin/testing/CommonAspect.pdl").toFile());
 
     final SchemaAnnotationRetriever schemaAnnotationRetriever =
-        new SchemaAnnotationRetriever(inputDir.toString(), new AlwaysAllowList());
+        new SchemaAnnotationRetriever(inputDir.toString(), new AlwaysAllowList(), null);
     final String[] sources = {inputDir.toString()};
     final List<EventSpec> eventSpecs = schemaAnnotationRetriever.generate(sources);
 
@@ -60,16 +62,18 @@ public class TestEventSpec {
     assertThat(eventSpecMap.asMap()).containsOnlyKeys("com.linkedin.testing.FooUrn", "com.linkedin.testing.BarUrn");
     assertThat(eventSpecMap.get("com.linkedin.testing.FooUrn")
         .stream()
-        .map(EventSpec::getValueType)
+        .map(s -> (SingleAspectEventSpec)s)
+        .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("CommonAspect");
     assertThat(eventSpecMap.get("com.linkedin.testing.BarUrn")
         .stream()
-        .map(EventSpec::getValueType)
+        .map(s -> (SingleAspectEventSpec)s)
+        .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("CommonAspect");
   }
 
   @Nonnull
   private Multimap<String, EventSpec> mapAspectToUrn(@Nonnull List<EventSpec> eventSpecs) {
-    return Multimaps.index(eventSpecs, EventSpec::getUrn);
+    return Multimaps.index(eventSpecs, spec -> spec.getUrnType());
   }
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSpec.java
@@ -36,12 +36,12 @@ public class TestEventSpec {
     assertThat(eventSpecMap.asMap()).containsOnlyKeys("com.linkedin.testing.FooUrn", "com.linkedin.testing.BarUrn");
     assertThat(eventSpecMap.get("com.linkedin.testing.FooUrn")
         .stream()
-        .map(s -> (SingleAspectEventSpec)s)
+        .map(s -> (SingleAspectEventSpec) s)
         .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("AnnotatedAspectFoo", "AnnotatedAspectOtherFoo");
     assertThat(eventSpecMap.get("com.linkedin.testing.BarUrn")
         .stream()
-        .map(s -> (SingleAspectEventSpec)s)
+        .map(s -> (SingleAspectEventSpec) s)
         .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("AnnotatedAspectBar");
   }
@@ -62,12 +62,12 @@ public class TestEventSpec {
     assertThat(eventSpecMap.asMap()).containsOnlyKeys("com.linkedin.testing.FooUrn", "com.linkedin.testing.BarUrn");
     assertThat(eventSpecMap.get("com.linkedin.testing.FooUrn")
         .stream()
-        .map(s -> (SingleAspectEventSpec)s)
+        .map(s -> (SingleAspectEventSpec) s)
         .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("CommonAspect");
     assertThat(eventSpecMap.get("com.linkedin.testing.BarUrn")
         .stream()
-        .map(s -> (SingleAspectEventSpec)s)
+        .map(s -> (SingleAspectEventSpec) s)
         .map(SingleAspectEventSpec::getShortValueType)
         .collect(Collectors.toList())).contains("CommonAspect");
   }

--- a/gradle-plugins/metadata-events-generator-plugin/build.gradle
+++ b/gradle-plugins/metadata-events-generator-plugin/build.gradle
@@ -19,6 +19,9 @@ dependencies {
   testImplementation externalDependency.junitJupiterApi
   testCompile externalDependency.junitVintageEngine
 
+  testCompile project(':core-models')
+  testCompile project(':dao-api')
+
   testProjectCompile  project(path: ':testing:test-models', configuration: 'dataTemplate')
 }
 


### PR DESCRIPTION
…ain multiple aspect types for the same URN.

Changes:
- Add a feature to metadata-events-generator-lib that can take a `typeref ... = union [...]` PDL schema annotated with `@gma.aspect.entity` and create an MCE (and associated FailedMCE) that allows for sending any combination of aspects in the union for a single URN in a single event.
- Refactor `EventSpec` and `EventSchemaComposer` to allow for easier extension. `EventSpec` now contains rendering infrastructure so different spec types can generate different rendering behaviors. Created `SingleAspectEventSpec` with the existing behavior and created a new `AspectUnionEventSpec` to render events for Aspect Union events.
- Expand `EventSchemaComposer` tests to verify that the events generated are in fact parseable by the Pegasus engine.
- Move reference test events in `metadata-events-generator-lib` to `metadata-annotations-test-models` so we can verify that they are parseable, transformable to Avro, and we can write basic unit tests on the output events.
- No change in this PR is expected to produce incompatibilities.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
