### PR TITLE
feat: Create BaseIngestionMode.pdl

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -31,8 +31,8 @@ record BaseVersionedAspect {
    /** Default write mode. First in first out. */
    FIFO
 
-   /** Override existing version. */
-   OVERRIDE
+   /** Overwrite existing version. */
+   OVERWRITE
  }
 
 

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -9,7 +9,7 @@ record BaseVersionedAspect {
  /**
   * The version of the metadata aspect
   */
- baseSematicVersion: optional record BaseSematicVersion {
+ baseSemanticVersion: optional record BaseSemanticVersion {
    /**
     * The major version of this version. This is the x in x.y.z.
     */

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -25,4 +25,16 @@ record BaseVersionedAspect {
    */
    patch: int
  }
+
+ /** Mode used when writing aspect version into backend */
+ writeMode: optional enum WriteMode {
+   /** Default write mode. First in first out. */
+   FIFO
+
+   /** Override existing version. */
+   OVERRIDE
+ }
+
+
+ }
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -30,10 +30,14 @@ record BaseVersionedAspect {
  * Mode used when writing aspect version into backend
  */
  writeMode: optional enum WriteMode {
-   /** Default write mode. First in first out. */
+   /**
+   * Default write mode. First in first out.
+   */
    FIFO
 
-   /** Overwrite existing version. */
+   /**
+   * Overwrite existing version.
+   */
    OVERWRITE
  }
 

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -26,7 +26,9 @@ record BaseVersionedAspect {
    patch: int
  }
 
- /** Mode used when writing aspect version into backend */
+ /**
+ * Mode used when writing aspect version into backend
+ */
  writeMode: optional enum WriteMode {
    /** Default write mode. First in first out. */
    FIFO
@@ -35,6 +37,4 @@ record BaseVersionedAspect {
    OVERWRITE
  }
 
-
- }
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -9,7 +9,7 @@ record BaseVersionedAspect {
  /**
   * The version of the metadata aspect
   */
- baseSemanticVersion: optional record BaseSemanticVersion {
+ baseSematicVersion: optional record BaseSematicVersion {
    /**
     * The major version of this version. This is the x in x.y.z.
     */
@@ -25,20 +25,4 @@ record BaseVersionedAspect {
    */
    patch: int
  }
-
- /**
- * Mode used when writing aspect version into backend
- */
- writeMode: optional enum WriteMode {
-   /**
-   * Default write mode. First in first out.
-   */
-   FIFO
-
-   /**
-   * Overwrite existing version.
-   */
-   OVERWRITE
- }
-
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionMode.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionMode.pdl
@@ -16,9 +16,9 @@ record BaseIngestionMode {
    FIFO
 
    /**
-   * Overwrite existing version.
+   * Override logic that may skip aspect metadata write (eg equality check)
    */
-   OVERWRITE
+   OVERRIDE
  }
 
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionMode.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionMode.pdl
@@ -11,12 +11,12 @@ record BaseIngestionMode {
  */
  writeMode: optional enum WriteMode {
    /**
-   * Default write mode. First in first out.
+   * Default write mode. Same behavior as not setting writeMode
    */
-   FIFO
+   DEFAULT
 
    /**
-   * Override logic that may skip aspect metadata write (eg equality check)
+   * Override checks that may skip metadata write (eg equality check)
    */
    OVERRIDE
  }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionMode.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/BaseIngestionMode.pdl
@@ -1,0 +1,24 @@
+namespace com.linkedin.metadata.events
+
+/**
+* A base record containing ingestion mode of aspects
+* Usage: Aspects can include this record to specify ingestion mode
+*/
+record BaseIngestionMode {
+
+ /**
+ * Mode used when writing aspect metadata into backend
+ */
+ writeMode: optional enum WriteMode {
+   /**
+   * Default write mode. First in first out.
+   */
+   FIFO
+
+   /**
+   * Overwrite existing version.
+   */
+   OVERWRITE
+ }
+
+}


### PR DESCRIPTION
## Summary
Adding BaseIngesitonMode.pdl. This record has a writeMode attribute will declare how the aspect metadata change events (MCEs) should be written to the backend.

## Details
For starters, we will allow MCEs to declare the following write modes:
- DEFAULT: Default write mode. Same behavior as not setting writeMode.
- OVERRIDE: Override checks that may skip metadata write (eg equality check).

## Testing
- **Build test**: `./gradlew build` ran successfully

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
