### PR TITLE
fix(new schema): getLatest should rely only on entity tables in new schema mode

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -53,6 +53,14 @@ public interface IEbeanLocalAccess<URN extends Urn> {
       int keysCount, int position);
 
   /**
+   * Get a single record (aspect) from entity table without the soft deletion filter.
+   * @param key {@link AspectKey} to retrieve the aspect metadata
+   * @return a single {@link EbeanMetadataAspect} result if present, or null
+   */
+  @Nullable
+  EbeanMetadataAspect getSingleRecordNoSoftDeleteCheck(@Nonnull AspectKey<URN, ? extends RecordTemplate> key);
+
+  /**
    * Returns list of urns that satisfy the given filter conditions.
    *
    * <p>Results are ordered by the order criterion but defaults to sorting lexicographically by the string

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -149,9 +149,25 @@ public class EBeanDAOUtils {
     return metadataRecord.equals(DELETED_METADATA);
   }
 
+  /**
+   * Checks whether the entity table record has been soft deleted.
+   * @param sqlRow {@link SqlRow} result from MySQL server
+   * @param aspectClass class of the aspect being queried
+   * @return boolean representing whether the aspect record has been soft deleted
+   */
+  public static <ASPECT extends RecordTemplate> boolean isSoftDeletedAspect(@Nonnull SqlRow sqlRow, @Nonnull Class<ASPECT> aspectClass) {
+    String columnName = SQLSchemaUtils.getAspectColumnName(aspectClass);
+    try {
+      SoftDeletedAspect aspect = RecordUtils.toRecordTemplate(SoftDeletedAspect.class, sqlRow.getString(columnName));
+      return aspect.hasGma_deleted() && aspect.isGma_deleted();
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
 
   /**
-   * Read {@link SqlRow} list into a {@link EbeanMetadataAspect} list.
+   * Read {@link SqlRow} list into a {@link EbeanMetadataAspect} list. Assumes rows are not soft-deleted.
    * @param sqlRows list of {@link SqlRow}
    * @return list of {@link EbeanMetadataAspect}
    */

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -49,6 +49,9 @@ public class SQLStatementUtils {
   private static final String SQL_READ_ASPECT_TEMPLATE =
       String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby FROM %%s WHERE urn = '%%s' AND %s", SOFT_DELETED_CHECK);
 
+  private static final String SQL_READ_ASPECT_NO_SOFT_DELETE_CHECK_TEMPLATE =
+      "SELECT urn, %s, lastmodifiedon, lastmodifiedby FROM %s WHERE urn = '%s'";
+
   private static final String INDEX_GROUP_BY_CRITERION = "SELECT count(*) as COUNT, %s FROM %s";
   private static final String SQL_GROUP_BY_COLUMN_EXISTS_TEMPLATE =
       "SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = database() AND TABLE_NAME = '%s' AND COLUMN_NAME = '%s'";
@@ -122,6 +125,20 @@ public class SQLStatementUtils {
         }).collect(Collectors.toList());
     stringBuilder.append(String.join(" UNION ALL ", selectStatements));
     return stringBuilder.toString();
+  }
+
+  /**
+   * Create read aspect SQL statement for a single entity / aspect record without checking for soft deletion. This is
+   * only meant to be used in EbeanLocalDAO::getLatest.
+   * @param aspectClass aspect class to query for
+   * @param urn urn to query for
+   * @return SQL statement string
+   */
+  public static <ASPECT extends RecordTemplate> String createAspectReadSqlNoSoftDeleteCheck(@Nonnull Class<ASPECT> aspectClass,
+      @Nonnull Urn urn) {
+    final String columnName = getAspectColumnName(aspectClass);
+    final String tableName = getTableName(urn);
+    return String.format(SQL_READ_ASPECT_NO_SOFT_DELETE_CHECK_TEMPLATE, columnName, tableName, escapeReservedCharInUrn(urn.toString()));
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -118,7 +118,16 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testGetAspectNoSoftDeleteCheck() {
+    FooUrn fooUrn = makeFooUrn(0);
+    _ebeanLocalAccessFoo.add(fooUrn, null, AspectFoo.class, makeAuditStamp("foo", System.currentTimeMillis()));
+    AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey(AspectFoo.class, fooUrn, 0L);
+    List<EbeanMetadataAspect> ebeanMetadataAspectList =
+        _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(aspectKey), 1000, 0);
+    assertEquals(0, ebeanMetadataAspectList.size());
 
+    EbeanMetadataAspect result = _ebeanLocalAccessFoo.getSingleRecordNoSoftDeleteCheck(aspectKey);
+    assertNotNull(result);
+    assertEquals(fooUrn.toString(), result.getKey().getUrn());
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -117,6 +117,11 @@ public class EbeanLocalAccessTest {
   }
 
   @Test
+  public void testGetAspectNoSoftDeleteCheck() {
+
+  }
+
+  @Test
   public void testListUrnsWithOffset() {
 
     // Given: metadata_entity_foo table with fooUrns from 0 ~ 99

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -6,11 +6,14 @@ import com.linkedin.metadata.dao.EbeanLocalAccess;
 import com.linkedin.metadata.dao.EbeanMetadataAspect;
 import com.linkedin.metadata.dao.ListResult;
 import com.linkedin.metadata.query.ListResultMetadata;
+import com.linkedin.testing.AspectBar;
+import com.linkedin.testing.AspectBaz;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
+import io.ebean.SqlRow;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -25,6 +28,7 @@ import javax.annotation.Nonnull;
 import org.testng.annotations.Test;
 
 import static com.linkedin.testing.TestUtils.*;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -143,6 +147,19 @@ public class EBeanDAOUtilsTest {
 
     // null
     assertFalse(EBeanDAOUtils.compareResults(Collections.singletonList(ema1), Collections.singletonList(null), "testMethod"));
+  }
+
+  @Test
+  public void testIsSoftDeletedAspect() {
+    SqlRow sqlRow = mock(SqlRow.class);
+    when(sqlRow.getString("a_aspectfoo")).thenReturn("{\"gma_deleted\": true}");
+    assertTrue(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, AspectFoo.class));
+
+    when(sqlRow.getString("a_aspectbar")).thenReturn("{\"aspect\": {\"value\": \"bar\"}, \"lastmodifiedby\": \"urn:li:tester\"}");
+    assertFalse(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, AspectBar.class));
+
+    when(sqlRow.getString("a_aspectbaz")).thenReturn("{\"random_value\": \"baz\"}");
+    assertFalse(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, AspectBaz.class));
   }
 
   @Test


### PR DESCRIPTION
### Why do we need to make this change?
Any GMS in NEW_SCHEMA_ONLY mode should only read from entity tables. During BaseLocalDAO::add, getLatest is called before saveLatest, since we need to get the latest version from metadata_aspect first before performing the upsert on both metadata_aspect and entity tables. Originally, getLatest gets this data from metadata_aspect even when in NEW_SCHEMA_ONLY mode. The reason is because it is assumed that data in the entity tables and data in metadata_aspect is **always** consistent in DUAL_SCHEMA and NEW_SCHEMA_ONLY modes.

However, we ran into a case recently where this assumption was not true. While trying to onboard entities in service-gms to the new schema, the following timeline occurred:

1. Real-time data was emitted and ingested before migration.
2. service-gms was switched over to NEW_SCHEMA mode.
3. CI/CD Platform team ran their backfill to send all inventory, and we noticed that the entity tables were missing rows.
4. Truncate was done as part of the debugging, to clear out the data so that we could see exactly what was getting inserted.
5. Most emitted MCEs after that were not inserted into the entity tables.

In theory, 2 should never happen before 1, but there are no safeguards to prevent this. So it did happen in this case. MCEs were re-emitted to try and backfill the entity tables. When processing MCEs, getLatest is called first to get the value (if any) from the tables. Then the proposedValue in the MCE is compared to the result of getLatest. If they are the same, then the MCE will get skipped (nothing added to tables). Because getLatest was relying on metadata_aspect, and most of the MCEs' proposedValues were the same as the latest versions in metadata_aspect, most of the MCEs skipped processing and few records were processed into the entity tables.

### Implementation details
We need to create a new method `getSingleRecordNoSoftDeleteCheck` because the current batchGet filters out soft-deleted records. This causes issue when trying to undelete a soft-deleted record. Here's what would happen if we used batchGet in getLatest:
1) add record
2) soft delete record
3) try to undelete that record:
- call add()
- getLatest -> returns nothing from entity tables since soft-deleted rows are filtered out
- dao thinks that this is a brand new record trying to be added since "it doesn't exist yet"
- dao writes new record into entity tables (no problem here since entity table writes are upserts)
- dao tries to write new record into metadata_aspect with version = 0 WITHOUT moving the current version = 0 to MAX_VERSION
- this results in a duplicate PK error

Thus, we need to return _something_ from the lower level get method in getLatest to ensure that the dao does not erroneous think that the incoming change is a new record. We can return the soft-deleted aspect and then getLatest already has logic to mark the AddResult with a `softDeleted` flag = true.




### Testing
updated a bunch of unit tests.

since in NEW_SCHEMA_ONLY mode we are only relying on entity tables now, we also need to update the addMetadata and addMetadataWithAuditStamp methods to correctly add records to the entity tables for tests.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
