### PR TITLE
Add toggle-able logic for job-gms record retrieval

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ project.ext.externalDependency = [
     'lombokAnnotationProcessor': 'org.projectlombok:lombok:1.18.22',
     'maria4j': 'ch.vorburger.mariaDB4j:mariaDB4j:2.5.3',
     'mockito': 'org.mockito:mockito-core:3.0.0',
-    'mockitoInline': 'org.mockito:mockito-inline:3.0.0',
+    'mockitoInline': 'org.mockito:mockito-inline:3.11.2',
     'mysql': 'mysql:mysql-connector-java:8.0.29',
     'neo4jHarness': 'org.neo4j.test:neo4j-harness:3.4.11',
     'neo4jJavaDriver': 'org.neo4j.driver:neo4j-java-driver:4.0.0',

--- a/dao-impl/ebean-dao/build.gradle
+++ b/dao-impl/ebean-dao/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   testCompile externalDependency.mysql
   testCompile externalDependency.h2
   testCompile externalDependency.mockito
+  testCompile externalDependency.mockitoInline
   testCompile externalDependency.maria4j
   enhance externalDependency.ebeanAgent
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -402,8 +402,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Toggle using direct SQL query through Ebean when retrieving + checking existing records during insertion
-   * See GCN-38382
+   * Toggle using direct SQL query through Ebean when retrieving + checking existing records during insertion.
+   * See GCN-38382.
    */
   public void useDirectSqlQuery() {
     _directSqlRetrieval = true;
@@ -411,8 +411,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Toggle using Ebean's find() query builder when retrieving + checking existing records during insertion
-   * See GCN-38382
+   * Toggle using Ebean's find() query builder when retrieving + checking existing records during insertion.
+   * See GCN-38382.
    */
   public void useEbeanFindBuild() {
     _ebeanFindBuilder = true;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -402,7 +402,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Toggle using direct SQL query through Ebean when retrieving + checking existing records during insertion.
+   * Toggle using direct SQL query through Ebean's .findNative() when retrieving + checking existing records during insertion.
    * See GCN-38382.
    */
   public void useDirectSqlQuery() {
@@ -426,7 +426,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       return _server.find(EbeanMetadataAspect.class, key);
     }
 
-    List<EbeanMetadataAspect> results = null;
+    List<EbeanMetadataAspect> results = Collections.emptyList();
   
     if (_directSqlRetrieval) {
       final String selectQuery = "SELECT * FROM metadata_aspect "
@@ -439,6 +439,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .findList();
     }
     
+    // TODO (@jphui): if directSqlRetrieval pathway ^ works, remove this
     if (_ebeanFindBuilder) {
       results = _server.find(EbeanMetadataAspect.class)
         .where()

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -581,7 +581,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       // the metadata entity tables shouldn't been updated.
       _localAccess.add(urn, (ASPECT) value, aspectClass, auditStamp);
     }
-    
+
     _server.insert(aspect);
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -420,9 +420,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   private  <ASPECT extends RecordTemplate> EbeanMetadataAspect queryLatest(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass) {
-    final PrimaryKey key = new PrimaryKey(urn.toString(), ModelUtils.getAspectName(aspectClass), 0L);
-
     if (!_directSqlRetrieval && !_ebeanFindBuilder) {
+      final PrimaryKey key = new PrimaryKey(urn.toString(), ModelUtils.getAspectName(aspectClass), 0L);
       return _server.find(EbeanMetadataAspect.class, key);
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -401,11 +401,19 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }, 1);
   }
 
+  /**
+   * Toggle using direct SQL query through Ebean when retrieving + checking existing records during insertion
+   * See GCN-38382
+   */
   public void useDirectSqlQuery() {
     _directSqlRetrieval = true;
     _ebeanFindBuilder = false;
   }
 
+  /**
+   * Toggle using Ebean's find() query builder when retrieving + checking existing records during insertion
+   * See GCN-38382
+   */
   public void useEbeanFindBuild() {
     _ebeanFindBuilder = true;
     _directSqlRetrieval = false;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -581,6 +581,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       // the metadata entity tables shouldn't been updated.
       _localAccess.add(urn, (ASPECT) value, aspectClass, auditStamp);
     }
+    
     _server.insert(aspect);
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -418,7 +418,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   private  <ASPECT extends RecordTemplate> EbeanMetadataAspect queryLatest(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass) {
     final PrimaryKey key = new PrimaryKey(urn.toString(), ModelUtils.getAspectName(aspectClass), 0L);
 
-    if (_directSqlRetrieval) {
+    if (!_directSqlRetrieval) {
       return _server.find(EbeanMetadataAspect.class, key);
     } else {
       final String selectQuery = "SELECT * FROM metadata_aspect "

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -58,7 +58,10 @@ import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.EbeanServerFactory;
+import io.ebean.ExpressionList;
+import io.ebean.OrderBy;
 import io.ebean.PagedList;
+import io.ebean.Query;
 import io.ebean.SqlRow;
 import io.ebean.Transaction;
 import java.io.IOException;
@@ -350,6 +353,7 @@ public class EbeanLocalDAOTest {
       when(server.beginTransaction()).thenReturn(mockTransaction);
       when(server.find(any(), any())).thenReturn(null);
       doThrow(RollbackException.class).doNothing().when(server).insert(any(EbeanMetadataAspect.class));
+
       EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(server, FooUrn.class);
       when(server.find(any(), any())).thenReturn(null);
       dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
@@ -364,6 +368,7 @@ public class EbeanLocalDAOTest {
     when(server.find(any(), any())).thenReturn(null);
     doThrow(RollbackException.class).when(server).insert(any(EbeanMetadataAspect.class));
     doThrow(RollbackException.class).when(server).createSqlUpdate(any());
+
     EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(server, FooUrn.class);
     dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
   }
@@ -3060,7 +3065,7 @@ public class EbeanLocalDAOTest {
 
   private void addMetadata(Urn urn, String aspectName, long version, @Nullable RecordTemplate metadata) {
     EbeanMetadataAspect aspect = getMetadata(urn, aspectName, version, metadata);
-    _server.save(aspect);
+    _server.insert(aspect);
   }
 
   private void addMetadataWithAuditStamp(Urn urn, String aspectName, long version, RecordTemplate metadata,

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -122,9 +122,9 @@ public class EbeanLocalDAOTest {
   private final FindMethodology _findMethodology;
 
   private static enum FindMethodology {
-    ORIGINAL,
-    DIRECT_SQL,
-    QUERY_BUILDER
+    UNIQUE_ID,      // https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/EbeanServer.html#find-java.lang.Class-java.lang.Object-
+    DIRECT_SQL,     // https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/EbeanServer.html#findNative-java.lang.Class-java.lang.String-
+    QUERY_BUILDER   // https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/Ebean.html#find-java.lang.Class-
   }
 
   @Factory(dataProvider = "inputList")
@@ -145,13 +145,13 @@ public class EbeanLocalDAOTest {
   @DataProvider
   public static Object[][] inputList() {
     return new Object[][]{
-        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.ORIGINAL},
+        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.UNIQUE_ID},
         {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.DIRECT_SQL},
         {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.QUERY_BUILDER},
-        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.ORIGINAL},
+        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.UNIQUE_ID},
         {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.DIRECT_SQL},
         {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.QUERY_BUILDER},
-        {SchemaConfig.DUAL_SCHEMA, FindMethodology.ORIGINAL},
+        {SchemaConfig.DUAL_SCHEMA, FindMethodology.UNIQUE_ID},
         {SchemaConfig.DUAL_SCHEMA, FindMethodology.DIRECT_SQL},
         {SchemaConfig.DUAL_SCHEMA, FindMethodology.QUERY_BUILDER}
     };

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -186,7 +186,6 @@ public class EbeanLocalDAOTest {
     if (urnClass == BarUrn.class) {
       dao.setUrnPathExtractor((UrnPathExtractor<URN>) new BarUrnPathExtractor());
     }
-
     return dao;
   }
 
@@ -390,7 +389,7 @@ public class EbeanLocalDAOTest {
       dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
     }
   }
-  
+
   @Test(expectedExceptions = RetryLimitReached.class)
   public void testAddFailedAfterRetry() {
     EbeanServer server = mock(EbeanServer.class);


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))

"""
`<feat>[getLatest()]: add support to use two alternative methods for checking record existence during record insertion`

Based off of logs introduced in a previous changeset, there is good reason to believe that `Ebean's EbeanServer.find(Class, Object)` method does not work accurately at scale, returning no matching existing records when it is clear that such a record exists. This appears to be the cause of mass duplicity introduced into the database. Luckily, Ebean has several ways to accomplish a task such as checking record existence, so this changeset attempts to leverage two of these in attempt to stop further duplicates from being introduced.

Might introduce breaking change in future if either (or both) of the alternative pathways is removed after adoption.
"""

- [x] Related issues linked
- [x] Tests for the changes have been added/updated (if applicable)
    - Added unit testing to cover all existing tests (which make use of EbeanLocalDAO's .find() ) but with each of retrieval mechanisms
- [x] Docs related to the changes have been added/updated (if applicable)