### PR TITLE
Fix local build on M1/M2 Apple computer

### DIFF
--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -63,6 +63,15 @@ public class EmbeddedMariaInstance {
           String baseDbDir = getBaseDbDir();
           configurationBuilder.setDataDir(baseDbDir + File.separator + "data");
           configurationBuilder.setBaseDir(baseDbDir + File.separator + "base");
+
+          /*
+           * Add below 3 lines of code if building datahub-gma on a M1 / M2 chip Apple computer.
+           *
+           * configurationBuilder.setBaseDir("/opt/homebrew");
+           * configurationBuilder.setUnpackingFromClasspath(false);
+           * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+           */
+
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {


### PR DESCRIPTION
Local build will fail on M1 / M2 Apple computer. This is PR provides a solution to local build the datahub-gma

**Prerequisite**
Make sure you install MariaDB on your computer first.
```
brew install mariadb
```

Add these 3 lines of code if you're building on M1/M2 chip computer.
```
configurationBuilder.setBaseDir("/opt/homebrew");
configurationBuilder.setUnpackingFromClasspath(false);
configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
```

Tested with `./gradlew build`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
