### PR TITLE
make GmaEntitiesAnnotationAllowList nullable

### DIFF
--- a/gradle-plugins/metadata-annotations-lib/src/main/java/com/linkedin/metadata/annotations/GmaAnnotationParser.java
+++ b/gradle-plugins/metadata-annotations-lib/src/main/java/com/linkedin/metadata/annotations/GmaAnnotationParser.java
@@ -11,6 +11,7 @@ import com.linkedin.data.template.DataTemplateUtil;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 public class GmaAnnotationParser {
@@ -18,7 +19,7 @@ public class GmaAnnotationParser {
 
   private final GmaEntitiesAnnotationAllowList _gmaEntitiesAnnotationAllowList;
 
-  public GmaAnnotationParser(@Nonnull GmaEntitiesAnnotationAllowList gmaEntitiesAnnotationAllowList) {
+  public GmaAnnotationParser(@Nullable GmaEntitiesAnnotationAllowList gmaEntitiesAnnotationAllowList) {
     _gmaEntitiesAnnotationAllowList = gmaEntitiesAnnotationAllowList;
   }
 
@@ -59,7 +60,7 @@ public class GmaAnnotationParser {
           Joiner.on('\n').join(result.getMessages())));
     }
 
-    if (gmaAnnotation.hasAspect() && gmaAnnotation.getAspect().hasEntities()) {
+    if (_gmaEntitiesAnnotationAllowList != null && gmaAnnotation.hasAspect() && gmaAnnotation.getAspect().hasEntities()) {
       _gmaEntitiesAnnotationAllowList.check(schema, gmaAnnotation.getAspect());
     }
 

--- a/gradle-plugins/metadata-annotations-lib/src/test/java/com/linkedin/metadata/annotations/GmaAnnotationParserTest.java
+++ b/gradle-plugins/metadata-annotations-lib/src/test/java/com/linkedin/metadata/annotations/GmaAnnotationParserTest.java
@@ -67,4 +67,13 @@ public class GmaAnnotationParserTest {
         GmaEntitiesAnnotationAllowList.AnnotationNotAllowedException.class)
         .hasMessage("@gma.aspect.entities not allowed on com.linkedin.testing.CommonAspect");
   }
+
+  @Test
+  public void parseCommonAspectAllowedWithNullAllowList() {
+    final Optional<GmaAnnotation> gma = new GmaAnnotationParser(null).parse(
+        (RecordDataSchema) DataTemplateUtil.getSchema(CommonAspect.class));
+    assertThat(gma).contains(new GmaAnnotation().setAspect(new AspectAnnotation().setEntities(
+        new AspectEntityAnnotationArray(new AspectEntityAnnotation().setUrn("com.linkedin.testing.FooUrn"),
+            new AspectEntityAnnotation().setUrn("com.linkedin.testing.BarUrn")))));
+  }
 }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaAnnotationRetriever.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaAnnotationRetriever.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -36,7 +37,7 @@ public class SchemaAnnotationRetriever {
     _baseNamespace = baseNamespace;
   }
 
-  public SchemaAnnotationRetriever(@Nonnull String resolverPath, @Nonnull GmaEntitiesAnnotationAllowList allowList,
+  public SchemaAnnotationRetriever(@Nonnull String resolverPath, @Nullable GmaEntitiesAnnotationAllowList allowList,
                                    String baseNamespace) {
     this(resolverPath, new GmaAnnotationParser(allowList), baseNamespace);
   }

--- a/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGenerator.java
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/java/com/linkedin/metadata/generator/SchemaGenerator.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.rythmengine.Rythm;
 
 
@@ -31,7 +32,7 @@ public class SchemaGenerator {
    * @throws IOException exception on input error
    */
   public void generate(@Nonnull Collection<String> resolverPaths, @Nonnull Collection<String> sourcePaths,
-      @Nonnull String generatedFileOutput, @Nonnull GmaEntitiesAnnotationAllowList allowList) throws IOException {
+      @Nonnull String generatedFileOutput, @Nullable GmaEntitiesAnnotationAllowList allowList) throws IOException {
     generate(sourcePaths, generatedFileOutput,
         new SchemaAnnotationRetriever(resolverPaths.stream().collect(Collectors.joining(":")), allowList, null));
   }


### PR DESCRIPTION
## Summary
This change is a requirement for removing allow list in metadata-models-plugin MP, which currently uses AlwaysAllowList as a workaround to enable reuse of aspects. In case like that, the allow list check becomes trivial, so we wish to remove the check as a whole for Plugins that don't require it.

This change will let the allow list to be nullable, so when the Project doesn't have a GmaEntitiesAnnotationAllowList passed to datahub-gma, we simply skip the check.

## Test Done
./gradlew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
