### PR TITLE
fix(audit): make MAE AuditStamp field backwards compatible

### DIFF
--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -46,5 +46,5 @@ record MetadataAuditEvent {
   /**
    * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
    */
-  auditStamp: union[null, AuditStamp]
+  auditStamp: union[null, AuditStamp] = null
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -49,5 +49,5 @@ record MetadataAuditEvent {
   /**
    * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
    */
-  auditStamp: union[null, AuditStamp]
+  auditStamp: union[null, AuditStamp] = null
 }

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -180,7 +180,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
          */
-        auditStamp: union[null, AuditStamp]
+        auditStamp: union[null, AuditStamp] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testAspect/FailedMetadataChangeEvent.pdl').text == '''\
@@ -300,7 +300,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
          */
-        auditStamp: union[null, AuditStamp]
+        auditStamp: union[null, AuditStamp] = null
       }'''.stripIndent()
 
     projectFile('build/my-dummy-module/generateMetadataEventsSchema/com/linkedin/mxe/foo/testTyperefAspect/FailedMetadataChangeEvent.pdl').text == '''\


### PR DESCRIPTION
"Adding a new field is backwards compatible if a default value is provided. The reader will substitute that default for missing data in records written with an older schema. At LinkedIn, we require that this new field be of a type that contains a union with null and that null be the default to allow readers to identify clearly records where the data is missing."

go/schemacompatbility

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
