### PR TITLE
fix: use MetadataAuditStamp instead of com.linkedin.common.AuditStamp

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/MetadataAuditStamp.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/MetadataAuditStamp.pdl
@@ -1,0 +1,25 @@
+namespace com.linkedin.metadata.events
+
+/**
+ * Data captured on a resource/association/sub-resource level giving insight into when that resource/association/sub-resource moved into a particular lifecycle stage, and who acted to move it into that specific lifecycle stage.
+ */
+record MetadataAuditStamp {
+
+  /**
+   * When did the resource/association/sub-resource move into the specific lifecycle stage represented by this MetadataAuditEvent.
+   * i.e. createdon column of a metadata entity table
+   */
+  time: long
+
+  /**
+   * The entity (e.g. a member URN) which will be credited for moving the resource/association/sub-resource into the specific lifecycle stage. It is also the one used to authorize the change.
+   * i.e. createdby column of a metadata entity table
+   */
+  actor: string
+
+  /**
+   * The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.
+   * i.e. createdfor column of a metadata entity table
+   */
+  impersonator: optional string
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -1,10 +1,10 @@
 namespace com.linkedin.testing.mxe.bar.annotatedAspectBar
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.common.AuditStamp
 import com.linkedin.metadata.events.ChangeType
 import com.linkedin.metadata.events.IngestionTrackingContext
 import com.linkedin.metadata.events.IngestionMode
+import com.linkedin.metadata.events.MetadataAuditStamp
 import com.linkedin.testing.BarUrn
 import com.linkedin.testing.AnnotatedAspectBar
 
@@ -47,7 +47,7 @@ record MetadataAuditEvent {
   /**
    * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
    */
-  auditStamp: union[null, AuditStamp] = null
+  auditStamp: union[null, MetadataAuditStamp] = null
 
   /**
    * Type of the ingestion. Allow null for backward compatibility. Downstream should treat null as live ingestion.

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -4,10 +4,10 @@
 namespace @(eventSpec.getNamespace())
 
 import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-import com.linkedin.common.AuditStamp
 import com.linkedin.metadata.events.ChangeType
 import com.linkedin.metadata.events.IngestionTrackingContext
 import com.linkedin.metadata.events.IngestionMode
+import com.linkedin.metadata.events.MetadataAuditStamp
 import @eventSpec.getUrnType()
 import @eventSpec.getFullValueType()
 
@@ -50,7 +50,7 @@ record MetadataAuditEvent {
   /**
    * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
    */
-  auditStamp: union[null, AuditStamp] = null
+  auditStamp: union[null, MetadataAuditStamp] = null
 
   /**
    * Type of the ingestion. Allow null for backward compatibility. Downstream should treat null as live ingestion.

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -135,10 +135,10 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
       namespace com.linkedin.mxe.foo.testAspect
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-      import com.linkedin.common.AuditStamp
       import com.linkedin.metadata.events.ChangeType
       import com.linkedin.metadata.events.IngestionTrackingContext
       import com.linkedin.metadata.events.IngestionMode
+      import com.linkedin.metadata.events.MetadataAuditStamp
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestAspect
 
@@ -181,7 +181,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
          */
-        auditStamp: union[null, AuditStamp] = null
+        auditStamp: union[null, MetadataAuditStamp] = null
         
         /**
          * Type of the ingestion. Allow null for backward compatibility. Downstream should treat null as live ingestion.
@@ -261,10 +261,10 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
       namespace com.linkedin.mxe.foo.testTyperefAspect
 
       import com.linkedin.avro2pegasus.events.KafkaAuditHeader
-      import com.linkedin.common.AuditStamp
       import com.linkedin.metadata.events.ChangeType
       import com.linkedin.metadata.events.IngestionTrackingContext
       import com.linkedin.metadata.events.IngestionMode
+      import com.linkedin.metadata.events.MetadataAuditStamp
       import com.linkedin.testing.FooUrn
       import com.linkedin.metadata.test.aspects.TestTyperefAspect
 
@@ -307,7 +307,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
          */
-        auditStamp: union[null, AuditStamp] = null
+        auditStamp: union[null, MetadataAuditStamp] = null
         
         /**
          * Type of the ingestion. Allow null for backward compatibility. Downstream should treat null as live ingestion.


### PR DESCRIPTION
Saw some downstream errors complaining about namespace mismatch i.e.
```
com.linkedin.schemaregistry.validation.IncompatibleSchemaException: com.linkedin.schemaregistry.AvroSchemaRenameException: (suspected) attempt to rename nested RECORD com.linkedin.common.AuditStamp to com.linkedin.pegasus2avro.common.AuditStamp
At :MetadataAuditEvent:auditStamp:union
```

The reason is because the downstream (metadata-models) explicitly excludes core-models module, which com.linkedin.common.AuditStamp is a part of. So one solution to this is to define our own AuditStamp model and use that instead. To avoid confusion, renamed to MetadataAuditStamp.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
