### PR TITLE
Make buildTopicName(String, String, String) public

### DIFF
--- a/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5.java
+++ b/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5.java
@@ -18,6 +18,12 @@ import javax.annotation.Nonnull;
  */
 public interface TopicConventionV5 {
   /**
+   * Returns the name of the topic based on event type, entity name and aspect name.
+   */
+  @Nonnull
+  String buildTopicName(@Nonnull String eventType, @Nonnull String entityName, @Nonnull String aspectName);
+
+  /**
    * Returns the name of the metadata change event topic.
    *
    * @param urn the urn of the entity being updated

--- a/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
+++ b/dao-api/src/main/java/com/linkedin/mxe/TopicConventionV5Impl.java
@@ -145,7 +145,8 @@ public final class TopicConventionV5Impl implements TopicConventionV5 {
   }
 
   @Nonnull
-  private String buildTopicName(@Nonnull String eventType, @Nonnull String entityName, @Nonnull String aspectName) {
+  @Override
+  public String buildTopicName(@Nonnull String eventType, @Nonnull String entityName, @Nonnull String aspectName) {
     final String name = _eventPattern.replace(EVENT_TYPE_PLACEHOLDER, eventType)
         .replace(ENTITY_PLACEHOLDER, entityName)
         .replace(ASPECT_PLACEHOLDER, aspectName);


### PR DESCRIPTION
## Details
This is useful for the backfill tool when user might provide an entity type and aspect name.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
