### PR TITLE
feat(unoin schema): Genereate union MAE schema

### DIFF
--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MAEBarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MAEBarAspect.pdl
@@ -1,0 +1,60 @@
+namespace com.linkedin.testing.mxe.bar
+
+import com.linkedin.avro2pegasus.events.KafkaAuditHeader
+import com.linkedin.common.AuditStamp
+import com.linkedin.metadata.events.IngestionTrackingContext
+import com.linkedin.metadata.events.IngestionMode
+import com.linkedin.metadata.events.ChangeType
+import com.linkedin.testing.BarUrn
+import com.linkedin.testing.AnnotatedAspectBar
+import com.linkedin.testing.AnotherAspectBar
+
+/**
+ * MetadataAuditEvent for aspects of BarUrn.
+ */
+@MetadataAuditEvent
+record MAEBarAspect {
+  /**
+   * Kafka audit header for the MetadataAuditEvent.
+   */
+  auditHeader: optional KafkaAuditHeader
+
+  /**
+   * BarUrn as the key for the MetadataAuditEvent.
+   */
+  urn: BarUrn
+
+  /**
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
+   */
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
+
+  /**
+   * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
+   */
+  auditStamp: union[null, AuditStamp] = null
+
+  /**
+   * Type of the ingestion. Allow null for backward compatibility. Downstream should treat null as live ingestion.
+   */
+  ingestionMode: optional union[null, IngestionMode] = null
+
+  /**
+   * Audit record for aspect AnnotatedAspectBar.
+   */
+  diffAnnotatedAspectBar: optional record AnnotatedAspectBarAudit {
+    oldValue: optional AnnotatedAspectBar
+    newValue: AnnotatedAspectBar
+    changeType: optional union[null, ChangeType] = null
+  }
+
+  /**
+   * Audit record for aspect AnotherAspectBar.
+   */
+  diffAnotherAspectBar: optional record AnotherAspectBarAudit {
+    oldValue: optional AnotherAspectBar
+    newValue: AnotherAspectBar
+    changeType: optional union[null, ChangeType] = null
+  }
+
+}

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/AspectUnionEventSpec.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/AspectUnionEventSpec.java
@@ -32,7 +32,9 @@ public class AspectUnionEventSpec extends EventSpec {
             renderFile(new File(subdirectory, "MCE" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
                     "AspectUnionEvent.rythm"),
             renderFile(new File(subdirectory, "FailedMCE" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
-                    "FailedAspectUnionEvent.rythm")
+                    "FailedAspectUnionEvent.rythm"),
+            renderFile(new File(subdirectory, "MAE" + getShortTyperefName() + SchemaGeneratorConstants.PDL_SUFFIX),
+                "AuditUnionEvent.rythm")
     );
   }
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/AuditUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/AuditUnionEvent.rythm
@@ -1,0 +1,57 @@
+@import com.linkedin.metadata.generator.AspectUnionEventSpec;
+@import com.linkedin.metadata.generator.SchemaGeneratorUtil;
+@args AspectUnionEventSpec eventSpec
+namespace @(eventSpec.getNamespace())
+
+import com.linkedin.avro2pegasus.events.KafkaAuditHeader
+import com.linkedin.common.AuditStamp
+import com.linkedin.metadata.events.IngestionTrackingContext
+import com.linkedin.metadata.events.IngestionMode
+import com.linkedin.metadata.events.ChangeType
+import @eventSpec.getUrnType()
+@for (String valueType: eventSpec.getValueTypes()) {
+import @valueType
+}
+
+/**
+ * MetadataAuditEvent for aspects of @(eventSpec.getShortUrn()).
+ */
+@@MetadataAuditEvent
+record MAE@(eventSpec.getShortTyperefName()) {
+  /**
+   * Kafka audit header for the MetadataAuditEvent.
+   */
+  auditHeader: optional KafkaAuditHeader
+
+  /**
+   * @(eventSpec.getShortUrn()) as the key for the MetadataAuditEvent.
+   */
+  urn: @(eventSpec.getShortUrn())
+
+  /**
+   * Tracking context to identify the lifecycle of the trackable ingestion item.
+   */
+  ingestionTrackingContext: optional union[null, IngestionTrackingContext] = null
+
+  /**
+   * Audit info (i.e. createdon, createdby, createdfor) to track the version history of metadata changes.
+   */
+  auditStamp: union[null, AuditStamp] = null
+
+  /**
+   * Type of the ingestion. Allow null for backward compatibility. Downstream should treat null as live ingestion.
+   */
+  ingestionMode: optional union[null, IngestionMode] = null
+
+  @for (String valueType: eventSpec.getValueTypes()) {
+  /**
+   * Audit record for aspect @(SchemaGeneratorUtil.stripNamespace(valueType)).
+   */
+  diff@(SchemaGeneratorUtil.stripNamespace(valueType)): optional record @(SchemaGeneratorUtil.stripNamespace(valueType))Audit {
+    oldValue: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
+    newValue: @(SchemaGeneratorUtil.stripNamespace(valueType))
+    changeType: optional union[null, ChangeType] = null
+  }
+
+  }
+}

--- a/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
@@ -8,7 +8,6 @@ import com.linkedin.metadata.annotations.testing.TestModels;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -78,11 +77,12 @@ public class TestEventSchemaComposer {
             "com.linkedin.testing.mxe.bar.annotatedAspectBar.FailedMetadataChangeEvent",
             "com.linkedin.testing.mxe.bar.annotatedAspectBar.MetadataAuditEvent",
             "com.linkedin.testing.mxe.bar.MCEBarAspect",
-            "com.linkedin.testing.mxe.bar.FailedMCEBarAspect"
+            "com.linkedin.testing.mxe.bar.FailedMCEBarAspect",
+            "com.linkedin.testing.mxe.bar.MAEBarAspect"
     );
   }
 
-  private void assertSame(File baseOutputDir, File relativeFilePath) throws URISyntaxException, IOException {
+  private void assertSame(File baseOutputDir, File relativeFilePath) throws IOException {
     File outputPath = baseOutputDir.toPath().resolve(relativeFilePath.toPath()).toFile();
     assertThat(outputPath).exists();
 
@@ -114,5 +114,6 @@ public class TestEventSchemaComposer {
   public void testUnionSchemaRender() throws Exception {
     assertSame(outputDir, new File("com/linkedin/testing/mxe/bar/MCEBarAspect.pdl"));
     assertSame(outputDir, new File("com/linkedin/testing/mxe/bar/FailedMCEBarAspect.pdl"));
+    assertSame(outputDir, new File("com/linkedin/testing/mxe/bar/MAEBarAspect.pdl"));
   }
 }


### PR DESCRIPTION
## TLDR
We already have support for union MCE. Similar idea can be extended to MAE. This PR add capability to generate union MAE schema.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
