### PR TITLE
Change aspectUnion events to use separate fields per aspect instead o…

### DIFF
--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MCEBarAspect.pdl
@@ -1,8 +1,8 @@
 namespace com.linkedin.testing.mxe.bar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.metadata.events.ChangeType
 import com.linkedin.metadata.events.IngestionTrackingContext
+import com.linkedin.metadata.events.ChangeType
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 import com.linkedin.testing.AnotherAspectBar
@@ -24,21 +24,24 @@ record MCEBarAspect {
   urn: BarUrn
 
   /**
-   * The proposed aspect values for this entity.
-   */
-  proposedValues: array[union[
-    record ProposedAnnotatedAspectBar {
-      proposed: optional AnnotatedAspectBar
-      changeType: ChangeType = "UPSERT"
-    }
-    record ProposedAnotherAspectBar {
-      proposed: optional AnotherAspectBar
-      changeType: ChangeType = "UPSERT"
-    }
-  ]]
-
-  /**
    * Tracking context to identify the lifecycle of the trackable ingestion item.
    */
   ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
+
+  /**
+   * Proposed change values for aspect AnnotatedAspectBar.
+   */
+  proposedAnnotatedAspectBar: optional record ProposedAnnotatedAspectBar {
+    value: optional AnnotatedAspectBar
+    changeType: ChangeType = "UPSERT"
+  }
+
+  /**
+   * Proposed change values for aspect AnotherAspectBar.
+   */
+  proposedAnotherAspectBar: optional record ProposedAnotherAspectBar {
+    value: optional AnotherAspectBar
+    changeType: ChangeType = "UPSERT"
+  }
+
 }

--- a/gradle-plugins/metadata-annotations-test-models/src/test/java/com/linkedin/metadata/annotations/testing/UnionAspectTest.java
+++ b/gradle-plugins/metadata-annotations-test-models/src/test/java/com/linkedin/metadata/annotations/testing/UnionAspectTest.java
@@ -19,15 +19,10 @@ public class UnionAspectTest {
     MCEBarAspect unionAspect = new MCEBarAspect().setUrn(new BarUrn(123));
 
     AnnotatedAspectBar bar = new AnnotatedAspectBar().setBoolField(true);
-    ProposedAnnotatedAspectBar proposedBar = new ProposedAnnotatedAspectBar().setProposed(bar);
-
     AnotherAspectBar anotherBar = new AnotherAspectBar().setStringField("foo");
-    ProposedAnotherAspectBar proposedAnotherBar =
-            new ProposedAnotherAspectBar().setProposed(anotherBar).setChangeType(ChangeType.DELETE);
 
-    unionAspect.setProposedValues(new MCEBarAspect.ProposedValuesArray(
-            MCEBarAspect.ProposedValues.create(proposedBar),
-            MCEBarAspect.ProposedValues.create(proposedAnotherBar)));
+    unionAspect.setProposedAnnotatedAspectBar(new ProposedAnnotatedAspectBar().setValue(bar));
+    unionAspect.setProposedAnotherAspectBar(new ProposedAnotherAspectBar().setValue(anotherBar).setChangeType(ChangeType.DELETE));
 
     FailedMCEBarAspect failedAspect = new FailedMCEBarAspect();
     failedAspect.setMetadataChangeEvent(unionAspect);

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/AspectUnionEvent.rythm
@@ -4,8 +4,8 @@
 namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.metadata.events.ChangeType
 import com.linkedin.metadata.events.IngestionTrackingContext
+import com.linkedin.metadata.events.ChangeType
 import @eventSpec.getUrnType()
 @for (String valueType: eventSpec.getValueTypes()) {
 import @valueType
@@ -28,19 +28,18 @@ record MCE@(eventSpec.getShortTyperefName()) {
   urn: @(eventSpec.getShortUrn())
 
   /**
-   * The proposed aspect values for this entity.
-   */
-  proposedValues: array[union[
-  @for (String valueType: eventSpec.getValueTypes()) {
-    record Proposed@(SchemaGeneratorUtil.stripNamespace(valueType)) {
-      proposed: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
-      changeType: ChangeType = "UPSERT"
-    }
-  }
-  ]]
-
-  /**
    * Tracking context to identify the lifecycle of the trackable ingestion item.
    */
   ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
+
+  @for (String valueType: eventSpec.getValueTypes()) {
+  /**
+   * Proposed change values for aspect @(SchemaGeneratorUtil.stripNamespace(valueType)).
+   */
+  proposed@(SchemaGeneratorUtil.stripNamespace(valueType)): optional record Proposed@(SchemaGeneratorUtil.stripNamespace(valueType)) {
+    value: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
+    changeType: ChangeType = "UPSERT"
+  }
+
+  }
 }


### PR DESCRIPTION
…f an array of unions. This improves Avro usability.

-----

Details:
Avro Java codegen converts unions of records into arrays of generic Object's. This means that a union of records loses all type-safety during coding and compilation. This change switches union in aspect union event into separate fields per aspect to retain the type-safety.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
