### PR TITLE
feat: Create a base ingestion failure model.

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionFailureModel.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionFailureModel.pdl
@@ -26,9 +26,9 @@ record BaseIngestionFailureModel {
   service: string
 
   /**
-   * Detailed error message.
+   * Detailed error message. Make it optional considering kafka message payload size limit.
    */
-  errorMessage: string
+  errorMessage: optional string
 
   /**
    * Error type.

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionFailureModel.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionFailureModel.pdl
@@ -8,10 +8,12 @@ record BaseIngestionFailureModel {
   /**
    * The ingestion tracking context from the original ingestion event.
    */
-  ingestionTrackingContext: optional IngestionTrackingContext
+  ingestionTrackingContext: IngestionTrackingContext
 
   /**
    * The ingestion record that represents the metadata change in the original ingestion event.
+   * For example, it can be the string representation of a GenericRecord, which is the input for ingestion in stream
+   * layer; it can also be the string representation of a RecordTemplate, which is the input for ingestion in gms layer.
    */
   ingestionRecord: string
 
@@ -21,9 +23,10 @@ record BaseIngestionFailureModel {
   urn: optional string
 
   /**
-   * service where the ingestion failure happens.
+   * the location where the ingestion failure happens. For example, it can be a stream service called "mce-v5-consumer-job".
+   * It can also be a generic name like "gms" to represent failures in gms layer.
    */
-  service: string
+  location: string
 
   /**
    * Detailed error message. Make it optional considering kafka message payload size limit.
@@ -31,7 +34,7 @@ record BaseIngestionFailureModel {
   errorMessage: optional string
 
   /**
-   * Error type.
+   * Error type. The number of possible error types is not limited, so we use string instead of enum.
    */
   errorType: string
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionFailureModel.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionFailureModel.pdl
@@ -1,0 +1,37 @@
+namespace com.linkedin.metadata.events
+
+/**
+ * The base model used to represent an ingestion failure in GMA.
+ */
+record BaseIngestionFailureModel {
+
+  /**
+   * The ingestion tracking context from the original ingestion event.
+   */
+  ingestionTrackingContext: optional IngestionTrackingContext
+
+  /**
+   * The ingestion record that represents the metadata change in the original ingestion event.
+   */
+  ingestionRecord: string
+
+  /**
+   * The urn in the ingestion event.
+   */
+  urn: optional string
+
+  /**
+   * service where the ingestion failure happens.
+   */
+  service: string
+
+  /**
+   * Detailed error message.
+   */
+  errorMessage: string
+
+  /**
+   * Error type.
+   */
+  errorType: string
+}


### PR DESCRIPTION
## Description
- this pr is to create a base model that can be used as the dead letter queue schema in metadata ingestion pipeline. The pipeline will share a single queue
- this model should be able to help user locate failures with what, when, where, why and whom

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
