### PR TITLE
docs: add a link to source code diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ DataHub. We're still in the process of moving it all over.
 
 - [GMA Developer's Guide](docs/developers.md)
 - [GMA Architecture](docs/architecture/architecture.md)
+- [GMA Source Code Diagrams](https://sourcespy.com/github/linkedindatahubgma/)
 
 ## Releases
 


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library, dependency and others  (https://sourcespy.com/github/linkedindatahubgma/). Intended to simplify introduction to the project for new developers.

In the spirit of transparency - I am the author of the generated diagrams. Hope contributors find it useful.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
