### PR TITLE
Exclude soft deleted relationships from local relationship query

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -245,15 +245,15 @@ public class EbeanLocalRelationshipQueryDAO {
       sqlBuilder.append("INNER JOIN ").append(sourceTableName).append(" st ON st.urn=rt.source ");
     }
 
+    sqlBuilder.append("WHERE deleted_ts is NULL");
     String whereClause = SQLStatementUtils.whereClause(SUPPORTED_CONDITIONS,
         new Pair<>(sourceEntityFilter, "st"),
         new Pair<>(destinationEntityFilter, "dt"),
         new Pair<>(relationshipFilter, "rt"));
 
     if (whereClause != null) {
-      sqlBuilder.append("WHERE ").append(whereClause);
+      sqlBuilder.append(" AND ").append(whereClause);
     }
-
     return sqlBuilder.toString();
   }
 }


### PR DESCRIPTION
## Context

During (local) relationship update, the out dated relationships will be soft deleted from local relationship table by marking the delete_ts = now(). However, the local relationship query does not exclude soft deleted relationships. This PR is to resolve this bug. 

This is a mandatory required fix in TMS Lineage Migration

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
