### PR TITLE
feat: add action emitNoChangeMetadataAuditEvent & add ingestionMode in mae

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseTrackingMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseTrackingMetadataEventProducer.java
@@ -4,6 +4,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.events.IngestionMode;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -26,7 +27,9 @@ public abstract class BaseTrackingMetadataEventProducer<SNAPSHOT extends RecordT
    * @param newValue the value after the update
    * @param trackingContext nullable tracking context passed in to be appended to produced MAEv5s
    * @param auditStamp {@link AuditStamp} containing version auditing information for the metadata change
+   * @param ingestionMode {@link IngestionMode} of the change
    */
   public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
-      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue, @Nullable AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext);
+      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue, @Nullable AuditStamp auditStamp,
+      @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionMode ingestionMode);
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/IngestionUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/IngestionUtils.java
@@ -1,0 +1,26 @@
+package com.linkedin.metadata.dao.utils;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.linkedin.metadata.backfill.BackfillMode;
+import com.linkedin.metadata.events.IngestionMode;
+
+
+public class IngestionUtils {
+
+  private IngestionUtils() {
+    //Utils class
+  }
+
+  /**
+   * This method provides the bidirectional mapping between {@link IngestionMode} and {@link BackfillMode}. Only
+   * user-allowed ingestion modes are included in the mapping.
+   */
+  public static final BiMap<IngestionMode, BackfillMode> ALLOWED_INGESTION_BACKFILL_BIMAP = createBiMap();
+  private static BiMap<IngestionMode, BackfillMode> createBiMap() {
+    BiMap<IngestionMode, BackfillMode> biMap = HashBiMap.create();
+    biMap.put(IngestionMode.BACKFILL, BackfillMode.BACKFILL_INCLUDING_LIVE_INDEX);
+    biMap.put(IngestionMode.BOOTSTRAP, BackfillMode.BACKFILL_ALL);
+    return biMap;
+  }
+}

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
@@ -21,7 +21,7 @@ enum BackfillMode {
   BACKFILL_ALL
 
   /**
-   * Backfill only using MAE. Setting the old value in MAE payload as null.
+   * DO NOT USE, it's deprecated. Backfill only using MAE. Setting the old value in MAE payload as null.
    */
   MAE_ONLY_WITH_OLD_VALUE_NULL
 

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
@@ -24,4 +24,10 @@ enum BackfillMode {
    * Backfill only using MAE. Setting the old value in MAE payload as null.
    */
   MAE_ONLY_WITH_OLD_VALUE_NULL
+
+  /**
+   * This type is a replacement type with the deprecation of MAE_ONLY_WITH_OLD_VALUE_NULL. It informs the downstream
+   * consumers that this backfill request should be ingested into the live index as well.
+   */
+   BACKFILL_INCLUDING_LIVE_INDEX
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -8,6 +8,7 @@ import com.linkedin.metadata.dao.producer.BaseTrackingMetadataEventProducer;
 import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
+import com.linkedin.metadata.events.IngestionMode;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.IndexFilter;
@@ -333,8 +334,10 @@ public class BaseLocalDAOTest {
 
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo);
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, foo, foo);
-    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, foo, _dummyAuditStamp, mockTrackingContext);
-    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, foo, foo, _dummyAuditStamp, mockTrackingContext);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null,
+        foo, _dummyAuditStamp, mockTrackingContext, IngestionMode.LIVE);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, foo,
+        foo, _dummyAuditStamp, mockTrackingContext, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/IngestionUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/IngestionUtilsTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.metadata.dao.utils;
+
+import com.linkedin.metadata.backfill.BackfillMode;
+import com.linkedin.metadata.events.IngestionMode;
+import org.testng.annotations.Test;
+
+import static com.linkedin.metadata.dao.utils.IngestionUtils.*;
+import static org.testng.Assert.*;
+
+
+public class IngestionUtilsTest {
+
+  @Test
+  public void testAllowedIngestionModeBackfillModeBimap() {
+    IngestionMode ingestionMode = IngestionMode.BACKFILL;
+    BackfillMode backfillMode = ALLOWED_INGESTION_BACKFILL_BIMAP.get(ingestionMode);
+    assertEquals(BackfillMode.BACKFILL_INCLUDING_LIVE_INDEX, backfillMode);
+
+    assertEquals(ingestionMode, ALLOWED_INGESTION_BACKFILL_BIMAP.inverse().get(backfillMode));
+    assertNull(ALLOWED_INGESTION_BACKFILL_BIMAP.get(IngestionMode.LIVE));
+    assertNull(ALLOWED_INGESTION_BACKFILL_BIMAP.inverse().get(BackfillMode.MAE_ONLY_WITH_OLD_VALUE_NULL));
+  }
+}

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -913,11 +913,24 @@ public class EbeanLocalDAOTest {
       Urn urn = urns.get(index);
       RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
       assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
-      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, null, aspect);
-      verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, aspect, null);
+      verify(_mockProducer, times(0)).produceMetadataAuditEvent(urn, aspect, aspect);
+      verify(_mockProducer, times(0)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
     }
     verifyNoMoreInteractions(_mockProducer);
     assertEquals(dao.listUrns(indexFilter, null, 3).size(), 3);
+
+    // Backfill in BACKFILL_INCLUDING_LIVE_INDEX mode
+    clearInvocations(_mockProducer);
+    backfilledAspects =
+        dao.backfill(BackfillMode.BACKFILL_INCLUDING_LIVE_INDEX, ImmutableSet.of(AspectBar.class), FooUrn.class, null, 3);
+    for (int index = 0; index < 3; index++) {
+      Urn urn = urns.get(index);
+      RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
+      assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
+      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
+      verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
+    }
+    verifyNoMoreInteractions(_mockProducer);
   }
 
   @Test

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -16,6 +16,7 @@ public final class RestliConstants {
   public static final String ACTION_BACKFILL_LEGACY = "backfillLegacy";
   public static final String ACTION_BROWSE = "browse";
   public static final String ACTION_COUNT_AGGREGATE = "countAggregate";
+  public static final String ACTION_EMIT_NO_CHANGE_METADATA_AUDIT_EVENT = "emitNoChangeMetadataAuditEvent";
   public static final String ACTION_GET_BROWSE_PATHS = "getBrowsePaths";
   public static final String ACTION_GET_SNAPSHOT = "getSnapshot";
   public static final String ACTION_INGEST = "ingest";
@@ -37,5 +38,6 @@ public final class RestliConstants {
   public static final String PARAM_URN = "urn";
   public static final String PARAM_URNS = "urns";
   public static final String PARAM_MODE = "mode";
+  public static final String PARAM_INGESTION_MODE = "ingestionMode";
   public static final String PARAM_TRACKING_CONTEXT = "trackingContext";
 }


### PR DESCRIPTION
## Summary
- start sending ingestionMode in backfill MAEs
- add `emitNoChangeMetadataAuditEvent` action with ingestionMode to support backfill into both live and backup index.
- deprecate `backfillWithNewValue` action

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
