### PR TITLE
Only select urn is needed for listUrns API

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -247,7 +247,7 @@ public class SQLStatementUtils {
     if (hasTotalCount) {
       sb.append(String.format(SQL_FILTER_TEMPLATE, totalCountSql, tableName));
     } else {
-      sb.append("SELECT * FROM ").append(tableName);
+      sb.append("SELECT urn FROM ").append(tableName);
     }
 
     sb.append("\n");


### PR DESCRIPTION
## Summary
When calling listUrns with large page size such as 1000, the API would throw OOM exception.
```
Caused by: java.lang.OutOfMemoryError: Java heap space
	at java.util.Arrays.copyOfRange(Arrays.java:4030) ~[?:?]
	at java.lang.StringCoding.decodeUTF8(StringCoding.java:710) ~[?:?]
	at java.lang.StringCoding.decode(StringCoding.java:231) ~[?:?]
	at java.lang.String.<init>(String.java:467) ~[?:?]
	at com.mysql.cj.util.StringUtils.toString(StringUtils.java:1350) ~[com.linkedin.li-mysql-connector-java.li-mysql-connector-java-8.0.27.73.jar:8.0.27.73]
```
select * is not necessary as only urn column is read for listUrns API. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
