### PR TITLE
fix get single/multi routing aspect issue

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -718,7 +718,7 @@ public abstract class BaseEntityResource<
    * Creates a snapshot of the entity with no aspects set, just the URN.
    */
   @Nonnull
-  private SNAPSHOT newSnapshot(@Nonnull URN urn) {
+  protected SNAPSHOT newSnapshot(@Nonnull URN urn) {
     return ModelUtils.newSnapshot(_snapshotClass, urn, Collections.emptyList());
   }
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -115,6 +115,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
           value.setAttributes(AspectAttributes.class.cast(a));
         }
       });
+      value.setId(snapshot.getUrn().getIdAsLong());
       return value;
     }
 
@@ -192,6 +193,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     assertTrue(value.hasAttributes());
     assertEquals(value.getAttributes(), attributes);
+    assertEquals(value.getId(), urn.getIdAsLong());
   }
 
   @Test
@@ -212,6 +214,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     assertTrue(value.hasBar());
     assertEquals(value.getBar(), bar);
+    assertEquals(value.getId(), urn.getIdAsLong());
   }
 
   @Test
@@ -236,7 +239,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     assertTrue(value.hasAttributes());
     assertEquals(value.getAttributes(), attributes);
-
+    assertEquals(value.getId(), urn.getIdAsLong());
     assertFalse(value.hasBar());
     verify(_mockLocalDAO, times(0)).get(anySet());
   }
@@ -257,6 +260,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     assertTrue(value.hasFoo());
     assertEquals(value.getFoo(), foo);
+    assertEquals(value.getId(), urn.getIdAsLong());
     assertFalse(value.hasBar());
   }
 
@@ -276,6 +280,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     assertTrue(value.hasBar());
     assertEquals(value.getBar(), bar);
+    assertEquals(value.getId(), urn.getIdAsLong());
     assertFalse(value.hasFoo());
   }
 

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityValue.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityValue.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.testing
 /**
  * For unit tests
  */
-record EntityValue {
+record EntityValue includes EntityKey {
 
   /**
    * For unit tests


### PR DESCRIPTION
## Context
- fix an issue that if only routing aspect is requested, the resource rendering will fail due to missing snapshot urn. [[restli example](https://sceptre.corp.linkedin.com/service-detail/datasets/resource/datasets/details#methods,get,permlinkId-68661442)]
- fix an issue that multi-routing-aspect request will fail the processing logic. 

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
