### PR TITLE
Disable MAEv4 on backfill path

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -134,6 +134,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
   private static final String DEFAULT_ID_NAMESPACE = "global";
 
+  private static final String BACKFILL_EMITTER = "dao_backfill_endpoint";
+
   private static final IndefiniteRetention INDEFINITE_RETENTION = new IndefiniteRetention();
 
   private static final int DEFAULT_MAX_TRANSACTION_RETRY = 3;
@@ -1163,14 +1165,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         || mode == BackfillMode.BACKFILL_INCLUDING_LIVE_INDEX) {
       IngestionMode ingestionMode = ALLOWED_INGESTION_BACKFILL_BIMAP.inverse().get(mode);
       if (_trackingProducer != null) {
-        _trackingProducer.produceMetadataAuditEvent(urn, aspect, aspect);
-        IngestionTrackingContext trackingContext = new IngestionTrackingContext();
-        trackingContext.setTrackingId(TrackingUtils.getRandomUUID());
-        trackingContext.setEmitter("dao_backfill_endpoint");
-        trackingContext.setEmitTime(System.currentTimeMillis());
+        IngestionTrackingContext trackingContext = buildIngestionTrackingContext(
+            TrackingUtils.getRandomUUID(), BACKFILL_EMITTER, System.currentTimeMillis());
+
         _trackingProducer.produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null, trackingContext, ingestionMode);
       } else {
-        _producer.produceMetadataAuditEvent(urn, aspect, aspect);
         _producer.produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
       }
     }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/IngestionUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/IngestionUtils.java
@@ -2,8 +2,11 @@ package com.linkedin.metadata.dao.utils;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.linkedin.avro2pegasus.events.UUID;
 import com.linkedin.metadata.backfill.BackfillMode;
 import com.linkedin.metadata.events.IngestionMode;
+import com.linkedin.metadata.events.IngestionTrackingContext;
+import javax.annotation.Nonnull;
 
 
 public class IngestionUtils {
@@ -22,5 +25,16 @@ public class IngestionUtils {
     biMap.put(IngestionMode.BACKFILL, BackfillMode.BACKFILL_INCLUDING_LIVE_INDEX);
     biMap.put(IngestionMode.BOOTSTRAP, BackfillMode.BACKFILL_ALL);
     return biMap;
+  }
+
+  /**
+   * Build IngestionTrackingContext.
+   */
+  @Nonnull
+  public static IngestionTrackingContext buildIngestionTrackingContext(@Nonnull UUID uuid, @Nonnull String emitter, long timestamp) {
+    return new IngestionTrackingContext()
+        .setTrackingId(uuid)
+        .setEmitter(emitter)
+        .setEmitTime(timestamp);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -719,8 +719,6 @@ public class EbeanLocalDAOTest {
     Optional<AspectFoo> foo = dao.backfill(AspectFoo.class, urn);
 
     assertEquals(foo.get(), expected);
-
-    verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, expected, expected);
     verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, expected, expected, null);
     verifyNoMoreInteractions(_mockProducer);
   }
@@ -801,7 +799,6 @@ public class EbeanLocalDAOTest {
     for (Urn urn : urns) {
       RecordTemplate aspect = aspects.get(urn).get(AspectFoo.class);
       assertEquals(backfilledAspects.get(urn).get(AspectFoo.class).get(), aspect);
-      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
     }
   }
 
@@ -829,7 +826,6 @@ public class EbeanLocalDAOTest {
     for (Class<? extends RecordTemplate> clazz : aspects.get(urns.get(0)).keySet()) {
       RecordTemplate aspect = aspects.get(urns.get(0)).get(clazz);
       assertEquals(backfilledAspects.get(urns.get(0)).get(clazz).get(), aspect);
-      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urns.get(0), aspect, aspect);
     }
   }
 
@@ -861,7 +857,6 @@ public class EbeanLocalDAOTest {
       for (Class<? extends RecordTemplate> clazz : aspects.get(urn).keySet()) {
         RecordTemplate aspect = aspects.get(urn).get(clazz);
         assertEquals(backfilledAspects.get(urn).get(clazz).get(), aspect);
-        verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
         verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
       }
     }
@@ -913,7 +908,6 @@ public class EbeanLocalDAOTest {
       Urn urn = urns.get(index);
       RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
       assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
-      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
       verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
     }
     clearInvocations(_mockProducer);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -923,7 +923,6 @@ public class EbeanLocalDAOTest {
       Urn urn = urns.get(index);
       RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
       assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
-      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
       verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
     }
     verifyNoMoreInteractions(_mockProducer);
@@ -937,7 +936,6 @@ public class EbeanLocalDAOTest {
       Urn urn = urns.get(index);
       RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
       assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
-      verify(_mockProducer, times(0)).produceMetadataAuditEvent(urn, aspect, aspect);
       verify(_mockProducer, times(0)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
     }
     verifyNoMoreInteractions(_mockProducer);
@@ -951,7 +949,6 @@ public class EbeanLocalDAOTest {
       Urn urn = urns.get(index);
       RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
       assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
-      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
       verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null);
     }
     verifyNoMoreInteractions(_mockProducer);


### PR DESCRIPTION
Normal MAEv4 emission is disabled by default in previous PR. https://github.com/linkedin/datahub-gma/pull/291
In this PR, we disable MAEv4 emission on backfill path as well. 

And some minor refactors to improve code style.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
