### PR TITLE
APA-93246 fix dual-write issue on update wiht optimitic locking

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -663,7 +663,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       @Nonnull Class<ASPECT> aspectClass) {
 
     EbeanMetadataAspect result;
-    if (_changeLogEnabled) {
+    if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       final String aspectName = ModelUtils.getAspectName(aspectClass);
       final PrimaryKey key = new PrimaryKey(urn.toString(), aspectName, LATEST_VERSION);
       if (_findMethodology == FindMethodology.DIRECT_SQL) {
@@ -728,6 +728,43 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     return aspect;
   }
 
+  // Build manual SQL update query to enable optimistic locking on a given column
+  // Optimistic locking is supported on ebean using @version, see https://ebean.io/docs/mapping/jpa/version
+  // But we can't use @version annotation for optimistic locking for two reasons:
+  //   1. That prevents flag guarding optimistic locking feature
+  //   2. When using @version annotation, Ebean starts to override all updates to that column
+  //      by disregarding any user change.
+  // Ideally, another column for the sake of optimistic locking would be preferred but that means a change to
+  // metadata_aspect schema and we don't take this route here to keep this change backward compatible.
+  static final String OPTIMISTIC_LOCKING_UPDATE_SQL = "UPDATE metadata_aspect "
+      + "SET urn = :urn, aspect = :aspect, version = :version, metadata = :metadata, createdOn = :createdOn, createdBy = :createdBy "
+      + "WHERE urn = :urn and aspect = :aspect and version = :version";
+  
+  /**
+   * Assembly SQL UPDATE script for old Schema.
+   * @param aspect {@link EbeanMetadataAspect}
+   * @param oldTimestamp old timestamp. If provided, the generated SQL will use optimistic locking and do compare-and-set
+   *                     with oldTimestamp during the update.
+   * @return {@link SqlUpdate} for SQL update execution
+   */
+  private SqlUpdate assemblyOldSchemaSqlUpdate(@Nonnull EbeanMetadataAspect aspect, @Nullable Timestamp oldTimestamp) {
+
+    final SqlUpdate oldSchemaSqlUpdate;
+    if (oldTimestamp == null) {
+      oldSchemaSqlUpdate = _server.createSqlUpdate(OPTIMISTIC_LOCKING_UPDATE_SQL);
+    } else {
+      oldSchemaSqlUpdate = _server.createSqlUpdate(OPTIMISTIC_LOCKING_UPDATE_SQL + " and createdOn = :oldTimestamp");
+      oldSchemaSqlUpdate.setParameter("oldTimestamp", oldTimestamp);
+    }
+    oldSchemaSqlUpdate.setParameter("urn", aspect.getKey().getUrn());
+    oldSchemaSqlUpdate.setParameter("aspect", aspect.getKey().getAspect());
+    oldSchemaSqlUpdate.setParameter("version", aspect.getKey().getVersion());
+    oldSchemaSqlUpdate.setParameter("metadata", aspect.getMetadata());
+    oldSchemaSqlUpdate.setParameter("createdOn", aspect.getCreatedOn());
+    oldSchemaSqlUpdate.setParameter("createdBy", aspect.getCreatedBy());
+    return oldSchemaSqlUpdate;
+  }
+
   @VisibleForTesting
   @Override
   protected <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull URN urn,
@@ -736,43 +773,37 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
     final EbeanMetadataAspect aspect = buildMetadataAspectBean(urn, value, aspectClass, newAuditStamp, version);
 
-    // Build manual SQL update query to enable optimistic locking on a given column
-    // Optimistic locking is supported on ebean using @version, see https://ebean.io/docs/mapping/jpa/version
-    // But we can't use @version annotation for optimistic locking for two reasons:
-    //   1. That prevents flag guarding optimistic locking feature
-    //   2. When using @version annotation, Ebean starts to override all updates to that column
-    //      by disregarding any user change.
-    // Ideally, another column for the sake of optimistic locking would be preferred but that means a change to
-    // metadata_aspect schema and we don't take this route here to keep this change backward compatible.
-    final String updateQuery = "UPDATE metadata_aspect "
-        + "SET urn = :urn, aspect = :aspect, version = :version, metadata = :metadata, createdOn = :createdOn, createdBy = :createdBy "
-        + "WHERE urn = :urn and aspect = :aspect and version = :version and createdOn = :oldTimestamp";
-
-    final SqlUpdate update = _server.createSqlUpdate(updateQuery);
-    update.setParameter("urn", aspect.getKey().getUrn());
-    update.setParameter("aspect", aspect.getKey().getAspect());
-    update.setParameter("version", aspect.getKey().getVersion());
-    update.setParameter("metadata", aspect.getMetadata());
-    update.setParameter("createdOn", aspect.getCreatedOn());
-    update.setParameter("createdBy", aspect.getCreatedBy());
-    update.setParameter("oldTimestamp", oldTimestamp);
-
-    int numOfUpdatedRows;
-    if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY || _schemaConfig == SchemaConfig.DUAL_SCHEMA) {
-      // ensure atomicity by running old schema update + new schema update in a transaction
-      numOfUpdatedRows = runInTransactionWithRetry(() -> {
-        UUID messageId = trackingContext != null ? trackingContext.getTrackingId() : null;
-        _localAccess.add(urn, (ASPECT) value, aspectClass, newAuditStamp, messageId);
-        return _server.execute(update);
-      }, 1);
-    } else {
-      numOfUpdatedRows = _server.execute(update);
+    if (!_changeLogEnabled) {
+      throw new UnsupportedOperationException(
+          String.format("updateWithOptimisticLocking should not be called when changeLog is disabled: %s", aspect));
     }
 
+    int numOfUpdatedRows;
+    // ensure atomicity by running old schema update + new schema update in a transaction
+
+    final SqlUpdate oldSchemaSqlUpdate;
+    if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY || _schemaConfig == SchemaConfig.DUAL_SCHEMA) {
+      // In NEW_SCHEMA or DUAL_SCHEMA, since entity table is the SOT and the getLatest (oldTimestamp) is from the entity
+      // table, therefore, we will apply compare-and-set with oldTimestamp on entity table (addWithOptimisticLocking)
+      // aspect table will apply regular update over (urn, aspect, version) primary key combination.
+      oldSchemaSqlUpdate = assemblyOldSchemaSqlUpdate(aspect, null);
+      numOfUpdatedRows = runInTransactionWithRetry(() -> {
+        UUID messageId = trackingContext != null ? trackingContext.getTrackingId() : null;
+        // DUAL WRITE: 1) update aspect table, 2) update entity table.
+        // Note: when cold-archive is enabled, this method: updateWithOptimisticLocking will not be called.
+        _server.execute(oldSchemaSqlUpdate);
+        return _localAccess.addWithOptimisticLocking(urn, (ASPECT) value, aspectClass, newAuditStamp, oldTimestamp, messageId);
+      }, 1);
+    } else {
+      // In OLD_SCHEMA mode since aspect table is the SOT and the getLatest (oldTimestamp) is from the aspect table
+      // therefore, we will apply compare-and-set with oldTimestamp on aspect table (assemblyOldSchemaSqlUpdate)
+      oldSchemaSqlUpdate = assemblyOldSchemaSqlUpdate(aspect, oldTimestamp);
+      numOfUpdatedRows = _server.execute(oldSchemaSqlUpdate);
+    }
     // If there is no single updated row, emit OptimisticLockException
     if (numOfUpdatedRows != 1) {
       throw new OptimisticLockException(
-          numOfUpdatedRows + " rows updated during save query: " + update.getGeneratedSql());
+          String.format("%s rows updated during update on update: %s.", numOfUpdatedRows, aspect));
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -10,6 +10,7 @@ import com.linkedin.metadata.dao.scsi.UrnPathExtractor;
 import com.linkedin.metadata.query.IndexFilter;
 import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -33,6 +34,19 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    */
   <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp, @Nullable UUID messageId);
+
+  /**
+   * Update aspect on entity table with optimistic locking. (compare-and-update on oldTimestamp).
+   * @param urn entity urn
+   * @param newValue aspect value in {@link RecordTemplate}
+   * @param aspectClass class of the aspect
+   * @param auditStamp audit timestamp
+   * @param oldTimestamp old time stamp for optimistic lock checking
+   * @param <ASPECT> metadata aspect value
+   * @return number of rows inserted or updated
+   */
+  <ASPECT extends RecordTemplate> int addWithOptimisticLocking(@Nonnull URN urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+      @Nonnull AuditStamp auditStamp, @Nullable Timestamp oldTimestamp, @Nullable UUID messageId);
 
   /**
    * Upsert relationships to the local relationship table(s).

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -48,6 +48,9 @@ public class SQLStatementUtils {
       "INSERT INTO %s (urn, a_urn, %s, lastmodifiedon, lastmodifiedby) VALUE (:urn, :a_urn, :metadata, :lastmodifiedon, :lastmodifiedby) "
           + "ON DUPLICATE KEY UPDATE %s = :metadata, lastmodifiedon = :lastmodifiedon;";
 
+  // "JSON_EXTRACT(%s, '$.gma_deleted') IS NOT NULL" is used to exclude soft-deleted entity which has no lastmodifiedon.
+  // for details, see the known limitations on https://github.com/linkedin/datahub-gma/pull/311. Same reason for
+  // SQL_UPDATE_ASPECT_WITH_URN_TEMPLATE
   private static final String SQL_UPDATE_ASPECT_TEMPLATE =
       "UPDATE %s SET %s = :metadata, lastmodifiedon = :lastmodifiedon, lastmodifiedby = :lastmodifiedby "
           + "WHERE urn = :urn and (JSON_EXTRACT(%s, '$.lastmodifiedon') = :oldTimestamp OR JSON_EXTRACT(%s, '$.gma_deleted') IS NOT NULL);";
@@ -227,7 +230,7 @@ public class SQLStatementUtils {
     final String tableName = getTableName(urn);
     final String columnName = getAspectColumnName(aspectClass);
     return String.format(urnExtraction ? SQL_UPDATE_ASPECT_WITH_URN_TEMPLATE : SQL_UPDATE_ASPECT_TEMPLATE, tableName,
-        columnName, columnName, columnName, columnName);
+        columnName, columnName, columnName);
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -289,4 +289,23 @@ public class SQLStatementUtilsTest {
             + "as _total_count FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL AND "
             + "JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL LIMIT 5 OFFSET 0");
   }
+
+  @Test
+  public void testUpdateAspectWithOptimisticLockSql() {
+    FooUrn fooUrn = makeFooUrn(1);
+    String expectedSql =
+        "UPDATE metadata_entity_foo SET a_aspectfoo = :metadata, a_urn = :a_urn, lastmodifiedon = :lastmodifiedon, "
+            + "lastmodifiedby = :lastmodifiedby WHERE urn = :urn and (JSON_EXTRACT(a_aspectfoo, '$.lastmodifiedon') = "
+            + ":oldTimestamp OR JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NOT NULL);";
+    assertEquals(SQLStatementUtils.createAspectUpdateWithOptimisticLockSql(fooUrn, AspectFoo.class, true),
+        expectedSql);
+
+    expectedSql =
+        "UPDATE metadata_entity_foo SET a_aspectfoo = :metadata, lastmodifiedon = :lastmodifiedon, lastmodifiedby = "
+            + ":lastmodifiedby WHERE urn = :urn and (JSON_EXTRACT(a_aspectfoo, '$.lastmodifiedon') = :oldTimestamp "
+            + "OR JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NOT NULL);";
+    assertEquals(
+        SQLStatementUtils.createAspectUpdateWithOptimisticLockSql(fooUrn, AspectFoo.class, false),
+        expectedSql);
+  }
 }


### PR DESCRIPTION
## Context

This change is to fix a bug in the optimistic locking update, whereas in NEW/DUAL Schema mode, we use last_modified time getting from getLatest() on entity table to run the UPDATE WHEN last_modified = :oldTimestamp on aspect table. Even in most cases the last modified time between entity/aspect table are the same. However, this is not guaranteed. The fix is to write a new optimistic locking logic for entity tables. The logic is written updateWithOptimisticLocking and  we expect this method to behave as below 

1.  In OLD_SCHEMA mode, 
    - getLatest runs over the aspect table
    - updateWithOptimisticLocking() with compare-and-set latest version on aspect table.
    - if updateWithOptimisticLocking fails, all the updates will be rollback

2. In NEW/DUAL schema model, when changeLog is enabled (default mode)
    - getLatest runs over entity tables
    - updateWithOptimisticLocking() with compare-and-set latest version on entity tables.
    - aspect table will be dual-written.
    - if updateWithOptimisticLocking fails, all the updates will be rollback
   
3. When changeLog is disabled (cold-archive mode, NEW schema only)
    - updateWithOptimisticLocking() shouldn't be called, an UnsupportedOperationExecption will be thrown.
    - in cold-archive mode, we don't need optimistic locking anymore since the updates on entity table is atomistic.

## Known Limitations
1. updateWithOptimisticLocking() is using JSON_EXTRACT to extract last modified time form AuditedAspect, which could have performance impact. But considering the primary key (urn) will restrict the search scope to be O(1), the impact should be trivial but worth of observation.
2. for entities which as been soft_deleted, there's no timestamp we can leverage from AuditedAspect for optimistic locking check. It is a feature gap which we should include in the future. The current solution is consider soft_deleted record will always satisfy optimistic locking. It may cause inconsistency between entity and aspect table. But considering this is an edge case, and the only consumer of aspect table is MAD which will migrate away after 11/10. We will consider this as an acceptable risk.  

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
