### PR TITLE
fix: update EbeanLocalDao constuctors with urnClass & minor update

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -223,14 +223,15 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param producer {@link BaseMetadataEventProducer} for the metadata event producer
    * @param storageConfig {@link LocalDAOStorageConfig} containing storage config of full list of supported aspects
    */
-  public BaseLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull LocalDAOStorageConfig storageConfig) {
+  public BaseLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull LocalDAOStorageConfig storageConfig,
+      @Nonnull Class<URN> urnClass) {
     super(storageConfig.getAspectStorageConfigMap().keySet());
     _producer = producer;
     _storageConfig = storageConfig;
     _aspectUnionClass = producer.getAspectUnionClass();
     _trackingManager = null;
     _trackingProducer = null;
-    _urnClass = null;
+    _urnClass = urnClass;
   }
 
   /**
@@ -242,14 +243,14 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *
    */
   public BaseLocalDAO(@Nonnull BaseTrackingMetadataEventProducer trackingProducer, @Nonnull LocalDAOStorageConfig storageConfig,
-      @Nonnull BaseTrackingManager trackingManager) {
+      @Nonnull BaseTrackingManager trackingManager, @Nonnull Class<URN> urnClass) {
     super(storageConfig.getAspectStorageConfigMap().keySet());
     _producer = null;
     _storageConfig = storageConfig;
     _aspectUnionClass = trackingProducer.getAspectUnionClass();
     _trackingManager = trackingManager;
     _trackingProducer = trackingProducer;
-    _urnClass = null;
+    _urnClass = urnClass;
   }
 
   /**

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -186,6 +186,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param aspectUnionClass containing union of all supported aspects. Must be a valid aspect union defined in
    *     com.linkedin.metadata.aspect
    * @param producer {@link BaseMetadataEventProducer} for the metadata event producer
+   * @param urnClass class of the URN type
    */
   public BaseLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
       @Nonnull Class<URN> urnClass) {
@@ -205,6 +206,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *     com.linkedin.metadata.aspect
    * @param trackingProducer {@link BaseTrackingMetadataEventProducer} for producing metadata events with tracking
    * @param trackingManager {@link BaseTrackingManager} for managing tracking requests
+   * @param urnClass class of the URN type
    */
   public BaseLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseTrackingMetadataEventProducer trackingProducer,
       @Nonnull BaseTrackingManager trackingManager, @Nonnull Class<URN> urnClass) {
@@ -222,6 +224,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *
    * @param producer {@link BaseMetadataEventProducer} for the metadata event producer
    * @param storageConfig {@link LocalDAOStorageConfig} containing storage config of full list of supported aspects
+   * @param urnClass class of the URN type
    */
   public BaseLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull LocalDAOStorageConfig storageConfig,
       @Nonnull Class<URN> urnClass) {
@@ -240,6 +243,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param trackingProducer {@link BaseTrackingMetadataEventProducer} for producing metadata events with tracking
    * @param storageConfig {@link LocalDAOStorageConfig} containing storage config of full list of supported aspects
    * @param trackingManager {@link BaseTrackingManager} for managing tracking requests
+   * @param urnClass class of the URN type
    *
    */
   public BaseLocalDAO(@Nonnull BaseTrackingMetadataEventProducer trackingProducer, @Nonnull LocalDAOStorageConfig storageConfig,

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -432,7 +432,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull EbeanServer server,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
       @Nonnull UrnPathExtractor<URN> urnPathExtractor) {
-    super(producer, storageConfig);
+    super(producer, storageConfig, urnClass);
     _server = server;
     _urnClass = urnClass;
     _urnPathExtractor = urnPathExtractor;
@@ -441,7 +441,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   private EbeanLocalDAO(@Nonnull BaseTrackingMetadataEventProducer producer, @Nonnull EbeanServer server,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
       @Nonnull UrnPathExtractor<URN> urnPathExtractor, @Nonnull BaseTrackingManager trackingManager) {
-    super(producer, storageConfig, trackingManager);
+    super(producer, storageConfig, trackingManager, urnClass);
     _server = server;
     _urnClass = urnClass;
     _urnPathExtractor = urnPathExtractor;

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticResource.java
@@ -49,7 +49,7 @@ public abstract class BaseEntityAgnosticResource {
    *
    * @param backfillRequests an array of {@link BackfillItem} to be backfilled. Empty aspect list means backfill all aspects.
    * @param ingestionMode {@link IngestionMode} to indicate the processing strategy. Live mode together with no-change
-   *                                           should represent no-op, empty map will be returned. Backfill is to redo
+   *                                           should represent no-op, empty array will be returned. Backfill is to redo
    *                                           any metadata update that is missed or skipped in the past.
    *                                           Bootstrap indicates building the metadata from scratch.
    * @return an array of {@link BackfillItem} that is backfilled, failed urns and aspects will be filtered out


### PR DESCRIPTION
## Summary
- BaseLocalDao has four constructors and [2 dependencies](https://jarvis.corp.linkedin.com/codesearch/results?query=%22extends+BaseLocalDao%3C%22): EbeanLocalDao and EspressoDao (not in this repo).
  - the update for EbeanLocalDao was completed for 2 constructors in #325 
  - the constructor update for EspressoDao was completed
- it turns out the rest two constructors in BaseLocalDao are also used in EbeanLocalDao in dao factory, therefore this PR updates remaining constructors with urnClass

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
