### PR TITLE
Add naive approach to backfilling

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -425,8 +425,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       } else if (oldAuditStamp == null || !oldAuditStamp.hasTime()) {
         log.info("Event is a backfill event, but current record has no timestamp. Proceeding as normal.");
       } else if (trackingContext.getEmitTime() < oldAuditStamp.getTime()) {
-        log.info("Event's emit time: {}, which is smaller than last modified time {}. Skipping event.",
-            trackingContext.getEmitTime(), oldAuditStamp.getTime());
+        log.info("Event's emit time: {}, which is smaller than last modified time {}. Skipping event for urn {}.",
+            trackingContext.getEmitTime(), oldAuditStamp.getTime(), urn);
         return new AddResult<>(oldValue, oldValue, aspectClass);
       } else {
         log.info("Event's emit time: {}, which is larger than last modified time {}. Proceeding as normal",

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -417,7 +417,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     boolean isBackfillEvent = trackingContext != null
         && trackingContext.hasBackfill() && trackingContext.isBackfill();
     if (isBackfillEvent) {
-      log.info("Encounter backfill event. Tracking context: {}", trackingContext);
+      log.info("Encounter backfill event. Tracking context: {}. Urn: {}. Aspect class: {}",
+          trackingContext, urn, aspectClass);
 
       if (!trackingContext.hasEmitTime()) {
         log.info("Event is a backfill event, but no emitTime was given. Proceeding as normal.");

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/IngestionTrackingContext.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/IngestionTrackingContext.pdl
@@ -14,4 +14,9 @@ record IngestionTrackingContext includes BaseTrackingContext {
    * The time at which the ingestion event was emitted into kafka.
    */
   emitTime: optional long
+
+  /**
+   * Whether this event is a re-emitted event for backfilling purposes
+   */
+  backfill: boolean = false
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.mockito.stubbing.OngoingStubbing;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.linkedin.common.AuditStamps.*;
@@ -437,15 +438,33 @@ public class BaseLocalDAOTest {
     verify(_mockTransactionRunner, times(2)).run(any());
   }
 
-  @Test(description = "When event is backfill event, but emit time is smaller than old audit time, it should be a no-op.")
-  public void testAddBackfillEmitTimeLargerThanOldAuditTime() throws URISyntaxException {
+  @DataProvider(name = "addBackfillForNoopCases")
+  public Object[][] addBackfillForNoopCases() {
+    AuditStamp oldAuditStamp = makeAuditStamp("susActor", 6L);
+
+    // case 1 - emitTime doesn't exist
+    IngestionTrackingContext contextWithNoEmitTime = new IngestionTrackingContext();
+    contextWithNoEmitTime.setBackfill(true);
+
+    // case 2 - emitTime < old stamp
+    IngestionTrackingContext contextWithSmallEmitTime = new IngestionTrackingContext();
+    contextWithSmallEmitTime.setBackfill(true);
+    contextWithSmallEmitTime.setEmitTime(5L);
+
+    return new Object[][] {
+        { contextWithNoEmitTime, oldAuditStamp },
+        { contextWithSmallEmitTime, oldAuditStamp }
+    };
+  }
+
+  @Test(description = "Each test case represents a scenario where a backfill event should NOT be backfilled",
+      dataProvider = "addBackfillForNoopCases")
+  public void testAddBackfillEmitTimeLargerThanOldAuditTime(
+      IngestionTrackingContext ingestionTrackingContext, AuditStamp oldAuditStamp
+  ) throws URISyntaxException {
     FooUrn urn = new FooUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    IngestionTrackingContext trackingContext = new IngestionTrackingContext();
-    trackingContext.setEmitTime(5L);
-    trackingContext.setBackfill(true);
 
-    AuditStamp oldAuditStamp = makeAuditStamp("susActor", 6L);
     ExtraInfo extraInfo = new ExtraInfo();
     extraInfo.setAudit(oldAuditStamp);
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
@@ -460,11 +479,43 @@ public class BaseLocalDAOTest {
     expectGetLatest(urn, AspectFoo.class,
         Arrays.asList(makeAspectEntry(null, oldAuditStamp), makeAspectEntry(foo, _dummyAuditStamp)));
 
-    dummyLocalDAO.add(urn, foo, _dummyAuditStamp, trackingContext);
+    dummyLocalDAO.add(urn, foo, _dummyAuditStamp, ingestionTrackingContext);
 
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null,
-        null, _dummyAuditStamp, trackingContext, IngestionMode.LIVE);
+        null, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  @Test(description = "Event should be processed for backfill event")
+  public void testAddForBackfill() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo foo = new AspectFoo().setValue("foo");
+
+    ExtraInfo extraInfo = new ExtraInfo();
+    AuditStamp oldAuditStamp = makeAuditStamp("nonSusActor", 5L);
+    extraInfo.setAudit(oldAuditStamp);
+    when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
+        .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(null, extraInfo));
+
+    DummyLocalDAO dummyLocalDAO = new DummyLocalDAO(_mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
+        _dummyLocalDAO._transactionRunner);
+    dummyLocalDAO.setEmitAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
+    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
+    expectGetLatest(urn, AspectFoo.class,
+        Arrays.asList(makeAspectEntry(null, oldAuditStamp), makeAspectEntry(foo, _dummyAuditStamp)));
+
+    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
+    ingestionTrackingContext.setBackfill(true);
+    ingestionTrackingContext.setEmitTime(6L);
+
+    dummyLocalDAO.add(urn, foo, _dummyAuditStamp, ingestionTrackingContext);
+
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null,
+        foo, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 }


### PR DESCRIPTION
Based on the last discussion, we'll be first implementing a naive approach where we compare `emitTime` against `lastmodifiedtime`. If `emitTime < lastmodifiedtime`, we'll discard the backfill event.

One scenario pointed out by Edwina where this approach might not be ideal:
```
1. MCE-1 for entity A goes into DLQ (emit time T1)
2. MCE-2 for entity A goes into DLQ (emit time T2)
3. backfill batches MCE-1 and MCE-2, and consolidates into MCE-2.
4. MCE-3 for entity A goes into DLQ (emit time T3)
5. backfill runs, and applies MCE-2 (modified time T4)
6. backfill runs for MCE-3 and is dropped, since T3 < T4.
```

We'll implement this approach and will keep the logic for the old schema.
Future tasks:
- Add `emitTime` column in the new schema and use that as comparison to whether we should do backfill. This should not be too much on operational side since this info will be stored in the json column
- Have the backfill tool to allow override `emitTime` so that the old schema could work

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
