### PR TITLE
(feat) generic aspect routing support

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseGenericAspectRoutingGmsClient.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseGenericAspectRoutingGmsClient.java
@@ -5,28 +5,25 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.restli.server.RestLiServiceException;
 import java.util.Set;
 
-
 /**
- * Deprecated, using {@link BaseGenericAspectRoutingGmsClient} instead.
  * <p>
  * A client interacts with standard GMS APIs.
  * </p>
  */
-@Deprecated
-public abstract class BaseAspectRoutingGmsClient<ASPECT extends RecordTemplate> {
+public abstract class BaseGenericAspectRoutingGmsClient {
 
   /**
    * Retrieves the latest version of the routing aspect for an entity.
    */
-  public abstract <URN extends Urn> ASPECT get(URN urn) throws RestLiServiceException;
+  public abstract <URN extends Urn> RecordTemplate get(URN urn, Class routingAspectClass) throws RestLiServiceException;
 
   /**
    * Backfill the routing aspect value for a given set of entity identified by the urns.
    */
-  public abstract <URN extends Urn> BackfillResult backfill(Set<URN> urn) throws RestLiServiceException;
+  public abstract <URN extends Urn> BackfillResult backfill(Set<URN> urn, Class routingAspectClass) throws RestLiServiceException;
 
   /**
    * Ingests the latest version of the routing aspect for an entity.
    */
-  public abstract <URN extends Urn> void ingest(URN urn, ASPECT aspect) throws RestLiServiceException;
+  public abstract <URN extends Urn> void ingest(URN urn, RecordTemplate aspect) throws RestLiServiceException;
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -58,7 +58,8 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     public TestResource() {
       // super(EntitySnapshot.class, EntityAspectUnion.class, AspectFoo.class, EntityValue.class);
-      super(EntitySnapshot.class, EntityAspectUnion.class, new HashSet<>(Arrays.asList(AspectFoo.class, AspectAttributes.class)), EntityValue.class);
+      super(EntitySnapshot.class, EntityAspectUnion.class,
+          ImmutableMap.of(AspectFoo.class, "setFoo", AspectAttributes.class, "setAttributes"), EntityValue.class);
     }
 
     @Nonnull

--- a/restli-resources/src/test/pegasus/com/linkedin/testing/Aspect.pdl
+++ b/restli-resources/src/test/pegasus/com/linkedin/testing/Aspect.pdl
@@ -3,4 +3,4 @@ namespace com.linkedin.testing
 /**
  * For unit tests
  */
-typeref Aspect = union[AspectFoo, AspectBar]
+typeref Aspect = union[AspectFoo, AspectBar, AspectAttributes]

--- a/restli-resources/src/test/pegasus/com/linkedin/testing/AspectAttributes.pdl
+++ b/restli-resources/src/test/pegasus/com/linkedin/testing/AspectAttributes.pdl
@@ -1,0 +1,13 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+@gma.aspect.column.name = "aspectattributes"
+record AspectAttributes {
+
+  /**
+   * For unit tests
+   */
+  attributes: array[string]
+}

--- a/restli-resources/src/test/pegasus/com/linkedin/testing/Value.pdl
+++ b/restli-resources/src/test/pegasus/com/linkedin/testing/Value.pdl
@@ -14,4 +14,9 @@ record Value {
    * For unit tests
    */
   bar: optional AspectBar
+
+  /**
+   * For unit tests
+   */
+  attributes: optional AspectAttributes
 }


### PR DESCRIPTION
## Context
This PR is to add support for more than one aspect routing per entity resource. Prior to this enhancement, we only allow one aspect  being routed to a different GMS service per entity. After this enhancement, we will allow multiple aspects being routed to other GMS services for better scale.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
