### PR TITLE
Bug fix: Check column existence before query

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -169,7 +169,12 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     for (int index = position; index < end; index++) {
       final Urn entityUrn = aspectKeys.get(index).getUrn();
       final Class<ASPECT> aspectClass = (Class<ASPECT>) aspectKeys.get(index).getAspectClass();
-      keysToQueryMap.computeIfAbsent(aspectClass, unused -> new HashSet<>()).add(entityUrn);
+      final String checkColumnExistSql = SQLStatementUtils.checkColumnExistsSql(getTableName(entityUrn), getAspectColumnName(aspectClass));
+
+      // An aspect's column might not be defined in entity table yet, check the column exist or not before add it to query map.
+      if (_server.createSqlQuery(checkColumnExistSql).findOne() != null) {
+        keysToQueryMap.computeIfAbsent(aspectClass, unused -> new HashSet<>()).add(entityUrn);
+      }
     }
 
     // each statement is for a single aspect class

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -50,7 +50,8 @@ public class SQLStatementUtils {
       String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby FROM %%s WHERE urn = '%%s' AND %s", SOFT_DELETED_CHECK);
 
   private static final String INDEX_GROUP_BY_CRITERION = "SELECT count(*) as COUNT, %s FROM %s";
-  private static final String SQL_GROUP_BY_COLUMN_EXISTS_TEMPLATE =
+
+  private static final String SQL_COLUMN_EXISTS_TEMPLATE =
       "SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = database() AND TABLE_NAME = '%s' AND COLUMN_NAME = '%s'";
 
   private static final String SQL_URN_EXIST_TEMPLATE = "SELECT urn FROM %s WHERE urn = '%s'";
@@ -176,8 +177,12 @@ public class SQLStatementUtils {
   }
 
   public static String createGroupByColumnExistsSql(String tableName, @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
-    return String.format(SQL_GROUP_BY_COLUMN_EXISTS_TEMPLATE, tableName, getGeneratedColumnName(indexGroupByCriterion.getAspect(),
+    return String.format(SQL_COLUMN_EXISTS_TEMPLATE, tableName, getGeneratedColumnName(indexGroupByCriterion.getAspect(),
         indexGroupByCriterion.getPath()));
+  }
+
+  public static String checkColumnExistsSql(@Nonnull String tableName, @Nonnull String columnName) {
+    return String.format(SQL_COLUMN_EXISTS_TEMPLATE, tableName, columnName);
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,6 +72,10 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
+          configurationBuilder.setBaseDir("/opt/homebrew");
+          configurationBuilder.setUnpackingFromClasspath(false);
+          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,10 +72,6 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
-          configurationBuilder.setBaseDir("/opt/homebrew");
-          configurationBuilder.setUnpackingFromClasspath(false);
-          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
-
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {


### PR DESCRIPTION
**Context**
There are cases in which aspects are defined in `metadata-models` but the SQL script has not been written in the GMS. After a metadata-models version bump in GMS, people start to query column that's not defined yet in entity table. For example, the batchGet method in BaseEntityResource. This leads to SQL errors. [Previous issue](https://linkedin-randd.slack.com/archives/CG4JHTZ3J/p1682961734486449) raised in support channel 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
