### PR TITLE
Refactor logging, introduce JDBC

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -453,7 +453,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     // TODO(@jphui) added for job-gms duplicity debug, throwaway afterwards
 
     // JDBC sanity check: should MATCH Ebean's results
-    if (log.isDebugEnabled() && "com.linkedin.dataJob.azkaban.AzkabanFlowInfo".equals(aspectName)) { 
+    if (log.isDebugEnabled() && "AzkabanFlowInfo".equals(aspectClass.getSimpleName())) { 
       final String sqlQuery = "SELECT * FROM metadata_aspect "
           + "WHERE urn = ? and aspect = ? and version = 0";
         
@@ -502,7 +502,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     results = query.findList();
 
     // Encouraged to run AFTER query execution based on getGeneratedSql() documentation
-    if (log.isDebugEnabled() && "com.linkedin.dataJob.azkaban.AzkabanFlowInfo".equals(aspectName)) {
+    if (log.isDebugEnabled() && "AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
       log.debug("Using {} retrieval; " + "Generated SQL: {}; urn: {}, aspect: {}, version: {}",
           _findMethodology.toString(),
           query.getGeneratedSql(),

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -595,13 +595,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     update.setParameter("createdBy", aspect.getCreatedBy());
     update.setParameter("oldTimestamp", oldTimestamp);
 
-    // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
-    if (log.isDebugEnabled()) {
-      if ("AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
-        log.debug("updateWithOptimisticLocking SQL: " + update.getGeneratedSql());
-      }
-    }
-
     int numOfUpdatedRows;
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY || _schemaConfig == SchemaConfig.DUAL_SCHEMA) {
       // ensure atomicity by running old schema update + new schema update in a transaction

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -502,7 +502,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     
     if (log.isDebugEnabled()) {
       if ("AzkabanFlowInfo".equals(aspectName)) {
-        log.debug("Using {} retrieval; " + "Generated SQL: {}", _findMethodology.toString() , query.getGeneratedSql());
+        log.debug("Using {} retrieval; " + "Generated SQL: {}", _findMethodology.toString(), query.getGeneratedSql());
       }
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -38,6 +38,7 @@ import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.ExpressionList;
 import io.ebean.PagedList;
+import io.ebean.PersistenceContextScope;
 import io.ebean.Query;
 import io.ebean.SqlUpdate;
 import io.ebean.Transaction;
@@ -509,7 +510,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         );
     }
 
-    results = query.findList();
+    // disable L1 caching, then execute
+    results = query.setPersistenceContextScope(PersistenceContextScope.QUERY).findList();
 
     if (results.isEmpty()) {
       return null;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -34,6 +34,7 @@ import com.linkedin.metadata.query.IndexValue;
 import com.linkedin.metadata.query.ListResultMetadata;
 import com.linkedin.metadata.query.SortOrder;
 import io.ebean.DuplicateKeyException;
+import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.ExpressionList;
 import io.ebean.PagedList;
@@ -44,6 +45,9 @@ import io.ebean.config.ServerConfig;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -439,55 +443,69 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   private  <ASPECT extends RecordTemplate> EbeanMetadataAspect queryLatest(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass) {
+    final String aspectName = ModelUtils.getAspectName(aspectClass);
+
     if (_findMethodology == FindMethodology.UNIQUE_ID) {
-      final PrimaryKey key = new PrimaryKey(urn.toString(), ModelUtils.getAspectName(aspectClass), 0L);
+      final PrimaryKey key = new PrimaryKey(urn.toString(), aspectName, 0L);
       return _server.find(EbeanMetadataAspect.class, key);
     }
 
+    // TODO(@jphui) added for job-gms duplicity debug, throwaway afterwards
+
+    // JDBC sanity check: should MATCH Ebean's results
+    if (log.isDebugEnabled()) { 
+      final String sqlQuery = "SELECT * FROM metadata_aspect "
+          + "WHERE urn = ? and aspect = ? and version = 0";
+        
+      try (Transaction transaction = _server.beginTransaction()) {
+      
+        // use PreparedStatement 
+        try (PreparedStatement stmt = transaction.getConnection().prepareStatement(sqlQuery)) {
+          stmt.setString(1, urn.toString());
+          stmt.setString(2, aspectName);
+          
+          try (ResultSet rset = stmt.executeQuery()) {
+            rset.last();  // go to the last returned record
+            log.debug("JDBC found {} existing records", rset.getRow());
+          }
+        }
+      
+        transaction.commit();
+      } catch (SQLException e) {
+        log.debug("JDBC ran into a SQLException: {}", e.getMessage());
+      }
+    }
+
     List<EbeanMetadataAspect> results = Collections.emptyList();
-    // TODO (@jphui): remove following pathway(s) that are not used
+    Query<EbeanMetadataAspect> query = Ebean.find(EbeanMetadataAspect.class); // non-null placeholder to be overridden
 
     if (_findMethodology == FindMethodology.DIRECT_SQL) {
       final String selectQuery = "SELECT * FROM metadata_aspect "
           + "WHERE urn = :urn and aspect = :aspect and version = 0 "
           + "ORDER BY createdOn DESC";
 
-      Query<EbeanMetadataAspect> query = _server.findNative(EbeanMetadataAspect.class, selectQuery)
+      query = _server.findNative(EbeanMetadataAspect.class, selectQuery)
       .setParameter("urn", urn.toString())
-      .setParameter("aspect", ModelUtils.getAspectName(aspectClass));
-
-      results = query.findList();
-
-      // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
-      if (log.isDebugEnabled()) {
-        if ("AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
-          log.debug("Using DIRECT_SQL retrieval.");
-          log.debug("queryLatest SQL: " + query.getGeneratedSql());
-          log.debug("queryLatest Result: " + results);
-        }
-      }
+      .setParameter("aspect", aspectName);
     }
 
     if (_findMethodology == FindMethodology.QUERY_BUILDER) {
-      Query<EbeanMetadataAspect> query = _server.find(EbeanMetadataAspect.class)
+      query = _server.find(EbeanMetadataAspect.class)
         .where()
         .eq(URN_COLUMN, urn.toString())
-        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
+        .eq(ASPECT_COLUMN, aspectName)
         .eq(VERSION_COLUMN, 0L)
         .orderBy()
         .desc(CREATED_ON_COLUMN);
-
-      results = query.findList();
-
-      // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
-      if (log.isDebugEnabled()) {
-        if ("AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
-          log.debug("Using QUERY_BUILDER retrieval.");
-          log.debug("queryLatest SQL: " + query.getGeneratedSql());
-          log.debug("queryLatest Result: " + results);
-        }
+    }
+    
+    if (log.isDebugEnabled()) {
+      if ("AzkabanFlowInfo".equals(aspectName)) {
+        log.debug("Using {} retrieval; " + "Generated SQL: {}", _findMethodology.toString() , query.getGeneratedSql());
       }
     }
+
+    results = query.findList();
 
     if (results.isEmpty()) {
       return null;
@@ -495,7 +513,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     // don't crash if find duplicates, but log an error
     if (results.size() > 1) {
-      log.error("Two version=0 records found for {}, {}", urn, aspectClass.getSimpleName());
+      log.error("Two version=0 records found for {}, {}", urn, aspectName);
     }
 
     // return value at the top of the list (latest createdOn)

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -452,30 +452,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     // TODO(@jphui) added for job-gms duplicity debug, throwaway afterwards
 
-    // JDBC sanity check: should MATCH Ebean's results
-    if (log.isDebugEnabled()) { 
-      final String sqlQuery = "SELECT * FROM metadata_aspect "
-          + "WHERE urn = ? and aspect = ? and version = 0";
-        
-      try (Transaction transaction = _server.beginTransaction()) {
-      
-        // use PreparedStatement 
-        try (PreparedStatement stmt = transaction.getConnection().prepareStatement(sqlQuery)) {
-          stmt.setString(1, urn.toString());
-          stmt.setString(2, aspectName);
-          
-          try (ResultSet rset = stmt.executeQuery()) {
-            rset.last();  // go to the last returned record
-            log.debug("JDBC found {} existing records", rset.getRow());
-          }
-        }
-      
-        transaction.commit();
-      } catch (SQLException e) {
-        log.debug("JDBC ran into a SQLException: {}", e.getMessage());
-      }
-    }
-
     List<EbeanMetadataAspect> results = Collections.emptyList();
     Query<EbeanMetadataAspect> query = Ebean.find(EbeanMetadataAspect.class); // non-null placeholder to be overridden
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -452,9 +452,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     // TODO(@jphui) added for job-gms duplicity debug, throwaway afterwards
 
-
     // JDBC sanity check: should MATCH Ebean's results
-    if (log.isDebugEnabled()) { 
+    if (log.isDebugEnabled() && "com.linkedin.dataJob.azkaban.AzkabanFlowInfo".equals(aspectName)) { 
       final String sqlQuery = "SELECT * FROM metadata_aspect "
           + "WHERE urn = ? and aspect = ? and version = 0";
         
@@ -486,8 +485,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
           + "ORDER BY createdOn DESC";
 
       query = _server.findNative(EbeanMetadataAspect.class, selectQuery)
-      .setParameter("urn", urn.toString())
-      .setParameter("aspect", aspectName);
+          .setParameter("urn", urn.toString())
+          .setParameter("aspect", aspectName);
     }
 
     if (_findMethodology == FindMethodology.QUERY_BUILDER) {
@@ -500,10 +499,14 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .desc(CREATED_ON_COLUMN);
     }
     
-    if (log.isDebugEnabled()) {
-      if ("AzkabanFlowInfo".equals(aspectName)) {
-        log.debug("Using {} retrieval; " + "Generated SQL: {}", _findMethodology.toString(), query.getGeneratedSql());
-      }
+    if (log.isDebugEnabled() && "com.linkedin.dataJob.azkaban.AzkabanFlowInfo".equals(aspectName)) {
+      log.debug("Using {} retrieval; " + "Generated SQL: {}; urn: {}, aspect: {}, version: {}",
+          _findMethodology.toString(),
+          query.getGeneratedSql(),
+          urn.toString(),
+          aspectName,
+          0L
+        );
     }
 
     results = query.findList();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -498,7 +498,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .orderBy()
         .desc(CREATED_ON_COLUMN);
     }
-    
+
+    results = query.findList();
+
+    // Encouraged to run AFTER query execution based on getGeneratedSql() documentation
     if (log.isDebugEnabled() && "com.linkedin.dataJob.azkaban.AzkabanFlowInfo".equals(aspectName)) {
       log.debug("Using {} retrieval; " + "Generated SQL: {}; urn: {}, aspect: {}, version: {}",
           _findMethodology.toString(),
@@ -508,8 +511,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
           0L
         );
     }
-
-    results = query.findList();
 
     if (results.isEmpty()) {
       return null;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -38,7 +38,6 @@ import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.ExpressionList;
 import io.ebean.PagedList;
-import io.ebean.PersistenceContextScope;
 import io.ebean.Query;
 import io.ebean.SqlUpdate;
 import io.ebean.Transaction;
@@ -510,8 +509,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         );
     }
 
-    // disable L1 caching, then execute
-    results = query.setPersistenceContextScope(PersistenceContextScope.QUERY).findList();
+    results = query.findList();
 
     if (results.isEmpty()) {
       return null;


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

`<refactor / feat> :` refactor logging to be more concise and consistent, introduce JDBC query for cross checking with Ebean results

Suggestions from @dnbaker surrounding logging conventions in https://github.com/linkedin/datahub-gma/pull/255 have been incorporated. In addition, a JDBC query has been introduced to be used in cross-checking against Ebean's results to determine if the duplicity issue arises from the Ebean layer.

NOTE that JDBC is _not_ added as a 4th Find Methodology; it's intentionally made to be run in parallel in order to allow cross-checking.

#### The Big Idea

The end result of this PR is that _**preceding the existing logging**_ we will be able to see the results that JDBC "would have gotten" ... because if BOTH JDBC and Ebean return `null` then we can be assured that Ebean is not the cuprit!