### PR TITLE
feat: Add BaseVersionedAspect.pdl

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -8,7 +8,7 @@ record BaseVersionedAspect {
  /**
   * The version of the metadata aspect
   */
- semanticVersion: optional record SemanticVersion {
+ baseSematicVersion: optional record BaseSematicVersion {
    major: int
    minor: int
    patch: int

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -1,0 +1,16 @@
+namespace com.linkedin.metadata.aspect
+
+/**
+* A record containing semantic version of aspects
+*/
+record BaseVersionedAspect {
+
+ /**
+  * The version of the metadata aspect
+  */
+ semanticVersion: optional record SemanticVersion {
+   major: int
+   minor: int
+   patch: int
+ }
+}

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -1,7 +1,8 @@
 namespace com.linkedin.metadata.aspect
 
 /**
-* A record containing semantic version of aspects
+* A base record containing semantic version of aspects
+* Usage: Aspects can include this record to add semantic version metadata to themselves
 */
 record BaseVersionedAspect {
 

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -9,8 +9,19 @@ record BaseVersionedAspect {
   * The version of the metadata aspect
   */
  baseSematicVersion: optional record BaseSematicVersion {
+   /**
+    * The major version of this version. This is the x in x.y.z.
+    */
    major: int
+
+   /**
+    * The minor version of this version. This is the y in x.y.z
+    */
    minor: int
+
+   /**
+   * The patch version of this version. This is the z in x.y.z
+   */
    patch: int
  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -64,10 +64,13 @@ public class EmbeddedMariaInstance {
           configurationBuilder.setDataDir(baseDbDir + File.separator + "data");
           configurationBuilder.setBaseDir(baseDbDir + File.separator + "base");
 
-          configurationBuilder.setBaseDir("/opt/homebrew");
-          configurationBuilder.setUnpackingFromClasspath(false);
-          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
-
+          /*
+           * Add below 3 lines of code if building datahub-gma on a M1 / M2 chip Apple computer.
+           *
+           * configurationBuilder.setBaseDir("/opt/homebrew");
+           * configurationBuilder.setUnpackingFromClasspath(false);
+           * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+           */
 
           try {
             // ensure the DB directory is deleted before we start to have a clean start

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -64,13 +64,10 @@ public class EmbeddedMariaInstance {
           configurationBuilder.setDataDir(baseDbDir + File.separator + "data");
           configurationBuilder.setBaseDir(baseDbDir + File.separator + "base");
 
-          /*
-           * Add below 3 lines of code if building datahub-gma on a M1 / M2 chip Apple computer.
-           *
-           * configurationBuilder.setBaseDir("/opt/homebrew");
-           * configurationBuilder.setUnpackingFromClasspath(false);
-           * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
-           */
+          configurationBuilder.setBaseDir("/opt/homebrew");
+          configurationBuilder.setUnpackingFromClasspath(false);
+          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+
 
           try {
             // ensure the DB directory is deleted before we start to have a clean start


### PR DESCRIPTION
## Summary
Adding BaseVersionedAspect.pdl. It can be included by other aspects to add semantic versioning to the aspect. 

## Details
**Context**: The Datahub backend can be updated with Kafka Metadata Change Events (MCEs). However MCEs with outdated metadata may be received by the backend, eg a developer testing an older version of a project. Thus we want to (1) add semantic versioning to aspects and (2) add logic for datahub to process MCEs based on the version of the MCE and aspect in backend. This PR covers (1).

**Internal design doc**: https://docs.google.com/document/d/1Von4_q_CtvGrdMDfWHHVCcqmGyFT9CMlmXoeZAO59Oo/edit?usp=sharing

## Testing
* **Build test**: Tested with `./gradlew build` as part of github checks

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)