### PR TITLE
Add RECORD as an allowed type for Relationships

### DIFF
--- a/docs/what/relationship.md
+++ b/docs/what/relationship.md
@@ -61,6 +61,7 @@ Below is an example of how a relationship is modeled in PDL. Note that:
 2. Each model is expected to have a `@pairings` annotation that is an array of all allowed source-destination URN pairs.
 3. Unlike entity attributes, there’s no requirement on making all relationship attributes optional since relationships
    do not support partial updates.
+4. Only primitive and RECORD field types are allowed.
 
 ```
 namespace com.linkedin.metadata.relationship

--- a/docs/what/relationship.md
+++ b/docs/what/relationship.md
@@ -61,7 +61,7 @@ Below is an example of how a relationship is modeled in PDL. Note that:
 2. Each model is expected to have a `@pairings` annotation that is an array of all allowed source-destination URN pairs.
 3. Unlike entity attributes, there’s no requirement on making all relationship attributes optional since relationships
    do not support partial updates.
-4. Only primitive and RECORD field types are allowed.
+4. Only primitive field types are allowed.
 
 ```
 namespace com.linkedin.metadata.relationship

--- a/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
@@ -56,6 +56,7 @@ public class RelationshipValidator {
           className);
     }
 
+    // META-19786 Add RECORD to allowlist to enable addition of AuditStamp to BaseRelationship
     final Set<DataSchema.Type> allowedRelationshipSchemaTypes = new HashSet<>(ValidationUtils.PRIMITIVE_TYPES);
     allowedRelationshipSchemaTypes.add(DataSchema.Type.RECORD);
 

--- a/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
@@ -3,11 +3,11 @@ package com.linkedin.metadata.validator;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
-import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -56,11 +56,11 @@ public class RelationshipValidator {
           className);
     }
 
-    // META-19786 Add RECORD to allowlist to enable addition of AuditStamp to BaseRelationship
-    final Set<DataSchema.Type> allowedRelationshipSchemaTypes = new HashSet<>(ValidationUtils.PRIMITIVE_TYPES);
-    allowedRelationshipSchemaTypes.add(DataSchema.Type.RECORD);
-
-    ValidationUtils.fieldsUsingInvalidType(schema, allowedRelationshipSchemaTypes).forEach(field -> {
+    ValidationUtils.fieldsUsingInvalidType(schema, ValidationUtils.PRIMITIVE_TYPES).forEach(field -> {
+      // META-19786 Add RECORD to allowlist to enable addition of AuditStamp to BaseRelationship
+      if (ValidationUtils.isValidAuditStamp(field)) {
+        return;
+      }
       ValidationUtils.invalidSchema("Relationship '%s' contains a field '%s' that makes use of a disallowed type '%s'.",
           className, field.getName(), field.getType().getType());
     });

--- a/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.validator;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
+import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.template.RecordTemplate;
@@ -11,6 +12,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
 import javax.annotation.Nonnull;
 import lombok.Value;
 
@@ -54,7 +56,10 @@ public class RelationshipValidator {
           className);
     }
 
-    ValidationUtils.fieldsUsingInvalidType(schema, ValidationUtils.PRIMITIVE_TYPES).forEach(field -> {
+    final Set<DataSchema.Type> allowedRelationshipSchemaTypes = new HashSet<>(ValidationUtils.PRIMITIVE_TYPES);
+    allowedRelationshipSchemaTypes.add(DataSchema.Type.RECORD);
+
+    ValidationUtils.fieldsUsingInvalidType(schema, allowedRelationshipSchemaTypes).forEach(field -> {
       ValidationUtils.invalidSchema("Relationship '%s' contains a field '%s' that makes use of a disallowed type '%s'.",
           className, field.getName(), field.getType().getType());
     });

--- a/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.validator;
 
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.schema.ArrayDataSchema;
@@ -161,6 +162,16 @@ public final class ValidationUtils {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Return true if the field is an AuditStamp of type RECORD.
+   *   META-19786 Add AuditStamp to allowlist to enable addition to BaseRelationship
+   */
+  @Nonnull
+  public static boolean isValidAuditStamp(@Nonnull RecordDataSchema.Field field) {
+    return field.getType().getUnionMemberKey().equals(AuditStamp.class.getCanonicalName())
+        && getFieldOrArrayItemType(field) == DataSchema.Type.RECORD;
+  }
+
   public static boolean isUnionWithOnlyComplexMembers(UnionDataSchema unionDataSchema) {
     return unionDataSchema.getMembers().stream().allMatch(member -> member.getType().isComplex());
   }
@@ -197,4 +208,6 @@ public final class ValidationUtils {
     }
     return type.getType();
   }
+
+
 }


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
  - [META-19786](https://jira01.corp.linkedin.com:8443/browse/META-19786)
- [x] Tests for the changes have been added/updated (if applicable)
  - n/a
- [x] Docs related to the changes have been added/updated (if applicable)

## Reference code

I used [this blurb](https://jarvis.corp.linkedin.com/codesearch/result/?name=SettingsUtil.java&path=identity%2Fmember-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fidentity%2Fmember&reponame=linkedin-multiproduct%2Fidentity#155) from `identity` MP's `SettingsUtil.java` found through CodeSearch to base my logic:

```
      } else if (field.getType().getType() == DataSchema.Type.RECORD
          && Locale.class.getCanonicalName().equals(field.getType().getUnionMemberKey())) {
        // Serialize the locale object
        return localeToSerializedString((Locale) object);
      } else {
```