### PR TITLE
feat: support of Tracking Context in MXE.

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseTrackingContext.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseTrackingContext.pdl
@@ -3,9 +3,9 @@ namespace com.linkedin.metadata.events
 import com.linkedin.avro2pegasus.events.UUID
 
 /**
- * Descriptor for the tracking context. To represent the lifecycle of the trackable item.
+ *  Base model to capture tracking context and represent the lifecycle of the trackable item.
  */
-record TrackingContext {
+record BaseTrackingContext {
 
   /**
    * A UUID of a trackable item. This UUID should be propagated in all events referencing the trackable item.

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/IngestionTrackingContext.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/IngestionTrackingContext.pdl
@@ -1,0 +1,17 @@
+namespace com.linkedin.metadata.events
+
+/**
+ * Descriptor for the ingestion tracking context. To represent the lifecycle of the trackable ingestion item.
+ */
+record IngestionTrackingContext includes BaseTrackingContext{
+
+  /**
+   * The name of the service from which the ingestion event is being emitted.
+   */
+  emitter: optional string
+
+  /**
+   * The time at which the ingestion event was emitted into kafka.
+   */
+  emitTime: optional long
+}

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/IngestionTrackingContext.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/IngestionTrackingContext.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.metadata.events
 /**
  * Descriptor for the ingestion tracking context. To represent the lifecycle of the trackable ingestion item.
  */
-record IngestionTrackingContext includes BaseTrackingContext{
+record IngestionTrackingContext includes BaseTrackingContext {
 
   /**
    * The name of the service from which the ingestion event is being emitted.

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/TrackingContext.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/TrackingContext.pdl
@@ -1,0 +1,14 @@
+namespace com.linkedin.metadata.events
+
+import com.linkedin.avro2pegasus.events.UUID
+
+/**
+ * Descriptor for the tracking context. To represent the lifecycle of the trackable item.
+ */
+record TrackingContext {
+
+  /**
+   * A UUID of a trackable item. This UUID should be propagated in all events referencing the trackable item.
+   */
+  trackingId: optional UUID
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
@@ -30,13 +30,15 @@ record MCEBarAspect {
     record ProposedAnnotatedAspectBar {
       proposed: optional AnnotatedAspectBar
       changeType: ChangeType = "UPSERT"
-      ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
     }
     record ProposedAnotherAspectBar {
       proposed: optional AnotherAspectBar
       changeType: ChangeType = "UPSERT"
-      ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
     }
   ]]
 
+  /**
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
+   */
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
 }

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.testing.mxe.bar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
+import com.linkedin.metadata.events.IngestionTrackingContext
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 import com.linkedin.testing.AnotherAspectBar
@@ -29,10 +30,12 @@ record MCEBarAspect {
     record ProposedAnnotatedAspectBar {
       proposed: optional AnnotatedAspectBar
       changeType: ChangeType = "UPSERT"
+      ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
     }
     record ProposedAnotherAspectBar {
       proposed: optional AnotherAspectBar
       changeType: ChangeType = "UPSERT"
+      ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
     }
   ]]
 

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -2,7 +2,7 @@ namespace com.linkedin.testing.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
-import com.linkedin.metadata.events.TrackingContext
+import com.linkedin.metadata.events.IngestionTrackingContext
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 
@@ -38,7 +38,7 @@ record MetadataAuditEvent {
   changeType: optional union[null, ChangeType] = null
 
   /**
-   * Tracking context to identify the lifecycle of the trackable item.
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
    */
-  trackingContext: optional union[null, TrackingContext] = null
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
 }

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.testing.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
+import com.linkedin.metadata.events.TrackingContext
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 
@@ -35,4 +36,9 @@ record MetadataAuditEvent {
    * Change type.
    */
   changeType: optional union[null, ChangeType] = null
+
+  /**
+   * Tracking context to identify the lifecycle of the trackable item.
+   */
+  trackingContext: optional union[null, TrackingContext] = null
 }

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataChangeEvent.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.testing.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
+import com.linkedin.metadata.events.IngestionTrackingContext
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 
@@ -30,4 +31,9 @@ record MetadataChangeEvent {
    * Change type.
    */
   changeType: optional union[null, ChangeType] = null
+
+  /**
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
+   */
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
@@ -35,9 +35,12 @@ record MCE@(eventSpec.getShortTyperefName()) {
     record Proposed@(SchemaGeneratorUtil.stripNamespace(valueType)) {
       proposed: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
       changeType: ChangeType = "UPSERT"
-      ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
     }
   }
   ]]
 
+  /**
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
+   */
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
@@ -5,6 +5,7 @@ namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
+import com.linkedin.metadata.events.IngestionTrackingContext
 import @eventSpec.getUrnType()
 @for (String valueType: eventSpec.getValueTypes()) {
 import @valueType
@@ -34,6 +35,7 @@ record MCE@(eventSpec.getShortTyperefName()) {
     record Proposed@(SchemaGeneratorUtil.stripNamespace(valueType)) {
       proposed: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
       changeType: ChangeType = "UPSERT"
+      ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
     }
   }
   ]]

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -5,7 +5,7 @@ namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
-import com.linkedin.metadata.events.TrackingContext
+import com.linkedin.metadata.events.IngestionTrackingContext
 import @eventSpec.getUrnType()
 import @eventSpec.getFullValueType()
 
@@ -41,7 +41,7 @@ record MetadataAuditEvent {
   changeType: optional union[null, ChangeType] = null
 
   /**
-   * Tracking context to identify the lifecycle of the trackable item.
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
    */
-  trackingContext: optional union[null, TrackingContext] = null
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -5,6 +5,7 @@ namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
+import com.linkedin.metadata.events.TrackingContext
 import @eventSpec.getUrnType()
 import @eventSpec.getFullValueType()
 
@@ -38,4 +39,9 @@ record MetadataAuditEvent {
    * Change type.
    */
   changeType: optional union[null, ChangeType] = null
+
+  /**
+   * Tracking context to identify the lifecycle of the trackable item.
+   */
+  trackingContext: optional union[null, TrackingContext] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataChangeEvent.rythm
@@ -5,6 +5,7 @@ namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
 import com.linkedin.metadata.events.ChangeType
+import com.linkedin.metadata.events.IngestionTrackingContext
 import @eventSpec.getUrnType()
 import @eventSpec.getFullValueType()
 
@@ -33,4 +34,9 @@ record MetadataChangeEvent {
    * Change type.
    */
   changeType: optional union[null, ChangeType] = null
+
+  /**
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
+   */
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
 }

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -130,7 +130,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
       import com.linkedin.metadata.events.ChangeType
-      import com.linkedin.metadata.events.TrackingContext
+      import com.linkedin.metadata.events.IngestionTrackingContext
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestAspect
 
@@ -166,9 +166,9 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         changeType: optional union[null, ChangeType] = null
         
         /**
-         * Tracking context to identify the lifecycle of the trackable item.
+         * Tracking context to identify the lifecycle of the trackable ingestion item.
          */
-        trackingContext: optional union[null, TrackingContext] = null
+        ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testAspect/FailedMetadataChangeEvent.pdl').text == '''\
@@ -238,7 +238,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
       import com.linkedin.metadata.events.ChangeType
-      import com.linkedin.metadata.events.TrackingContext
+      import com.linkedin.metadata.events.IngestionTrackingContext
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestTyperefAspect
 
@@ -274,9 +274,9 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         changeType: optional union[null, ChangeType] = null
         
         /**
-         * Tracking context to identify the lifecycle of the trackable item.
+         * Tracking context to identify the lifecycle of the trackable ingestion item.
          */
-        trackingContext: optional union[null, TrackingContext] = null
+        ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testTyperefAspect/FailedMetadataChangeEvent.pdl').text == '''\

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -130,6 +130,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
       import com.linkedin.metadata.events.ChangeType
+      import com.linkedin.metadata.events.TrackingContext
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestAspect
 
@@ -163,6 +164,11 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
          * Change type.
          */
         changeType: optional union[null, ChangeType] = null
+        
+        /**
+         * Tracking context to identify the lifecycle of the trackable item.
+         */
+        trackingContext: optional union[null, TrackingContext] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testAspect/FailedMetadataChangeEvent.pdl').text == '''\
@@ -232,6 +238,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
       import com.linkedin.metadata.events.ChangeType
+      import com.linkedin.metadata.events.TrackingContext
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestTyperefAspect
 
@@ -265,6 +272,11 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
          * Change type.
          */
         changeType: optional union[null, ChangeType] = null
+        
+        /**
+         * Tracking context to identify the lifecycle of the trackable item.
+         */
+        trackingContext: optional union[null, TrackingContext] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testTyperefAspect/FailedMetadataChangeEvent.pdl').text == '''\

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -95,6 +95,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
       import com.linkedin.metadata.events.ChangeType
+      import com.linkedin.metadata.events.IngestionTrackingContext
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestAspect
 
@@ -123,6 +124,11 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
          * Change type.
          */
         changeType: optional union[null, ChangeType] = null
+
+        /**
+         * Tracking context to identify the lifecycle of the trackable ingestion item.
+         */
+        ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testAspect/MetadataAuditEvent.pdl').text == '''\
@@ -203,6 +209,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
       import com.linkedin.metadata.events.ChangeType
+      import com.linkedin.metadata.events.IngestionTrackingContext
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestTyperefAspect
 
@@ -231,6 +238,11 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
          * Change type.
          */
         changeType: optional union[null, ChangeType] = null
+        
+        /**
+         * Tracking context to identify the lifecycle of the trackable ingestion item.
+         */
+        ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testTyperefAspect/MetadataAuditEvent.pdl').text == '''\


### PR DESCRIPTION
## Checklist
- This adds support for tracking context in MXE as the interface to propagate the tracking information for identifying the request lifecycle.
- Adding a new field is backward compatible if a default value is provided. The reader will substitute that default for missing data in records written with an older schema. At LinkedIn, we require that this new field is of a type that contains a union with null and that null be the default to allow readers to identify clearly records where the data is missing.
- Place the model in the dao-api module as it is event-specific.




- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
