### PR TITLE
Decouple listUrns with lastUrn to use seperate filter SQL

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -812,14 +812,14 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return List of urns from local secondary index that satisfy the given filter conditions
    */
   @Nonnull
-  public abstract List<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+  public abstract List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       @Nullable URN lastUrn, int pageSize);
 
   /**
    * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int)} but sorts lexicographically by the URN.
    */
   @Nonnull
-  public List<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
+  public List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
     return listUrns(indexFilter, null, lastUrn, pageSize);
   }
 
@@ -831,7 +831,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return a {@link ListResult} containing a list of urns and other pagination information
    */
   @Nonnull
-  public abstract <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter,
+  public abstract <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nullable IndexFilter indexFilter,
       @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize);
 
   /**
@@ -892,7 +892,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public List<UrnAspectEntry<URN>> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      @Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, @Nullable URN lastUrn,
+      @Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, @Nullable URN lastUrn,
       int pageSize) {
 
     final List<URN> urns = listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize);
@@ -920,7 +920,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public ListResult<UrnAspectEntry<URN>> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      @Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
+      @Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
 
     final ListResult<URN> listResult = listUrns(indexFilter, indexSortCriterion, start, pageSize);
     final List<URN> urns = listResult.getValues();
@@ -1232,7 +1232,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return map of the field to the count
    */
   @Nonnull
-  public abstract Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter,
+  public abstract Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion);
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -321,7 +321,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   @Nonnull
   @Override
-  public Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter,
+  public Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
     final String tableName = SQLSchemaUtils.getTableName(_entityType);
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1418,8 +1418,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Nonnull
   public List<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       @Nullable URN lastUrn, int pageSize) {
-    final IndexCriterionArray indexCriterionArray = indexFilter.getCriteria();
-    checkValidIndexCriterionArray(indexCriterionArray);
 
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("listUrns with index filter is only supported in new schema.");
@@ -1437,11 +1435,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   @Override
   @Nonnull
-  public ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+  public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize) {
-
-    final IndexCriterionArray indexCriterionArray = indexFilter.getCriteria();
-    checkValidIndexCriterionArray(indexCriterionArray);
 
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("listUrns with index filter is only supported in new schema.");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -29,7 +29,6 @@ import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.ExtraInfoArray;
 import com.linkedin.metadata.query.IndexCriterion;
-import com.linkedin.metadata.query.IndexCriterionArray;
 import com.linkedin.metadata.query.IndexFilter;
 import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
@@ -1394,12 +1393,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
-  void checkValidIndexCriterionArray(@Nonnull IndexCriterionArray indexCriterionArray) {
-    if (indexCriterionArray.isEmpty()) {
-      throw new UnsupportedOperationException("Empty Index Filter is not supported by EbeanLocalDAO");
-    }
-  }
-
   /**
    * Returns list of urns that satisfy the given filter conditions.
    *
@@ -1416,7 +1409,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   @Override
   @Nonnull
-  public List<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+  public List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       @Nullable URN lastUrn, int pageSize) {
 
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
@@ -1447,10 +1440,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   @Nonnull
-  public Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter,
+  public Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
-    final IndexCriterionArray indexCriterionArray = indexFilter.getCriteria();
-    checkValidIndexCriterionArray(indexCriterionArray);
 
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("countAggregate is only supported in new schema.");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -111,7 +111,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @return map of the field to the count
    */
   @Nonnull
-  Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter,
+  Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion);
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -84,7 +84,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param pageSize maximum number of distinct urns to return
    * @return List of urns from local secondary index that satisfy the given filter conditions
    */
-  List<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+  List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       @Nullable URN lastUrn, int pageSize);
 
   /**
@@ -94,9 +94,8 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param start the starting offset of the page
    * @return a {@link ListResult} containing a list of urns and other pagination information
    */
-  ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+  ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize);
-
 
   /**
    * Returns a boolean representing if an Urn has any Aspects associated with it (i.e. if it exists in the DB).

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -87,8 +87,12 @@ public class SQLIndexFilterUtils {
    * @param indexFilter index filter
    * @return translated SQL condition expression, e.g. WHERE ...
    */
-  public static String parseIndexFilter(@Nonnull IndexFilter indexFilter) {
+  public static String parseIndexFilter(@Nullable IndexFilter indexFilter) {
     List<String> sqlFilters = new ArrayList<>();
+
+    if (indexFilter == null || !indexFilter.hasCriteria()) {
+      return "";
+    }
 
     for (IndexCriterion indexCriterion : indexFilter.getCriteria()) {
       final String aspect = indexCriterion.getAspect();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -262,7 +262,7 @@ public class SQLStatementUtils {
    * @param indexGroupByCriterion group by
    * @return translated group by SQL
    */
-  public static String createGroupBySql(String tableName, @Nonnull IndexFilter indexFilter,
+  public static String createGroupBySql(String tableName, @Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
     final String columnName = getGeneratedColumnName(indexGroupByCriterion.getAspect(), indexGroupByCriterion.getPath());
     StringBuilder sb = new StringBuilder();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -236,13 +236,20 @@ public class SQLStatementUtils {
    * Create filter SQL statement.
    * @param tableName table name
    * @param indexFilter index filter
+   * @param hasTotalCount whether to calculate total count in SQL.
    * @return translated SQL where statement
    */
-  public static String createFilterSql(String tableName, @Nonnull IndexFilter indexFilter) {
+  public static String createFilterSql(String tableName, @Nullable IndexFilter indexFilter, boolean hasTotalCount) {
     String whereClause = parseIndexFilter(indexFilter);
     String totalCountSql = String.format("SELECT COUNT(urn) FROM %s %s", tableName, whereClause);
     StringBuilder sb = new StringBuilder();
-    sb.append(String.format(SQL_FILTER_TEMPLATE, totalCountSql, tableName));
+
+    if (hasTotalCount) {
+      sb.append(String.format(SQL_FILTER_TEMPLATE, totalCountSql, tableName));
+    } else {
+      sb.append("SELECT * FROM ").append(tableName);
+    }
+
     sb.append("\n");
     sb.append(whereClause);
     return sb.toString();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -196,6 +196,22 @@ public class EbeanLocalAccessTest {
     // Expect: 5 rows are returns (35~39) and the first element is 'urn:li:foo:35'
     assertEquals(5, result2.size());
     assertEquals("35", result2.get(0).getId());
+
+    // When: list urns with no filter, no sorting criterion, no last urn.
+    List<FooUrn> result3 = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
+
+    // 0, 1, 10, 11, 12, 13, 14, 15, 16, 17
+    assertEquals(result3.size(), 10);
+    assertEquals(result3.get(0).getId(), "0");
+    assertEquals(result3.get(9).getId(), "17");
+
+    // When: list urns with no filter, no sorting criterion
+    List<FooUrn> result4 = _ebeanLocalAccessFoo.listUrns(null, null, new FooUrn(17), 10);
+
+    // 18, 19, 2, 20, 21, 22, 23, 24, 25, 26
+    assertEquals(result4.size(), 10);
+    assertEquals(result4.get(0).getId(), "18");
+    assertEquals(result4.get(9).getId(), "26");
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -1652,17 +1652,13 @@ public class EbeanLocalDAOTest {
     IndexCriterion indexCriterion = new IndexCriterion().setAspect(aspect);
     final IndexFilter indexFilter1 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
 
-    // 1. index criterion array is empty, should throw exception
-    final IndexFilter indexFilter2 = new IndexFilter().setCriteria(new IndexCriterionArray());
-    assertThrows(UnsupportedOperationException.class, () -> dao.listUrns(indexFilter2, null, 2));
-
-    // 2. only aspect and not path or value is provided in Index Filter
+    // 1. only aspect and not path or value is provided in Index Filter
     indexCriterion = new IndexCriterion().setAspect(aspect);
     final IndexFilter indexFilter4 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
     List<FooUrn> urns = dao.listUrns(indexFilter4, null, 2);
     assertEquals(urns, Arrays.asList(urn1, urn2));
 
-    // 3. aspect with path and value is provided in index filter
+    // 2. aspect with path and value is provided in index filter
     IndexValue indexValue = new IndexValue();
     indexValue.setString("val1");
     IndexPathParams indexPathParams = new IndexPathParams().setPath("/path1").setValue(indexValue);
@@ -1671,7 +1667,7 @@ public class EbeanLocalDAOTest {
     urns = dao.listUrns(indexFilter5, urn1, 2);
     assertEquals(urns, Arrays.asList(urn2, urn3));
 
-    // 4. aspect with correct path but incorrect value
+    // 3. aspect with correct path but incorrect value
     indexValue.setString("valX");
     indexPathParams = new IndexPathParams().setPath("/path1").setValue(indexValue);
     indexCriterion = new IndexCriterion().setAspect(aspect).setPathParams(indexPathParams);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -1245,15 +1245,6 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
-  public void testCheckValidIndexCriterionArray() {
-    EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
-
-    // empty index criterion array
-    final IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray();
-    assertThrows(UnsupportedOperationException.class, () -> dao.checkValidIndexCriterionArray(indexCriterionArray1));
-  }
-
-  @Test
   public void testListUrnsOffsetPagination() {
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       return;

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,6 +72,10 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
+          configurationBuilder.setBaseDir("/opt/homebrew");
+          configurationBuilder.setUnpackingFromClasspath(false);
+          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,10 +72,6 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
-          configurationBuilder.setBaseDir("/opt/homebrew");
-          configurationBuilder.setUnpackingFromClasspath(false);
-          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
-
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -75,7 +75,7 @@ public class SQLStatementUtilsTest {
     indexCriterionArray.add(indexCriterion2);
     indexFilter.setCriteria(indexCriterionArray);
 
-    String sql = SQLStatementUtils.createFilterSql("metadata_entity_foo", indexFilter);
+    String sql = SQLStatementUtils.createFilterSql("metadata_entity_foo", indexFilter, true);
     String expectedSql = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -433,19 +433,6 @@ public abstract class BaseEntityResource<
   }
 
   /**
-   * For strongly consistent local secondary index, this provides {@link IndexFilter} which uses FQCN of the entity urn to filter
-   * on the aspect field of the index table. This serves the purpose of returning urns that are of given entity type from index table.
-   */
-  @Nonnull
-  private IndexFilter getDefaultIndexFilter() {
-    if (_urnClass == null) {
-      throw new UnsupportedOperationException("Urn class has not been defined in BaseEntityResource");
-    }
-    final IndexCriterion indexCriterion = new IndexCriterion().setAspect(_urnClass.getCanonicalName());
-    return new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
-  }
-
-  /**
    * An action method for getting filtered urns from local secondary index.
    * If no filter conditions are provided, then it returns urns of given entity type.
    *
@@ -461,11 +448,9 @@ public abstract class BaseEntityResource<
   public Task<String[]> listUrnsFromIndex(@ActionParam(PARAM_FILTER) @Optional @Nullable IndexFilter indexFilter,
       @ActionParam(PARAM_URN) @Optional @Nullable String lastUrn, @ActionParam(PARAM_LIMIT) int limit) {
 
-    final IndexFilter filter = indexFilter == null ? getDefaultIndexFilter() : indexFilter;
-
     return RestliUtils.toTask(() ->
         getLocalDAO()
-            .listUrns(filter, parseUrnParam(lastUrn), limit)
+            .listUrns(indexFilter, parseUrnParam(lastUrn), limit)
             .stream()
             .map(Urn::toString)
             .collect(Collectors.toList())

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -809,13 +809,13 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     IndexCriterion indexCriterion2 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
     IndexFilter indexFilter2 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion2));
     when(_mockLocalDAO.listUrns(indexFilter2, urn1, 2)).thenReturn(urns1);
-    actual = runAndWait(_resource.listUrnsFromIndex(null, urn1.toString(), 2));
+    actual = runAndWait(_resource.listUrnsFromIndex(indexFilter2, urn1.toString(), 2));
     assertEquals(actual, new String[]{urn2.toString(), urn3.toString()});
 
     // case 3: lastUrn is null
     List<FooUrn> urns3 = Arrays.asList(urn1, urn2);
     when(_mockLocalDAO.listUrns(indexFilter2, null, 2)).thenReturn(urns3);
-    actual = runAndWait(_resource.listUrnsFromIndex(null, null, 2));
+    actual = runAndWait(_resource.listUrnsFromIndex(indexFilter2, null, 2));
     assertEquals(actual, new String[]{urn1.toString(), urn2.toString()});
   }
 
@@ -842,7 +842,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     List<FooUrn> urns2 = Arrays.asList(urn1, urn2);
     IndexCriterion indexCriterion2 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
     IndexFilter indexFilter2 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion2));
-    when(_mockLocalDAO.listUrns(indexFilter2, null, null, 2)).thenReturn(urns2);
+    when(_mockLocalDAO.listUrns(null, null, null, 2)).thenReturn(urns2);
     actual = runAndWait(_resource.filter(null, new String[0], null, new PagingContext(0, 2)));
     assertEquals(actual.size(), 2);
     assertEquals(actual.get(0), new EntityValue());
@@ -852,7 +852,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     List<FooUrn> urns3 = Arrays.asList(urn3, urn2);
     IndexSortCriterion indexSortCriterion = new IndexSortCriterion().setAspect("aspect1").setPath("/id")
         .setOrder(SortOrder.DESCENDING);
-    when(_mockLocalDAO.listUrns(indexFilter2, indexSortCriterion, null, 2)).thenReturn(urns3);
+    when(_mockLocalDAO.listUrns(null, indexSortCriterion, null, 2)).thenReturn(urns3);
     actual = runAndWait(_resource.filter(null, indexSortCriterion, new String[0], null, 2));
     assertEquals(actual.size(), 2);
     assertEquals(actual.get(0), new EntityValue());
@@ -868,7 +868,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         .totalPageCount(1)
         .pageSize(2)
         .build();
-    when(_mockLocalDAO.listUrns(indexFilter2, indexSortCriterion, 0, 2)).thenReturn(urnsListResult);
+    when(_mockLocalDAO.listUrns(null, indexSortCriterion, 0, 2)).thenReturn(urnsListResult);
     ListResult<EntityValue>
         listResultActual = runAndWait(_resource.filter(null, indexSortCriterion, new String[0], new PagingContext(0, 2)));
     List<EntityValue> actualValues = listResultActual.getValues();


### PR DESCRIPTION
This PR addressed a few issues:
1. make IndexFilter nullable when calling listUrns. Previously it can't be nullable because of SCSI constraint. 
2. decouple listUrns with lastUrn to use separate filter SQL because it doesn't need to know the total count.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
