### PR TITLE
Add emitTime to the read path

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -393,14 +393,17 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         && trackingContext.hasBackfill() && trackingContext.isBackfill();
     if (isBackfillEvent) {
       boolean shouldBackfill =
-          // the time in old audit stamp represents last modified time of the aspect
-          // if the record doesn't exist, it will be null, which means we should process the record as normal
-          oldAuditStamp != null && oldAuditStamp.hasTime()
-              // ingestionTrackingContext if not null should always have emitTime. If emitTime doesn't exist within
-              // a non-null IngestionTrackingContext, it should be investigated. We'll also skip backfilling in this case
-              && trackingContext.hasEmitTime()
-              // we should only process this backfilling event if the emit time is greater than last modified time
-              && trackingContext.getEmitTime() > oldAuditStamp.getTime();
+          // new value is being inserted. We should backfill
+          oldValue == null
+              // the time in old audit stamp represents last modified time of the aspect
+              // if the record doesn't exist, it will be null, which means we should process the record as normal
+              || (
+              oldAuditStamp != null && oldAuditStamp.hasTime()
+                  // ingestionTrackingContext if not null should always have emitTime. If emitTime doesn't exist within
+                  // a non-null IngestionTrackingContext, it should be investigated. We'll also skip backfilling in this case
+                  && trackingContext.hasEmitTime()
+                  // we should only process this backfilling event if the emit time is greater than last modified time
+                  && trackingContext.getEmitTime() > oldAuditStamp.getTime());
 
       log.info("Encounter backfill event. Tracking context: {}. Urn: {}. Aspect class: {}. Old audit stamp: {}. "
               + "Based on this information, shouldBackfill = {}.",

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/AuditedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/AuditedAspect.pdl
@@ -33,6 +33,10 @@ record AuditedAspect {
    * The emit time of the MCE that last modified this aspect.
    * This is the same emitTime set in IngestionTrackingContext
    * If an aspect is added / modified without providing an IngestionTrackingContext, this will be null.
+   *
+   * This value is different from lastmodifiedon / the timestamp in AuditStamp since auditStamp
+   * is created when the restli resource receives the ingestion request.
+   * This is set by the MCE producers (or MCE consumers if not set by producers)
    */
    emitTime: optional long
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/AuditedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/AuditedAspect.pdl
@@ -28,4 +28,11 @@ record AuditedAspect {
    * Audit information to track who this aspect was created for.
    */
   createdfor: optional string
+
+  /**
+   * The emit time of the MCE that last modified this aspect.
+   * This is the same emitTime set in IngestionTrackingContext
+   * If an aspect is added / modified without providing an IngestionTrackingContext, this will be null.
+   */
+   emitTime: optional long
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/ListResultMetadata.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/ListResultMetadata.pdl
@@ -31,5 +31,12 @@ record ListResultMetadata {
        * The audit trail associated with the version
        */
       audit: AuditStamp
+
+      /**
+       * The emit time of the MCE that last modified this aspect.
+       * This is the same emitTime set in IngestionTrackingContext
+       * If an aspect is added / modified without providing an IngestionTrackingContext, this will be null.
+       */
+       emitTime: optional long
     }]
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/ListResultMetadata.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/ListResultMetadata.pdl
@@ -36,6 +36,10 @@ record ListResultMetadata {
        * The emit time of the MCE that last modified this aspect.
        * This is the same emitTime set in IngestionTrackingContext
        * If an aspect is added / modified without providing an IngestionTrackingContext, this will be null.
+       *
+       * This value is different from lastmodifiedon / the timestamp in AuditStamp since auditStamp
+       * is created when the restli resource receives the ingestion request.
+       * This is set by the MCE producers (or MCE consumers if not set by producers)
        */
        emitTime: optional long
     }]

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -7,6 +7,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.builder.BaseLocalRelationshipBuilder.LocalRelationshipUpdates;
 import com.linkedin.metadata.dao.builder.LocalRelationshipBuilderRegistry;
@@ -1257,6 +1258,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     final ExtraInfo extraInfo = new ExtraInfo();
     extraInfo.setVersion(aspect.getKey().getVersion());
     extraInfo.setAudit(makeAuditStamp(aspect));
+    extraInfo.setEmitTime(aspect.getEmitTime(), SetMode.IGNORE_NULL);
     try {
       extraInfo.setUrn(Urn.createFromString(aspect.getKey().getUrn()));
     } catch (URISyntaxException e) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataAspect.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataAspect.java
@@ -3,12 +3,14 @@ package com.linkedin.metadata.dao;
 import io.ebean.Model;
 import io.ebean.annotation.Index;
 import java.sql.Timestamp;
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.Lob;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -87,6 +89,12 @@ public class EbeanMetadataAspect extends Model {
 
   @Column(name = CREATED_FOR_COLUMN, nullable = true)
   private String createdFor;
+
+  // this column doesn't exist in the old schema
+  // in the new schema, it's part of the aspect json
+  @Nullable
+  @Transient
+  private Long emitTime;
 
   // TODO (@jphui) META-18962 De-deduplicity investigation
   // @SneakyThrows

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -1,10 +1,10 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.AuditedAspect;
+import com.linkedin.metadata.aspect.SoftDeletedAspect;
 import com.linkedin.metadata.dao.EbeanMetadataAspect;
 import com.linkedin.metadata.dao.ListResult;
-import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.metadata.aspect.SoftDeletedAspect;
 import io.ebean.EbeanServer;
 import io.ebean.SqlRow;
 import java.lang.reflect.InvocationTargetException;
@@ -224,6 +224,7 @@ public class EBeanDAOUtils {
       ebeanMetadataAspect.setCreatedBy(auditedAspect.getLastmodifiedby());
       ebeanMetadataAspect.setCreatedOn(Timestamp.valueOf(auditedAspect.getLastmodifiedon()));
       ebeanMetadataAspect.setCreatedFor(auditedAspect.getCreatedfor());
+      ebeanMetadataAspect.setEmitTime(auditedAspect.getEmitTime());
       ebeanMetadataAspect.setMetadata(extractAspectJsonString(sqlRow.getString(columnName)));
     }
     ebeanMetadataAspect.setKey(primaryKey);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -509,6 +509,7 @@ public class EBeanDAOUtilsTest {
     aspect.setMetadata(RecordUtils.toJsonString(fooAspect));
     aspect.setCreatedOn(new Timestamp(now - 100));
     aspect.setCreatedBy("fooActor");
+    aspect.setEmitTime(12345L);
 
     // add aspect to the db
     server.insert(aspect);


### PR DESCRIPTION
## Context
This is related to the MCEv5 backfill project where events with `backfill = true` will be emitted and processed. We'd like to add a column called `emitTime` to denote the emit time of the MCE that last modified the aspect. This will work for new schema only.

In follow up PR's, we will write the `emitTime` (new schema only) as well as add backfill logic related to `emitTime`. The logic will look something like:
```java
if (latestAspectEmitTime > ingestionTrackingContext.getEmitTime()) {
  // skip backfill
} else {
  // proceed with backfill
}
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
