### PR TITLE
disable change history during persistence

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -273,7 +273,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
       }
     } catch (PersistenceException pe) {
       throw new RuntimeException(
-          String.format("Expect at most 1 aspect value per entity. Sql: %s", listAspectByUrnSql));
+          String.format("Expect at most 1 aspect value per entity per aspect type . Sql: %s", listAspectByUrnSql));
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -38,7 +38,6 @@ import com.linkedin.metadata.query.ListResultMetadata;
 import com.linkedin.metadata.query.SortOrder;
 import io.ebean.DuplicateKeyException;
 import io.ebean.EbeanServer;
-import io.ebean.ExpressionList;
 import io.ebean.PagedList;
 import io.ebean.Query;
 import io.ebean.SqlUpdate;
@@ -100,6 +99,19 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   // Which approach to be used for record retrieval when inserting a new record
   // See GCN-38382
   private FindMethodology _findMethodology = FindMethodology.UNIQUE_ID;
+
+  // true if metadata change will be persisted into the change log table (metadata_aspect)
+  private boolean _changeLogEnabled = true;
+
+  public void setChangeLogEnabled(boolean changeLogEnabled) {
+    if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
+      _changeLogEnabled = changeLogEnabled;
+    }
+  }
+
+  public boolean isChangeLogEnabled() {
+    return _changeLogEnabled;
+  }
 
   public enum FindMethodology {
     UNIQUE_ID,      // (legacy) https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/EbeanServer.html#find-java.lang.Class-java.lang.Object-
@@ -512,22 +524,29 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       @Nonnull AuditStamp newAuditStamp, boolean isSoftDeleted, @Nullable IngestionTrackingContext trackingContext) {
     // Save oldValue as the largest version + 1
     long largestVersion = 0;
-    if ((isSoftDeleted || oldValue != null) && oldAuditStamp != null) {
-      largestVersion = getNextVersion(urn, aspectClass);
+    if ((isSoftDeleted || oldValue != null) && oldAuditStamp != null && _changeLogEnabled) {
+      // When saving on entity which has history version (including being soft deleted), and changeLog is enabled,
+      // the saveLatest will process the following steps:
 
+      // 1. get the next version from the metadata_aspect table
+      // 2. write value of latest version (version = 0) as a new version
+      // 3. update the latest version (version = 0) with the new value. If the value of latest version has been
+      //    changed during this process, then rollback by throwing OptimisticLockException
+
+      largestVersion = getNextVersion(urn, aspectClass);
       // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
       if (log.isDebugEnabled()) {
         if ("AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
           log.debug("Insert: {} => oldValue = {}, latest version = {}", urn, oldValue, largestVersion);
         }
       }
-
       // Move latest version to historical version by insert a new record.
       insert(urn, oldValue, aspectClass, oldAuditStamp, largestVersion, trackingContext);
       // update latest version
       updateWithOptimisticLocking(urn, newValue, aspectClass, newAuditStamp, LATEST_VERSION,
           new Timestamp(oldAuditStamp.getTime()), trackingContext);
     } else {
+      // When for fresh ingestion or with changeLog disabled
 
       // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
       if (log.isDebugEnabled()) {
@@ -586,7 +605,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
     AspectKey<URN, ASPECT> key = new AspectKey<>(aspectClass, urn, LATEST_VERSION);
     return runInTransactionWithRetry(() -> {
-      List<EbeanMetadataAspect> results = _localAccess.batchGetUnion(Collections.singletonList(key), 1, 0);
+          List<EbeanMetadataAspect> results = _localAccess.batchGetUnion(Collections.singletonList(key), 1, 0, false);
       if (results.size() == 0) {
         return new ArrayList<>();
       }
@@ -595,22 +614,37 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }, 1);
   }
 
-  private <ASPECT extends RecordTemplate> EbeanMetadataAspect queryLatest(@Nonnull URN urn,
+  /**
+   * Get latest metadata aspect record by urn and aspect.
+   * @param urn entity urn
+   * @param aspectClass aspect class
+   * @param <ASPECT> aspect type
+   * @return metadata aspect ebean model {@link EbeanMetadataAspect}
+   */
+  private @Nullable <ASPECT extends RecordTemplate> EbeanMetadataAspect queryLatest(@Nonnull URN urn,
       @Nonnull Class<ASPECT> aspectClass) {
-    final String aspectName = ModelUtils.getAspectName(aspectClass);
-    final PrimaryKey key = new PrimaryKey(urn.toString(), aspectName, 0L);
+
     EbeanMetadataAspect result;
-    if (_findMethodology == FindMethodology.DIRECT_SQL) {
-      result = findLatestMetadataAspect(_server, urn, aspectClass);
-      if (result == null) {
-        // Attempt 1: retry
-        result = _server.find(EbeanMetadataAspect.class, key);
-        if (log.isDebugEnabled()) {
-          log.debug("Attempt 1: Retried on {}, {}", urn, result);
+    if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
+      final String aspectName = ModelUtils.getAspectName(aspectClass);
+      final PrimaryKey key = new PrimaryKey(urn.toString(), aspectName, LATEST_VERSION);
+      if (_findMethodology == FindMethodology.DIRECT_SQL) {
+        result = findLatestMetadataAspect(_server, urn, aspectClass);
+        if (result == null) {
+          // Attempt 1: retry
+          result = _server.find(EbeanMetadataAspect.class, key);
+          if (log.isDebugEnabled()) {
+            log.debug("Attempt 1: Retried on {}, {}", urn, result);
+          }
         }
+      } else {
+        result = _server.find(EbeanMetadataAspect.class, key);
       }
     } else {
-      result = _server.find(EbeanMetadataAspect.class, key);
+      // for new schema or old schema, get latest data from new schema. (Resolving the read de-coupling issue)
+      final List<EbeanMetadataAspect> results = _localAccess.batchGetUnion(
+          Collections.singletonList(new AspectKey<>(aspectClass, urn, LATEST_VERSION)), 1, 0, true);
+      result = results.isEmpty() ? null : results.get(0);
     }
     return result;
   }
@@ -713,7 +747,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       // the metadata entity tables shouldn't been updated.
       _localAccess.add(urn, (ASPECT) value, aspectClass, auditStamp);
     }
-    _server.insert(aspect);
+
+    if (_changeLogEnabled) {
+      // skip appending change log table (metadata_aspect) if not enabled
+      _server.insert(aspect);
+    }
   }
 
   protected void saveRecordsToLocalIndex(@Nonnull URN urn, @Nonnull String aspect, @Nonnull String path,
@@ -784,42 +822,49 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   protected <ASPECT extends RecordTemplate> long getNextVersion(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass) {
+    if (!_changeLogEnabled) {
+      throw new UnsupportedOperationException("getNextVersion shouldn't be called when changeLog is disabled");
+    } else {
+      final List<PrimaryKey> result = _server.find(EbeanMetadataAspect.class)
+          .where()
+          .eq(URN_COLUMN, urn.toString())
+          .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
+          .orderBy()
+          .desc(VERSION_COLUMN)
+          .setMaxRows(1)
+          .findIds();
 
-    final List<PrimaryKey> result = _server.find(EbeanMetadataAspect.class)
-        .where()
-        .eq(URN_COLUMN, urn.toString())
-        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
-        .orderBy()
-        .desc(VERSION_COLUMN)
-        .setMaxRows(1)
-        .findIds();
-
-    return result.isEmpty() ? 0 : result.get(0).getVersion() + 1L;
+      return result.isEmpty() ? 0 : result.get(0).getVersion() + 1L;
+    }
   }
 
   @Override
   protected <ASPECT extends RecordTemplate> void applyVersionBasedRetention(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull URN urn, @Nonnull VersionBasedRetention retention, long largestVersion) {
-
-    _server.find(EbeanMetadataAspect.class)
-        .where()
-        .eq(URN_COLUMN, urn.toString())
-        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
-        .ne(VERSION_COLUMN, LATEST_VERSION)
-        .le(VERSION_COLUMN, largestVersion - retention.getMaxVersionsToRetain() + 1)
-        .delete();
+    if (_changeLogEnabled) {
+      // only apply version based retention when changeLog is enabled
+      _server.find(EbeanMetadataAspect.class)
+          .where()
+          .eq(URN_COLUMN, urn.toString())
+          .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
+          .ne(VERSION_COLUMN, LATEST_VERSION)
+          .le(VERSION_COLUMN, largestVersion - retention.getMaxVersionsToRetain() + 1)
+          .delete();
+    }
   }
 
   @Override
   protected <ASPECT extends RecordTemplate> void applyTimeBasedRetention(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull URN urn, @Nonnull TimeBasedRetention retention, long currentTime) {
-
-    _server.find(EbeanMetadataAspect.class)
-        .where()
-        .eq(URN_COLUMN, urn.toString())
-        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
-        .lt(CREATED_ON_COLUMN, new Timestamp(currentTime - retention.getMaxAgeToRetain()))
-        .delete();
+    if (_changeLogEnabled) {
+      // only apply time based retention when changeLog is enabled
+      _server.find(EbeanMetadataAspect.class)
+          .where()
+          .eq(URN_COLUMN, urn.toString())
+          .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
+          .lt(CREATED_ON_COLUMN, new Timestamp(currentTime - retention.getMaxAgeToRetain()))
+          .delete();
+    }
   }
 
   @Override
@@ -992,27 +1037,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  private List<EbeanMetadataAspect> batchGetOr(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
-      int keysCount, int position) {
-    ExpressionList<EbeanMetadataAspect> query = _server.find(EbeanMetadataAspect.class).select(ALL_COLUMNS).where();
-
-    // add or if it is not the last element
-    if (position != keys.size() - 1) {
-      query = query.or();
-    }
-
-    for (int index = position; index < keys.size() && index < position + keysCount; index++) {
-      query = query.and()
-          .eq(URN_COLUMN, keys.get(index).getUrn().toString())
-          .eq(ASPECT_COLUMN, ModelUtils.getAspectName(keys.get(index).getAspectClass()))
-          .eq(VERSION_COLUMN, keys.get(index).getVersion())
-          .endAnd();
-    }
-
-    return query.findList();
-  }
-
-  @Nonnull
   @SuppressWarnings({"checkstyle:FallThrough", "checkstyle:DefaultComesLast"})
   List<EbeanMetadataAspect> batchGetHelper(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
       int keysCount, int position) {
@@ -1024,13 +1048,13 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
 
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
-      return _localAccess.batchGetUnion(keys, keysCount, position);
+      return _localAccess.batchGetUnion(keys, keysCount, position, false);
     }
 
     if (_schemaConfig == SchemaConfig.DUAL_SCHEMA) {
       // Compare results from both new and old schemas
       final List<EbeanMetadataAspect> resultsOldSchema = batchGetUnion(keys, keysCount, position);
-      final List<EbeanMetadataAspect> resultsNewSchema = _localAccess.batchGetUnion(keys, keysCount, position);
+      final List<EbeanMetadataAspect> resultsNewSchema = _localAccess.batchGetUnion(keys, keysCount, position, false);
       EBeanDAOUtils.compareResults(resultsOldSchema, resultsNewSchema, "batchGet");
       return resultsOldSchema;
     }
@@ -1053,31 +1077,34 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   public <ASPECT extends RecordTemplate> ListResult<Long> listVersions(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull URN urn, int start, int pageSize) {
-
     checkValidAspect(aspectClass);
-
-    final PagedList<EbeanMetadataAspect> pagedList = _server.find(EbeanMetadataAspect.class)
-        .select(KEY_ID)
-        .where()
-        .eq(URN_COLUMN, urn.toString())
-        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
-        .ne(METADATA_COLUMN, DELETED_VALUE)
-        .setFirstRow(start)
-        .setMaxRows(pageSize)
-        .orderBy()
-        .asc(VERSION_COLUMN)
-        .findPagedList();
-
-    final List<Long> versions =
-        pagedList.getList().stream().map(a -> a.getKey().getVersion()).collect(Collectors.toList());
-    return toListResult(versions, null, pagedList, start);
+    if (_changeLogEnabled) {
+      PagedList<EbeanMetadataAspect> pagedList = _server.find(EbeanMetadataAspect.class)
+          .select(KEY_ID)
+          .where()
+          .eq(URN_COLUMN, urn.toString())
+          .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
+          .ne(METADATA_COLUMN, DELETED_VALUE)
+          .setFirstRow(start)
+          .setMaxRows(pageSize)
+          .orderBy()
+          .asc(VERSION_COLUMN)
+          .findPagedList();
+      final List<Long> versions =
+          pagedList.getList().stream().map(a -> a.getKey().getVersion()).collect(Collectors.toList());
+      return toListResult(versions, null, pagedList, start);
+    } else {
+      ListResult<ASPECT> aspectListResult = _localAccess.list(aspectClass, urn, start, pageSize);
+      return transformListResult(aspectListResult, aspect -> LATEST_VERSION);
+    }
   }
 
   @Override
   @Nonnull
   public <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull Class<ASPECT> aspectClass, int start,
       int pageSize) {
-    if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
+    if (_schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
+      // decouple from old schema
       return _localAccess.listUrns(aspectClass, start, pageSize);
     }
     checkValidAspect(aspectClass);
@@ -1125,22 +1152,26 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn,
       int start, int pageSize) {
-
     checkValidAspect(aspectClass);
-
-    final PagedList<EbeanMetadataAspect> pagedList = _server.find(EbeanMetadataAspect.class)
-        .select(ALL_COLUMNS)
-        .where()
-        .eq(URN_COLUMN, urn.toString())
-        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
-        .ne(METADATA_COLUMN, DELETED_VALUE)
-        .setFirstRow(start)
-        .setMaxRows(pageSize)
-        .orderBy()
-        .asc(VERSION_COLUMN)
-        .findPagedList();
-
-    return getListResult(aspectClass, pagedList, start);
+    PagedList<EbeanMetadataAspect> pagedList;
+    if (_changeLogEnabled) {
+      pagedList = _server.find(EbeanMetadataAspect.class)
+          .select(ALL_COLUMNS)
+          .where()
+          .eq(URN_COLUMN, urn.toString())
+          .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
+          .ne(METADATA_COLUMN, DELETED_VALUE)
+          .setFirstRow(start)
+          .setMaxRows(pageSize)
+          .orderBy()
+          .asc(VERSION_COLUMN)
+          .findPagedList();
+      return getListResult(aspectClass, pagedList, start);
+    } else {
+      // if changeLog is disabled, then list all the non-null,
+      // non-solft deleted, version-0) aspects from new schema table
+      return _localAccess.list(aspectClass, urn, start, pageSize);
+    }
   }
 
   @Override
@@ -1150,19 +1181,28 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     checkValidAspect(aspectClass);
 
-    final PagedList<EbeanMetadataAspect> pagedList = _server.find(EbeanMetadataAspect.class)
-        .select(ALL_COLUMNS)
-        .where()
-        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
-        .eq(VERSION_COLUMN, version)
-        .ne(METADATA_COLUMN, DELETED_VALUE)
-        .setFirstRow(start)
-        .setMaxRows(pageSize)
-        .orderBy()
-        .asc(URN_COLUMN)
-        .findPagedList();
+    if (_changeLogEnabled) {
 
-    return getListResult(aspectClass, pagedList, start);
+      PagedList<EbeanMetadataAspect> pagedList = _server.find(EbeanMetadataAspect.class)
+          .select(ALL_COLUMNS)
+          .where()
+          .eq(ASPECT_COLUMN, ModelUtils.getAspectName(aspectClass))
+          .eq(VERSION_COLUMN, version)
+          .ne(METADATA_COLUMN, DELETED_VALUE)
+          .setFirstRow(start)
+          .setMaxRows(pageSize)
+          .orderBy()
+          .asc(URN_COLUMN)
+          .findPagedList();
+
+      return getListResult(aspectClass, pagedList, start);
+    } else {
+      if (version != LATEST_VERSION) {
+        throw new UnsupportedOperationException(
+            "non-current version based list is not supported when ChangeLog is disabled");
+      }
+      return _localAccess.list(aspectClass, LATEST_VERSION, start, pageSize);
+    }
   }
 
   @Override
@@ -1202,6 +1242,29 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         extraInfo));
   }
 
+
+  /**
+   * Transform list result from type T to type R.
+   * @param listResult input list result
+   * @param function transform funcdtion
+   * @param <T> input data type
+   * @param <R> output data type
+   * @return ListResult of type R
+   */
+  @Nonnull
+  public static  <T, R> ListResult<R> transformListResult(@Nonnull ListResult<T> listResult,
+      @Nonnull Function<T, R> function) {
+    List<R> values = listResult.getValues().stream().map(function).collect(Collectors.toList());
+    return ListResult.<R>builder().values(values)
+        .metadata(listResult.getMetadata())
+        .nextStart(listResult.getNextStart())
+        .havingMore(listResult.isHavingMore())
+        .totalCount(listResult.getTotalCount())
+        .totalPageCount(listResult.getTotalPageCount())
+        .pageSize(listResult.getPageSize())
+        .build();
+  }
+
   @Nonnull
   private <T> ListResult<T> toListResult(@Nonnull List<T> values, @Nullable ListResultMetadata listResultMetadata,
       @Nonnull PagedList<?> pagedList, @Nullable Integer start) {
@@ -1234,19 +1297,23 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  static AuditStamp makeAuditStamp(@Nonnull EbeanMetadataAspect aspect) {
+  static AuditStamp makeAuditStamp(@Nonnull Timestamp timestamp, @Nonnull String actor, @Nullable String impersonator) {
     final AuditStamp auditStamp = new AuditStamp();
-    auditStamp.setTime(aspect.getCreatedOn().getTime());
-
+    auditStamp.setTime(timestamp.getTime());
     try {
-      auditStamp.setActor(new Urn(aspect.getCreatedBy()));
-      if (aspect.getCreatedFor() != null) {
-        auditStamp.setImpersonator(new Urn(aspect.getCreatedFor()));
+      auditStamp.setActor(new Urn(actor));
+      if (impersonator != null) {
+        auditStamp.setImpersonator(new Urn(impersonator));
       }
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
     }
     return auditStamp;
+  }
+
+  @Nonnull
+  static AuditStamp makeAuditStamp(@Nonnull EbeanMetadataAspect aspect) {
+    return makeAuditStamp(aspect.getCreatedOn(), aspect.getCreatedBy(), aspect.getCreatedFor());
   }
 
   @Nonnull

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -106,6 +106,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   public void setChangeLogEnabled(boolean changeLogEnabled) {
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
       _changeLogEnabled = changeLogEnabled;
+    } else {
+      // For non-new schema, _changeLog will be enforced to be true
+      _changeLogEnabled = true;
     }
   }
 
@@ -480,6 +483,14 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public SchemaConfig getSchemaConfig() {
     return _schemaConfig;
+  }
+
+  /**
+   * Overwride schema config, unit-test only.
+   * @param schemaConfig schema config
+   */
+  void setSchemaConfig(SchemaConfig schemaConfig) {
+    _schemaConfig = schemaConfig;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -641,7 +641,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         result = _server.find(EbeanMetadataAspect.class, key);
       }
     } else {
-      // for new schema or old schema, get latest data from new schema. (Resolving the read de-coupling issue)
+      // for new schema or dual-schema, get latest data from new schema. (Resolving the read de-coupling issue)
       final List<EbeanMetadataAspect> results = _localAccess.batchGetUnion(
           Collections.singletonList(new AspectKey<>(aspectClass, urn, LATEST_VERSION)), 1, 0, true);
       result = results.isEmpty() ? null : results.get(0);
@@ -1201,7 +1201,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         throw new UnsupportedOperationException(
             "non-current version based list is not supported when ChangeLog is disabled");
       }
-      return _localAccess.list(aspectClass, LATEST_VERSION, start, pageSize);
+
+      return _localAccess.list(aspectClass, start, pageSize);
     }
   }
 
@@ -1246,7 +1247,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   /**
    * Transform list result from type T to type R.
    * @param listResult input list result
-   * @param function transform funcdtion
+   * @param function transform function
    * @param <T> input data type
    * @param <R> output data type
    * @return ListResult of type R

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -134,7 +134,6 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * aspect if the specific version of a specific aspect was soft deleted.
    *
    * @param aspectClass the type of the aspect to query
-   * @param version the version of the aspect
    * @param start the starting offset of the page
    * @param pageSize the size of the page
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
@@ -142,7 +141,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    */
   @Nonnull
   <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
-      long version, int start, int pageSize);
+     int start, int pageSize);
 
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -49,12 +49,13 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param keys {@link AspectKey} to retrieve aspect metadata
    * @param keysCount pagination key count limit
    * @param position starting position of pagination
+   * @param includeSoftDeleted include soft deleted aspects, default false
    * @param <ASPECT> metadata aspect value
    * @return a list of {@link EbeanMetadataAspect} as get response
    */
   @Nonnull
   <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> batchGetUnion(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
-      int keysCount, int position);
+      int keysCount, int position, boolean includeSoftDeleted);
 
   /**
    * Returns list of urns that satisfy the given filter conditions.
@@ -111,6 +112,38 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    */
   @Nonnull
   <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull Class<ASPECT> aspectClass, int start, int pageSize);
+
+
+  /**
+   * Paginates over all versions of an aspect for a specific Urn. It does not return metadata corresponding to versions
+   * indicating soft deleted aspect(s).
+   *
+   * @param aspectClass the type of the aspect to query
+   * @param urn {@link Urn} for the entity
+   * @param start the starting offset of the page
+   * @param pageSize the size of the page
+   * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
+   * @return a {@link ListResult} containing a list of aspects and other pagination information
+   */
+  @Nonnull
+  <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
+      @Nonnull URN urn, int start, int pageSize);
+
+  /**
+   * Paginates over a specific version of a specific aspect for all Urns. The result does not include soft deleted
+   * aspect if the specific version of a specific aspect was soft deleted.
+   *
+   * @param aspectClass the type of the aspect to query
+   * @param version the version of the aspect
+   * @param start the starting offset of the page
+   * @param pageSize the size of the page
+   * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
+   * @return a {@link ListResult} containing a list of aspects and other pagination information
+   */
+  @Nonnull
+  <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
+      long version, int start, int pageSize);
+
 
   /**
    * Provide a local relationship builder registry. Local relationships will be built based on the builders during data ingestion.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -15,6 +15,7 @@ import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -154,6 +155,7 @@ public class EBeanDAOUtils {
    * Read {@link SqlRow} list into a {@link EbeanMetadataAspect} list.
    * @param sqlRows list of {@link SqlRow}
    * @return list of {@link EbeanMetadataAspect}
+   * @deprecated This method has been deprecated, use {@link #readSqlRow(SqlRow, Class)} instead.
    */
   // TODO: make this method private once all users' custom SQL queries have been replaced by DAO-supported methods
   public static List<EbeanMetadataAspect> readSqlRows(List<SqlRow> sqlRows) {
@@ -174,6 +176,73 @@ public class EBeanDAOUtils {
         return ebeanMetadataAspect;
       });
     }).collect(Collectors.toList());
+  }
+
+  /**
+   * Read {@link SqlRow} list into a {@link EbeanMetadataAspect} list.
+   * @param sqlRows a list of {@link SqlRow} to aspect {@link Class} map.
+   * @param <ASPECT> aspect class type
+   * @return list of {@link EbeanMetadataAspect}
+   */
+  public static <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> readSqlRows(
+      @Nonnull Map<SqlRow, Class<ASPECT>> sqlRows) {
+    return sqlRows.entrySet().stream().flatMap(entry -> {
+      List<String> columns = new ArrayList<>();
+      SqlRow sqlRow = entry.getKey();
+      sqlRow.keySet()
+          .stream()
+          .filter(key -> key.startsWith(SQLSchemaUtils.ASPECT_PREFIX) && sqlRow.get(key) != null)
+          .forEach(columns::add);
+
+      return columns.stream().map(columnName -> readSqlRow(sqlRow, entry.getValue()));
+    }).collect(Collectors.toList());
+  }
+
+  /**
+   * Read EbeanMetadataAspect from {@link SqlRow}.
+   * @param sqlRow {@link SqlRow}
+   * @param aspectClass aspect class
+   * @param <ASPECT> aspect type
+   * @return {@link EbeanMetadataAspect}
+   */
+  private static <ASPECT extends RecordTemplate> EbeanMetadataAspect readSqlRow(SqlRow sqlRow,
+      Class<ASPECT> aspectClass) {
+    final String columnName = SQLSchemaUtils.getAspectColumnName(aspectClass);
+    final EbeanMetadataAspect ebeanMetadataAspect = new EbeanMetadataAspect();
+    final String urn = sqlRow.getString("urn");
+    EbeanMetadataAspect.PrimaryKey primaryKey;
+
+    if (isSoftDeletedAspect(sqlRow, columnName)) {
+      primaryKey = new EbeanMetadataAspect.PrimaryKey(urn, aspectClass.getCanonicalName(), LATEST_VERSION);
+      ebeanMetadataAspect.setCreatedBy(sqlRow.getString("lastmodifiedby"));
+      ebeanMetadataAspect.setCreatedOn(sqlRow.getTimestamp("lastmodifiedon"));
+      ebeanMetadataAspect.setCreatedFor(sqlRow.getString("createdfor"));
+      ebeanMetadataAspect.setMetadata(DELETED_VALUE);
+    } else {
+      AuditedAspect auditedAspect = RecordUtils.toRecordTemplate(AuditedAspect.class, sqlRow.getString(columnName));
+      primaryKey = new EbeanMetadataAspect.PrimaryKey(urn, auditedAspect.getCanonicalName(), LATEST_VERSION);
+      ebeanMetadataAspect.setCreatedBy(auditedAspect.getLastmodifiedby());
+      ebeanMetadataAspect.setCreatedOn(Timestamp.valueOf(auditedAspect.getLastmodifiedon()));
+      ebeanMetadataAspect.setCreatedFor(auditedAspect.getCreatedfor());
+      ebeanMetadataAspect.setMetadata(extractAspectJsonString(sqlRow.getString(columnName)));
+    }
+    ebeanMetadataAspect.setKey(primaryKey);
+    return ebeanMetadataAspect;
+  }
+
+  /**
+   * Checks whether the entity table record has been soft deleted.
+   * @param sqlRow {@link SqlRow} result from MySQL server
+   * @param columnName column name of entity table
+   * @return boolean representing whether the aspect record has been soft deleted
+   */
+  public static boolean isSoftDeletedAspect(@Nonnull SqlRow sqlRow, @Nonnull String columnName) {
+    try {
+      SoftDeletedAspect aspect = RecordUtils.toRecordTemplate(SoftDeletedAspect.class, sqlRow.getString(columnName));
+      return aspect.hasGma_deleted() && aspect.isGma_deleted();
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -38,6 +38,8 @@ public class SQLStatementUtils {
 
   public static final String SOFT_DELETED_CHECK = "JSON_EXTRACT(%s, '$.gma_deleted') IS NULL"; // true when not soft deleted
 
+  public static final String NONNULL_CHECK = "%s IS NOT NULL"; // true when the value of aspect_column is not NULL
+
   private static final String SQL_UPSERT_ASPECT_TEMPLATE =
       "INSERT INTO %s (urn, %s, lastmodifiedon, lastmodifiedby) VALUE (:urn, :metadata, :lastmodifiedon, :lastmodifiedby) "
           + "ON DUPLICATE KEY UPDATE %s = :metadata, lastmodifiedon = :lastmodifiedon;";
@@ -48,6 +50,23 @@ public class SQLStatementUtils {
 
   private static final String SQL_READ_ASPECT_TEMPLATE =
       String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby FROM %%s WHERE urn = '%%s' AND %s", SOFT_DELETED_CHECK);
+
+  private static final String SQL_LIST_ASPECT_BY_URN_TEMPLATE =
+      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby, createdfor FROM %%s WHERE urn = '%%s' AND %s AND %s", NONNULL_CHECK, SOFT_DELETED_CHECK);
+
+  private static final String SQL_LIST_ASPECT_BY_URN_WITH_SOFT_DELETED_TEMPLATE =
+      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby, createdfor FROM %%s WHERE urn = '%%s' AND %s", NONNULL_CHECK);
+
+  private static final String SQL_LIST_ASPECT_WITH_PAGINATION_TEMPLATE =
+      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby, createdfor, (SELECT COUNT(urn) FROM %%s WHERE %s AND %s) "
+          + "as _total_count FROM %%s WHERE %s AND %s LIMIT %%s OFFSET %%s", NONNULL_CHECK, SOFT_DELETED_CHECK, NONNULL_CHECK, SOFT_DELETED_CHECK);
+
+  private static final String SQL_LIST_ASPECT_WITH_PAGINATION_WITH_SOFT_DELETED_TEMPLATE =
+      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby, createdfor, (SELECT COUNT(urn) FROM %%s WHERE %s) "
+          + "as _total_count FROM %%s WHERE %s LIMIT %%s OFFSET %%s", NONNULL_CHECK,  NONNULL_CHECK);
+
+  private static final String SQL_READ_ASPECT_WITH_SOFT_DELETED_TEMPLATE =
+      "SELECT urn, %s, lastmodifiedon, lastmodifiedby FROM %s WHERE urn = '%s'";
 
   private static final String INDEX_GROUP_BY_CRITERION = "SELECT count(*) as COUNT, %s FROM %s";
   private static final String SQL_GROUP_BY_COLUMN_EXISTS_TEMPLATE =
@@ -106,23 +125,71 @@ public class SQLStatementUtils {
    * </p>
    * @param aspectClass aspect class to query for
    * @param urns a Set of Urns to query for
+   * @param includeSoftDeleted a flag to include soft deleted records
    * @param <ASPECT> aspect type
    * @return aspect read sql statement for a single aspect (across multiple tables and urns)
    */
   public static <ASPECT extends RecordTemplate> String createAspectReadSql(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull Set<Urn> urns) {
+      @Nonnull Set<Urn> urns, boolean includeSoftDeleted) {
     if (urns.size() == 0) {
       throw new IllegalArgumentException("Need at least 1 urn to query.");
     }
     final String columnName = getAspectColumnName(aspectClass);
     StringBuilder stringBuilder = new StringBuilder();
     List<String> selectStatements = urns.stream().map(urn -> {
-          final String tableName = getTableName(urn);
-          return String.format(SQL_READ_ASPECT_TEMPLATE, columnName, tableName, escapeReservedCharInUrn(urn.toString()), columnName);
-        }).collect(Collectors.toList());
+      final String tableName = getTableName(urn);
+      final String sqlTemplate =
+          includeSoftDeleted ? SQL_READ_ASPECT_WITH_SOFT_DELETED_TEMPLATE : SQL_READ_ASPECT_TEMPLATE;
+      return String.format(sqlTemplate, columnName, tableName, escapeReservedCharInUrn(urn.toString()), columnName);
+    }).collect(Collectors.toList());
     stringBuilder.append(String.join(" UNION ALL ", selectStatements));
     return stringBuilder.toString();
   }
+
+  /**
+   * List all the aspect (versions) for a given entity urn and aspect type.
+   * @param aspectClass aspect type
+   * @param urn entity urn
+   * @param includeSoftDeleted whether to include soft deleted aspects
+   * @param <ASPECT> aspect type
+   * @return a SQL to run listing aspect query
+   */
+  public static <ASPECT extends RecordTemplate> String createListAspectByUrnSql(@Nonnull Class<ASPECT> aspectClass,
+      @Nonnull Urn urn, boolean includeSoftDeleted) {
+    final String columnName = getAspectColumnName(aspectClass);
+    final String tableName = getTableName(urn);
+    if (includeSoftDeleted) {
+      return String.format(SQL_LIST_ASPECT_BY_URN_WITH_SOFT_DELETED_TEMPLATE, columnName, tableName,
+          escapeReservedCharInUrn(urn.toString()), columnName);
+    } else {
+      return String.format(SQL_LIST_ASPECT_BY_URN_TEMPLATE, columnName, tableName,
+          escapeReservedCharInUrn(urn.toString()), columnName, columnName);
+    }
+  }
+
+  /**
+   * List all the aspects for a given entity type and aspect type.
+   * @param aspectClass aspect type
+   * @param tableName table name
+   * @param includeSoftDeleted whether to include soft deleted aspects
+   * @param start pagination offset
+   * @param pageSize page size
+   * @param <ASPECT> aspect type
+   * @return a SQL to run listing aspect query with pagination.
+   */
+  public static <ASPECT extends RecordTemplate> String createListAspectWithPaginationSql(@Nonnull Class<ASPECT> aspectClass,
+      String tableName, boolean includeSoftDeleted, int start, int pageSize) {
+    final String columnName = getAspectColumnName(aspectClass);
+    if (includeSoftDeleted) {
+      return String.format(SQL_LIST_ASPECT_WITH_PAGINATION_WITH_SOFT_DELETED_TEMPLATE, columnName, tableName,
+          columnName, tableName, columnName, pageSize, start);
+    } else {
+      return String.format(SQL_LIST_ASPECT_WITH_PAGINATION_TEMPLATE, columnName, tableName, columnName, columnName,
+          tableName, columnName, columnName, pageSize, start);
+    }
+  }
+
+
 
   /**
    * Create Upsert SQL statement.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -147,7 +147,7 @@ public class SQLStatementUtils {
   }
 
   /**
-   * List all the aspect (versions) for a given entity urn and aspect type.
+   * List all the aspect record (0 or 1) for a given entity urn and aspect type.
    * @param aspectClass aspect type
    * @param urn entity urn
    * @param includeSoftDeleted whether to include soft deleted aspects

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -3309,6 +3309,28 @@ public class EbeanLocalDAOTest {
     }
   }
 
+  @Test
+  public void testDataNotWrittenIntoOldSchemaWhenChangeLogIsDisabled() {
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+    if (dao.isChangeLogEnabled()) {
+      // this test is only applicable when changeLog is disabled
+      return;
+    }
+
+    // Given: an empty old schema and empty new schema and changelog is disabled
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> legacyDao = createDao(FooUrn.class);
+    legacyDao.setSchemaConfig(SchemaConfig.OLD_SCHEMA_ONLY);
+    legacyDao.setChangeLogEnabled(false);
+
+    // When: AspectFoo is written into the dao.
+    FooUrn fooUrn = makeFooUrn(1);
+    AspectFoo v1 = new AspectFoo().setValue("foo");
+    dao.add(fooUrn, v1, _dummyAuditStamp);
+
+    // Expect: the aspect foo is only written into the new schema.
+    assertTrue(dao.get(AspectFoo.class, fooUrn).isPresent());
+    assertFalse(legacyDao.get(AspectFoo.class, fooUrn).isPresent());
+  }
 
   @Nonnull
   private EbeanMetadataAspect getMetadata(Urn urn, String aspectName, long version, @Nullable RecordTemplate metadata) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -138,11 +138,6 @@ public class EbeanLocalDAOTest {
 
   @Factory(dataProvider = "inputList")
   public EbeanLocalDAOTest(SchemaConfig schemaConfig, FindMethodology findMethodology, boolean enableChangeLog) {
-
-    System.out.println(
-        String.format("schema config: %s, find method %s, enable change log: %s", schemaConfig, findMethodology,
-            enableChangeLog));
-
     _schemaConfig = schemaConfig;
     _findMethodology = findMethodology;
     _enableChangeLog = enableChangeLog;
@@ -166,6 +161,12 @@ public class EbeanLocalDAOTest {
         {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, false},
         {SchemaConfig.DUAL_SCHEMA, FindMethodology.UNIQUE_ID, true},
         {SchemaConfig.DUAL_SCHEMA, FindMethodology.UNIQUE_ID, false},
+        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, true},
+        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, false},
+        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, true},
+        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, false},
+        {SchemaConfig.DUAL_SCHEMA, FindMethodology.DIRECT_SQL, true},
+        {SchemaConfig.DUAL_SCHEMA, FindMethodology.DIRECT_SQL, false},
     };
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -11,6 +11,7 @@ import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
+import io.ebean.SqlRow;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -25,7 +26,9 @@ import javax.annotation.Nonnull;
 import org.testng.annotations.Test;
 
 import static com.linkedin.testing.TestUtils.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
@@ -512,5 +515,19 @@ public class EBeanDAOUtilsTest {
 
     // sanity test on JDBC functions
     assertNotNull(EBeanDAOUtils.getWithJdbc(fooUrn.toString(), fooAspect.getClass().getCanonicalName(), server, key));
+  }
+
+  @Test
+  public void testIsSoftDeletedAspect() {
+    SqlRow sqlRow = mock(SqlRow.class);
+    when(sqlRow.getString("a_aspectfoo")).thenReturn("{\"gma_deleted\": true}");
+    assertTrue(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, "a_aspectfoo"));
+
+    when(sqlRow.getString("a_aspectbar")).thenReturn(
+        "{\"aspect\": {\"value\": \"bar\"}, \"lastmodifiedby\": \"urn:li:tester\"}");
+    assertFalse(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, "a_aspectbar"));
+
+    when(sqlRow.getString("a_aspectbaz")).thenReturn("{\"random_value\": \"baz\"}");
+    assertFalse(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, "a_aspectbaz"));
   }
 }


### PR DESCRIPTION
## Summary

This change is as port of the Cold Archive provide, which target for moving change history out of the online MySQL datastore. This change will provide a configurable figure at entity DAO level, that users can stop writing change history into metadata_aspect table after updating the entity_table (dual-write)

with this change log disabled, the behavior of the following DAO APIs will behave differently

* list aspect history, list versions by given urn or aspect type - it will only return at most 1 aspect (current version), whereas previously it will return all the aspect change histories
* version or time-based retention will not be applicable when change log is disabled.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
