### PR TITLE
fix(new schema): read metadata_aspect during getLatest regardless of schema mode

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -663,7 +663,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       @Nonnull Class<ASPECT> aspectClass) {
 
     EbeanMetadataAspect result;
-    if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
+    if (_changeLogEnabled) {
       final String aspectName = ModelUtils.getAspectName(aspectClass);
       final PrimaryKey key = new PrimaryKey(urn.toString(), aspectName, LATEST_VERSION);
       if (_findMethodology == FindMethodology.DIRECT_SQL) {


### PR DESCRIPTION
There is a bug with a recent PR #298 which is causing OptimisticLockException to be thrown. Essentially, getLatest is reading from the new schema (in new schema only mode) but updateWithOptimisticLocking is trying to apply optimistic locking on the old schema table using the timestamp returned from the getLatest call on the entity table. The timestamps in the old and new schema tables may be off by a few ms so the update will fail during timestamp comparation.

This PR aims to revert part of that PR by reading the old schema table during getLatest always UNLESS change log is disabled.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
