### PR TITLE
feat: Add a new backfill method that sets the old value as null in MAE

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1080,7 +1080,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * This method provides a hack solution to enable low volume backfill against elastic search live index.
    * This method should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
-   * methods starts to safely backfill against live index.
+   * method starts to safely backfill against live index.
    *
    * @param aspectClasses set of aspects to backfill
    * @param urns  set of urns to backfill

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1152,7 +1152,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     ASPECT oldValue = (mode == BackfillMode.MAE_ONLY_WITH_OLD_VALUE_NULL) ? null : aspect;
 
-    if (mode == BackfillMode.MAE_ONLY || mode == BackfillMode.BACKFILL_ALL) {
+    if (mode == BackfillMode.MAE_ONLY
+        || mode == BackfillMode.BACKFILL_ALL
+        || mode == BackfillMode.MAE_ONLY_WITH_OLD_VALUE_NULL) {
       if (_trackingProducer != null) {
         _trackingProducer.produceMetadataAuditEvent(urn, oldValue, aspect);
         IngestionTrackingContext trackingContext = new IngestionTrackingContext();

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1078,16 +1078,16 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * This method provides a hack solution to enable low volume backfill against elastic search live index.
-   * This method should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
-   * method starts to safely backfill against live index.
+   * This method provides a hack solution to enable low volume backfill against secondary live index by setting oldValue
+   * in mae payload as null. This method should be deprecated once the secondary store is moving away from elastic search,
+   * or the standard backfill method starts to safely backfill against live index.
    *
    * @param aspectClasses set of aspects to backfill
    * @param urns  set of urns to backfill
    * @return map of urn to their backfilled aspect values
    */
   @Nonnull
-  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillESLiveIndex(
+  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillWithNewValue(
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
     return backfill(BackfillMode.MAE_ONLY_WITH_OLD_VALUE_NULL, aspectClasses, urns);
   }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1079,8 +1079,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
   /**
    * This method provides a hack solution to enable low volume backfill against elastic search live index.
-   * This method should be deprecated once the secondary store is moving away from elastic search, or offline backfill
-   * is supported for elastic search.
+   * This method should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
+   * methods starts to safely backfill against live index.
    *
    * @param aspectClasses set of aspects to backfill
    * @param urns  set of urns to backfill
@@ -1150,20 +1150,19 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       updateLocalIndex(urn, aspect, FIRST_VERSION);
     }
 
-    ASPECT newValue = aspect;
     ASPECT oldValue = (mode == BackfillMode.MAE_ONLY_WITH_OLD_VALUE_NULL) ? null : aspect;
 
     if (mode == BackfillMode.MAE_ONLY || mode == BackfillMode.BACKFILL_ALL) {
       if (_trackingProducer != null) {
-        _trackingProducer.produceMetadataAuditEvent(urn, oldValue, newValue);
+        _trackingProducer.produceMetadataAuditEvent(urn, oldValue, aspect);
         IngestionTrackingContext trackingContext = new IngestionTrackingContext();
         trackingContext.setTrackingId(TrackingUtils.getRandomUUID());
         trackingContext.setEmitter("dao_backfill_endpoint");
         trackingContext.setEmitTime(System.currentTimeMillis());
-        _trackingProducer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, trackingContext);
+        _trackingProducer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, aspect, trackingContext);
       } else {
-        _producer.produceMetadataAuditEvent(urn, oldValue, newValue);
-        _producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue);
+        _producer.produceMetadataAuditEvent(urn, oldValue, aspect);
+        _producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, aspect);
       }
     }
   }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
@@ -19,4 +19,9 @@ enum BackfillMode {
    * Backfill all secondary stores
    */
   BACKFILL_ALL
+
+  /**
+   * Backfill only using MAE. Setting the old value in MAE payload as null.
+   */
+  MAE_ONLY_WITH_OLD_VALUE_NULL
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -903,6 +903,20 @@ public class EbeanLocalDAOTest {
     }
     verifyNoMoreInteractions(_mockProducer);
     assertEquals(dao.listUrns(indexFilter, null, 3).size(), 3);
+
+    // Backfill in MAE_ONLY_WITH_OLD_VALUE_NULL mode
+    clearInvocations(_mockProducer);
+    backfilledAspects =
+        dao.backfill(BackfillMode.MAE_ONLY_WITH_OLD_VALUE_NULL, ImmutableSet.of(AspectBar.class), FooUrn.class, null, 3);
+    for (int index = 0; index < 3; index++) {
+      Urn urn = urns.get(index);
+      RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
+      assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
+      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, null, aspect);
+      verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, aspect);
+    }
+    verifyNoMoreInteractions(_mockProducer);
+    assertEquals(dao.listUrns(indexFilter, null, 3).size(), 3);
   }
 
   @Test

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -181,7 +181,7 @@ public abstract class BaseAspectRoutingResource<
    * should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
    * method starts to safely backfill against live index.
    *
-   * As a hack solution, we only cover the aspects that belong to the request serving gms.
+   * <p>As a hack solution, we only cover the aspects that belong to the request serving gms.
    */
   @Action(name = ACTION_BACKFILL_ES_LIVE_INDEX)
   @Nonnull

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -185,6 +185,7 @@ public abstract class BaseAspectRoutingResource<
    */
   @Action(name = ACTION_BACKFILL_ES_LIVE_INDEX)
   @Nonnull
+  @Override
   public Task<BackfillResult> backfillESLiveIndex(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
       @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -177,7 +177,11 @@ public abstract class BaseAspectRoutingResource<
   }
 
   /**
-   * An action method for emitting MAE backfill messages to overwrite data in elastic search live index.
+   * An action method for emitting MAE backfill messages to overwrite data in elastic search live index. This action
+   * should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
+   * methods starts to safely backfill against live index.
+   *
+   * As a hack solution, we only cover the aspects that belong to the request serving gms.
    */
   @Action(name = ACTION_BACKFILL_ES_LIVE_INDEX)
   @Nonnull

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -176,6 +176,21 @@ public abstract class BaseAspectRoutingResource<
     });
   }
 
+  /**
+   * An action method for emitting MAE backfill messages to overwrite data in elastic search live index.
+   */
+  @Action(name = ACTION_BACKFILL_ES_LIVE_INDEX)
+  @Nonnull
+  public Task<BackfillResult> backfillESLiveIndex(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
+
+    return RestliUtils.toTask(() -> {
+      final Set<URN> urnSet = Arrays.stream(urns).map(this::parseUrnParam).collect(Collectors.toSet());
+      final Set<Class<? extends RecordTemplate>> aspectClasses = parseAspectsParam(aspectNames);
+      return RestliUtils.buildBackfillResult(getLocalDAO().backfillESLiveIndex(getNonRoutingAspects(aspectClasses), urnSet));
+    });
+  }
+
   @Nonnull
   @Override
   protected Task<Void> ingestInternal(@Nonnull SNAPSHOT snapshot,

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -179,7 +179,7 @@ public abstract class BaseAspectRoutingResource<
   /**
    * An action method for emitting MAE backfill messages to overwrite data in elastic search live index. This action
    * should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
-   * methods starts to safely backfill against live index.
+   * method starts to safely backfill against live index.
    *
    * As a hack solution, we only cover the aspects that belong to the request serving gms.
    */

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -177,22 +177,22 @@ public abstract class BaseAspectRoutingResource<
   }
 
   /**
-   * An action method for emitting MAE backfill messages to overwrite data in elastic search live index. This action
+   * An action method for emitting MAE backfill messages with new value (old value will be set as null). This action
    * should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
    * method starts to safely backfill against live index.
    *
    * <p>As a hack solution, we only cover the aspects that belong to the request serving gms.
    */
-  @Action(name = ACTION_BACKFILL_ES_LIVE_INDEX)
+  @Action(name = ACTION_BACKFILL_WITH_NEW_VALUE)
   @Nonnull
   @Override
-  public Task<BackfillResult> backfillESLiveIndex(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
+  public Task<BackfillResult> backfillWithNewValue(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
       @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
 
     return RestliUtils.toTask(() -> {
       final Set<URN> urnSet = Arrays.stream(urns).map(this::parseUrnParam).collect(Collectors.toSet());
       final Set<Class<? extends RecordTemplate>> aspectClasses = parseAspectsParam(aspectNames);
-      return RestliUtils.buildBackfillResult(getLocalDAO().backfillESLiveIndex(getNonRoutingAspects(aspectClasses), urnSet));
+      return RestliUtils.buildBackfillResult(getLocalDAO().backfillWithNewValue(getNonRoutingAspects(aspectClasses), urnSet));
     });
   }
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -327,18 +327,18 @@ public abstract class BaseEntityResource<
   }
 
   /**
-   * An action method for emitting MAE backfill messages to overwrite data in elastic search live index. This action
+   * An action method for emitting MAE backfill messages with new value (old value will be set as null). This action
    * should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
    * method starts to safely backfill against live index.
    */
-  @Action(name = ACTION_BACKFILL_ES_LIVE_INDEX)
+  @Action(name = ACTION_BACKFILL_WITH_NEW_VALUE)
   @Nonnull
-  public Task<BackfillResult> backfillESLiveIndex(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
+  public Task<BackfillResult> backfillWithNewValue(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
       @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
 
     return RestliUtils.toTask(() -> {
       final Set<URN> urnSet = Arrays.stream(urns).map(urnString -> parseUrnParam(urnString)).collect(Collectors.toSet());
-      return RestliUtils.buildBackfillResult(getLocalDAO().backfillESLiveIndex(parseAspectsParam(aspectNames), urnSet));
+      return RestliUtils.buildBackfillResult(getLocalDAO().backfillWithNewValue(parseAspectsParam(aspectNames), urnSet));
     });
   }
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -327,6 +327,22 @@ public abstract class BaseEntityResource<
   }
 
   /**
+   * An action method for emitting MAE backfill messages to overwrite data in elastic search live index. This action
+   * should be deprecated once the secondary store is moving away from elastic search, or the standard backfill
+   * method starts to safely backfill against live index.
+   */
+  @Action(name = ACTION_BACKFILL_ES_LIVE_INDEX)
+  @Nonnull
+  public Task<BackfillResult> backfillESLiveIndex(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
+
+    return RestliUtils.toTask(() -> {
+      final Set<URN> urnSet = Arrays.stream(urns).map(urnString -> parseUrnParam(urnString)).collect(Collectors.toSet());
+      return RestliUtils.buildBackfillResult(getLocalDAO().backfillESLiveIndex(parseAspectsParam(aspectNames), urnSet));
+    });
+  }
+
+  /**
    * An action method for backfilling the new schema's entity tables with metadata from the old schema.
    */
   @Action(name = ACTION_BACKFILL_ENTITY_TABLES)

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -11,6 +11,7 @@ public final class RestliConstants {
   public static final String ACTION_BACKFILL = "backfill";
   public static final String ACTION_BACKFILL_ENTITY_TABLES = "backfillEntityTables";
   public static final String ACTION_BACKFILL_WITH_URNS = "backfillWithUrns";
+  public static final String ACTION_BACKFILL_ES_LIVE_INDEX = "backfillESLiveIndex";
   public static final String ACTION_BACKFILL_LEGACY = "backfillLegacy";
   public static final String ACTION_BROWSE = "browse";
   public static final String ACTION_COUNT_AGGREGATE = "countAggregate";

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -11,7 +11,7 @@ public final class RestliConstants {
   public static final String ACTION_BACKFILL = "backfill";
   public static final String ACTION_BACKFILL_ENTITY_TABLES = "backfillEntityTables";
   public static final String ACTION_BACKFILL_WITH_URNS = "backfillWithUrns";
-  public static final String ACTION_BACKFILL_ES_LIVE_INDEX = "backfillESLiveIndex";
+  public static final String ACTION_BACKFILL_WITH_NEW_VALUE = "backfillWithNewValue";
   public static final String ACTION_BACKFILL_LEGACY = "backfillLegacy";
   public static final String ACTION_BROWSE = "browse";
   public static final String ACTION_COUNT_AGGREGATE = "countAggregate";

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -504,4 +504,23 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     assertTrue(backfillResult.getEntities().get(1).getAspects().contains(AspectFoo.class.getCanonicalName()));
     assertTrue(backfillResult.getEntities().get(1).getAspects().contains(AspectAttributes.class.getCanonicalName()));
   }
+
+  @Test
+  public void testBackfillWithNewValue() {
+    FooUrn fooUrn1 = makeFooUrn(1);
+    FooUrn fooUrn2 = makeFooUrn(2);
+    AspectBar bar1 = new AspectBar().setValue("bar1");
+    AspectBar bar2 = new AspectBar().setValue("bar2");
+
+    Map<FooUrn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> daoResult =
+        ImmutableMap.of(fooUrn1, Collections.singletonMap(AspectBar.class, Optional.of(bar1)),
+            fooUrn2, Collections.singletonMap(AspectBar.class, Optional.of(bar2)));
+
+    when(_mockLocalDAO.backfillWithNewValue(Collections.singleton(AspectBar.class), ImmutableSet.of(fooUrn1, fooUrn2))).thenReturn(daoResult);
+    BackfillResult backfillResult = runAndWait(_resource.backfillWithNewValue(new String[]{fooUrn1.toString(), fooUrn2.toString()},
+        new String[]{AspectBar.class.getCanonicalName(), AspectFoo.class.getCanonicalName()}));
+
+    assertEquals(backfillResult.getEntities().size(), 2);
+    verifyZeroInteractions(_mockAspectFooGmsClient);
+  }
 }


### PR DESCRIPTION
## Summary
- We want to support low volume backfill against the live es index. Currently, such request needs manual operation to switch es indexes, which is dangerous and requires quite effort. In reality, we can't even close an oncall ticket.
- As the continuation in https://github.com/linkedin/datahub-gma/pull/286#discussion_r1277752227, we considered 1) adding tag in MAE payload; vs 2) setting old value as null to bypass consumer check. Eventually decided to go with 2) as it doesn't impact the MAE payload and can be easily deprecated as we migrate to other secondary store.
- Implement 2) in `BaseAspectRoutingResource` and `BaseEntityResource`.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
