### PR TITLE
(fix) fix collision with legacy constructor issue

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -456,15 +456,16 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       .setParameter("urn", urn.toString())
       .setParameter("aspect", ModelUtils.getAspectName(aspectClass));
 
+      results = query.findList();
+
       // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
       if (log.isDebugEnabled()) {
         if ("AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
           log.debug("Using DIRECT_SQL retrieval.");
           log.debug("queryLatest SQL: " + query.getGeneratedSql());
+          log.debug("queryLatest Result: " + results);
         }
       }
-
-      results = query.findList();
     }
 
     if (_findMethodology == FindMethodology.QUERY_BUILDER) {
@@ -475,7 +476,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .eq(VERSION_COLUMN, 0L)
         .orderBy()
         .desc(CREATED_ON_COLUMN);
-      
+
       results = query.findList();
 
       // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
@@ -483,6 +484,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         if ("AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
           log.debug("Using QUERY_BUILDER retrieval.");
           log.debug("queryLatest SQL: " + query.getGeneratedSql());
+          log.debug("queryLatest Result: " + results);
         }
       }
     }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -101,6 +101,18 @@ public abstract class BaseAspectRoutingResource<
     _routingAspectClass = null;
   }
 
+  public BaseAspectRoutingResource(@Nonnull Class<SNAPSHOT> snapshotClass,
+      @Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull Class<URN> urnClass,
+      @Nonnull Class<VALUE> valueClass, @Nullable Object dummyObject) {
+    super(snapshotClass, aspectUnionClass, urnClass);
+    // "dummyObject" the dummyObject is used to avoid the conflict with the two deprecated constructors
+    // TODO(yanyang) clean up dummyObject when removing the deprecated constructors
+    _valueClass = valueClass;
+    _aspectUnionClass = aspectUnionClass;
+    _snapshotClass = snapshotClass;
+    _routingAspectClass = null;
+  }
+
   public void setAspectRoutingGmsClientManager(AspectRoutingGmsClientManager aspectRoutingGmsClientManager) {
     log.info("set aspect routing gms client manager: {}", aspectRoutingGmsClientManager);
     _aspectRoutingGmsClientManager = aspectRoutingGmsClientManager;


### PR DESCRIPTION
## Context

- add a new constructor for BaseAspectRoutingResource with a dummy param to avoid the conflict with the existing constructor (which has been deprecated)
- added a few temporary logging lines for EBean to help with the job-gms duplicity issue.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
