### PR TITLE
(fix) include routing aspect selector

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -144,7 +144,7 @@ public abstract class BaseAspectRoutingResource<
 
       // Get entity from aspect GMS
       if (containsRoutingAspect(aspectClasses) && aspectClasses.size() == 1) {
-        return merge(null, getRoutingAspects(toUrn(id), aspectClasses));
+        return merge(null, getValueFromRoutingGms(toUrn(id), aspectClasses));
       }
 
       // The assumption is main GMS must have this entity.
@@ -160,7 +160,7 @@ public abstract class BaseAspectRoutingResource<
 
       // Need to read from both aspect GMS and local DAO.
       final VALUE valueFromLocalDao = getValueFromLocalDao(id, getNonRoutingAspects(aspectClasses));
-      return merge(valueFromLocalDao, getRoutingAspects(toUrn(id), aspectClasses));
+      return merge(valueFromLocalDao, getValueFromRoutingGms(toUrn(id), getRoutingAspects(aspectClasses)));
     });
   }
 
@@ -375,7 +375,7 @@ public abstract class BaseAspectRoutingResource<
   @ParametersAreNonnullByDefault
   private List<ASPECT_UNION> getAspectsFromGms(URN urn, Class aspectClass) {
     final List<? extends RecordTemplate> routingAspects =
-        getRoutingAspects(urn, Collections.singletonList(aspectClass));
+        getValueFromRoutingGms(urn, Collections.singletonList(aspectClass));
     if (routingAspects.isEmpty()) {
       return new ArrayList<>();
     }
@@ -479,7 +479,7 @@ public abstract class BaseAspectRoutingResource<
   }
 
   @Nullable
-  private List<? extends RecordTemplate> getRoutingAspects(@Nonnull URN urn,
+  private List<? extends RecordTemplate> getValueFromRoutingGms(@Nonnull URN urn,
       Collection<Class<? extends RecordTemplate>> routeAspectClasses) {
     return routeAspectClasses.stream().map(routeAspectClass -> {
 


### PR DESCRIPTION
## Context
Mostly an innocuous bug (result in unnecessary error logs). 
- rename getRoutingAspects() to getValueFromRoutingGms() to differentiate the other method: getRoutingAspects()
- add a getRoutingAspects() selector before passing aspect for getValueFromRoutingGms(). Currently the downstream will process non-routing aspects and print out error message. But the exception will be caught and handle silently. 

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
