### PR TITLE
Adding support for non dollar virtual columns names

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EBeanDAOConfig.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EBeanDAOConfig.java
@@ -1,0 +1,9 @@
+package com.linkedin.metadata.dao;
+
+import lombok.Data;
+
+
+@Data
+public class EBeanDAOConfig {
+  private boolean nonDollarVirtualColumnsEnabled = false;
+}

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -367,6 +367,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    * Produce {@link SqlQuery} for list urn by offset (start) and limit (pageSize).
    * @param indexFilter index filter conditions
    * @param indexSortCriterion sorting criterion, default ACS
+   * @param nonDollarVirtualColumnsEnabled true if virtual column does not contain $, false otherwise
    * @return SqlQuery a SQL query which can be executed by ebean server.
    */
   private SqlQuery createFilterSqlQuery(@Nullable IndexFilter indexFilter,

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -334,9 +334,12 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   @Nonnull
   @Override
   public Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
-      @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
+      @Nonnull IndexGroupByCriterion indexGroupByCriterion, boolean nonDollarVirtualColumnsEnabled) {
     final String tableName = SQLSchemaUtils.getTableName(_entityType);
-    final String groupByColumn = getGeneratedColumnName(indexGroupByCriterion.getAspect(), indexGroupByCriterion.getPath());
+    String groupByColumn = getGeneratedColumnName(indexGroupByCriterion.getAspect(), indexGroupByCriterion.getPath());
+    if (nonDollarVirtualColumnsEnabled) {
+      groupByColumn = groupByColumn.replace('$', '0');
+    }
 
     // first, check for existence of the column we want to GROUP BY
     if (!checkColumnExists(tableName, groupByColumn)) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -339,7 +339,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   public Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
     final String tableName = SQLSchemaUtils.getTableName(_entityType);
-    String groupByColumn = getGeneratedColumnName(indexGroupByCriterion.getAspect(), indexGroupByCriterion.getPath(), _nonDollarVirtualColumnsEnabled);
+    final String groupByColumn = getGeneratedColumnName(indexGroupByCriterion.getAspect(), indexGroupByCriterion.getPath(), _nonDollarVirtualColumnsEnabled);
     // first, check for existence of the column we want to GROUP BY
     if (!checkColumnExists(tableName, groupByColumn)) {
       // if we are trying to GROUP BY the results on a column that does not exist, just return an empty map

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1423,8 +1423,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("listUrns with index filter is only supported in new schema.");
     }
-
-    return _localAccess.listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize);
+    return _localAccess.listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize, _nonDollarVirtualColumnsEnabled);
   }
 
   /**
@@ -1443,7 +1442,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       throw new UnsupportedOperationException("listUrns with index filter is only supported in new schema.");
     }
 
-    return _localAccess.listUrns(indexFilter, indexSortCriterion, start, pageSize);
+    return _localAccess.listUrns(indexFilter, indexSortCriterion, start, pageSize, _nonDollarVirtualColumnsEnabled);
   }
 
   @Override
@@ -1454,11 +1453,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("countAggregate is only supported in new schema.");
     }
-    //If the non dollar virtual columns are not enabled, then we will pass the flag to the local access to not consider
-    if (!_nonDollarVirtualColumnsEnabled) {
-      return _localAccess.countAggregate(indexFilter, indexGroupByCriterion);
-    }
     //If the non dollar virtual columns are enabled, then we will pass the flag to the local access to consider
-    return _localAccess.countAggregate(indexFilter, indexGroupByCriterion, true);
+    return _localAccess.countAggregate(indexFilter, indexGroupByCriterion, _nonDollarVirtualColumnsEnabled);
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -102,6 +102,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   // true = overwrite 2nd latest version with latest version (equivalent to keeping only version = 0 rows in metadata_aspect)
   private boolean _overwriteLatestVersionEnabled = false;
 
+  //true if virtual columns with non dollar characters are enabled
+  private boolean _nonDollarVirtualColumnsEnabled = false;
+
   public void setChangeLogEnabled(boolean changeLogEnabled) {
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
       _changeLogEnabled = changeLogEnabled;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -82,6 +82,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   private IEbeanLocalAccess<URN> _localAccess;
   private UrnPathExtractor<URN> _urnPathExtractor;
   private SchemaConfig _schemaConfig = SchemaConfig.OLD_SCHEMA_ONLY;
+  private final EBeanDAOConfig _eBeanDAOConfig = new EBeanDAOConfig();
 
   public enum SchemaConfig {
     OLD_SCHEMA_ONLY, // Default: read from and write to the old schema table
@@ -101,9 +102,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   // false = read/bump 2nd latest version + insert latest version
   // true = overwrite 2nd latest version with latest version (equivalent to keeping only version = 0 rows in metadata_aspect)
   private boolean _overwriteLatestVersionEnabled = false;
-
-  //true if virtual columns with non dollar characters are enabled
-  private boolean _nonDollarVirtualColumnsEnabled = false;
 
   public void setChangeLogEnabled(boolean changeLogEnabled) {
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
@@ -397,7 +395,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     this(aspectUnionClass, producer, server, urnClass);
     _schemaConfig = schemaConfig;
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
-      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _nonDollarVirtualColumnsEnabled);
+      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     }
   }
 
@@ -407,7 +405,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     this(aspectUnionClass, producer, server, urnClass, trackingManager);
     _schemaConfig = schemaConfig;
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
-      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _nonDollarVirtualColumnsEnabled);
+      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     }
   }
 
@@ -416,9 +414,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       @Nonnull EBeanDAOConfig ebeanDAOConfig) {
     this(aspectUnionClass, producer, server, urnClass);
     _schemaConfig = schemaConfig;
-    _nonDollarVirtualColumnsEnabled = ebeanDAOConfig.isNonDollarVirtualColumnsEnabled();
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
-      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _nonDollarVirtualColumnsEnabled);
+      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, ebeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     }
   }
 
@@ -443,10 +440,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       @Nonnull SchemaConfig schemaConfig,
       @Nonnull FindMethodology findMethodology, @Nonnull EBeanDAOConfig ebeanDAOConfig) {
     this(aspectUnionClass, producer, server, serverConfig, urnClass, schemaConfig);
-    _nonDollarVirtualColumnsEnabled = ebeanDAOConfig.isNonDollarVirtualColumnsEnabled();
     _findMethodology = findMethodology;
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
-      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _nonDollarVirtualColumnsEnabled);
+      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, ebeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     }
   }
 
@@ -475,7 +471,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     this(producer, server, storageConfig, urnClass, urnPathExtractor);
     _schemaConfig = schemaConfig;
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
-      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, urnPathExtractor, _nonDollarVirtualColumnsEnabled);
+      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, urnPathExtractor, _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     }
   }
 
@@ -485,7 +481,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     this(producer, server, storageConfig, urnClass, urnPathExtractor, trackingManager);
     _schemaConfig = schemaConfig;
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
-      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, urnPathExtractor, _nonDollarVirtualColumnsEnabled);
+      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, urnPathExtractor, _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1454,11 +1454,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("countAggregate is only supported in new schema.");
     }
-
+    //If the non dollar virtual columns are not enabled, then we will pass the flag to the local access to not consider
     if (!_nonDollarVirtualColumnsEnabled) {
       return _localAccess.countAggregate(indexFilter, indexGroupByCriterion);
     }
-
+    //If the non dollar virtual columns are enabled, then we will pass the flag to the local access to consider
     return _localAccess.countAggregate(indexFilter, indexGroupByCriterion, true);
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1453,7 +1453,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("countAggregate is only supported in new schema.");
     }
-    //If the non dollar virtual columns are enabled, then we will pass the flag to the local access to consider
     return _localAccess.countAggregate(indexFilter, indexGroupByCriterion, _nonDollarVirtualColumnsEnabled);
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -136,6 +136,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
+  public void setNonDollarVirtualColumnsEnabled(boolean nonDollarVirtualColumnsEnabled) {
+    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
+  }
+
   public enum FindMethodology {
     UNIQUE_ID,      // (legacy) https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/EbeanServer.html#find-java.lang.Class-java.lang.Object-
     DIRECT_SQL,     // https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/EbeanServer.html#findNative-java.lang.Class-java.lang.String-
@@ -1451,6 +1455,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       throw new UnsupportedOperationException("countAggregate is only supported in new schema.");
     }
 
-    return _localAccess.countAggregate(indexFilter, indexGroupByCriterion);
+    if(!_nonDollarVirtualColumnsEnabled) {
+      return _localAccess.countAggregate(indexFilter, indexGroupByCriterion);
+    }
+
+    return _localAccess.countAggregate(indexFilter, indexGroupByCriterion, true);
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1455,7 +1455,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       throw new UnsupportedOperationException("countAggregate is only supported in new schema.");
     }
 
-    if(!_nonDollarVirtualColumnsEnabled) {
+    if (!_nonDollarVirtualColumnsEnabled) {
       return _localAccess.countAggregate(indexFilter, indexGroupByCriterion);
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -436,26 +436,18 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     _findMethodology = findMethodology;
   }
 
-  private EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
-      @Nonnull EbeanServer server, @Nonnull ServerConfig serverConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull SchemaConfig schemaConfig, boolean nonDollarVirtualColumnsEnabled) {
-    this(aspectUnionClass, producer, server, urnClass);
-    _schemaConfig = schemaConfig;
-    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
-    if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
-      _localAccess =
-          new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _nonDollarVirtualColumnsEnabled);
-    }
-  }
-
-  // Only called in testing (test all possible combos of SchemaConfig, FindMethodology and nonDollarVirtualColumnsEnabled)
+  // Only called in testing (test all possible combos of SchemaConfig, FindMethodology)
   @VisibleForTesting
   EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
       @Nonnull EbeanServer server, @Nonnull ServerConfig serverConfig, @Nonnull Class<URN> urnClass,
       @Nonnull SchemaConfig schemaConfig,
-      @Nonnull FindMethodology findMethodology, boolean nonDollarVirtualColumnsEnabled) {
-    this(aspectUnionClass, producer, server, serverConfig, urnClass, schemaConfig, nonDollarVirtualColumnsEnabled);
+      @Nonnull FindMethodology findMethodology, @Nonnull EBeanDAOConfig ebeanDAOConfig) {
+    this(aspectUnionClass, producer, server, serverConfig, urnClass, schemaConfig);
+    _nonDollarVirtualColumnsEnabled = ebeanDAOConfig.isNonDollarVirtualColumnsEnabled();
     _findMethodology = findMethodology;
+    if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
+      _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _nonDollarVirtualColumnsEnabled);
+    }
   }
 
   @VisibleForTesting

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -136,14 +136,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
-  public void setNonDollarVirtualColumnsEnabled(boolean nonDollarVirtualColumnsEnabled) {
-    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
-  }
-
-  public boolean isNonDollarVirtualColumnsEnabled() {
-    return _nonDollarVirtualColumnsEnabled;
-  }
-
   public enum FindMethodology {
     UNIQUE_ID,      // (legacy) https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/EbeanServer.html#find-java.lang.Class-java.lang.Object-
     DIRECT_SQL,     // https://javadoc.io/static/io.ebean/ebean/11.19.2/io/ebean/EbeanServer.html#findNative-java.lang.Class-java.lang.String-
@@ -380,6 +372,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     this(producer, createServer(serverConfig), serverConfig, storageConfig, urnClass, new EmptyPathExtractor<>(), schemaConfig, trackingManager);
   }
 
+  public EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseTrackingMetadataEventProducer producer,
+      @Nonnull EbeanServer server, @Nonnull ServerConfig serverConfig, @Nonnull SchemaConfig schemaConfig, @Nonnull Class<URN> urnClass) {
+    this(aspectUnionClass, producer, server, serverConfig, urnClass, schemaConfig, new EBeanDAOConfig());
+  }
+
   private EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
       @Nonnull EbeanServer server, @Nonnull Class<URN> urnClass) {
     super(aspectUnionClass, producer, urnClass);
@@ -414,13 +411,12 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
-  @VisibleForTesting
-  EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseTrackingMetadataEventProducer producer,
+  private EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseTrackingMetadataEventProducer producer,
       @Nonnull EbeanServer server, @Nonnull ServerConfig serverConfig, @Nonnull Class<URN> urnClass, @Nonnull SchemaConfig schemaConfig,
-      boolean nonDollarVirtualColumnsEnabled) {
+      @Nonnull EBeanDAOConfig ebeanDAOConfig) {
     this(aspectUnionClass, producer, server, urnClass);
     _schemaConfig = schemaConfig;
-    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
+    _nonDollarVirtualColumnsEnabled = ebeanDAOConfig.isNonDollarVirtualColumnsEnabled();
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
       _localAccess = new EbeanLocalAccess<>(server, serverConfig, urnClass, _urnPathExtractor, _nonDollarVirtualColumnsEnabled);
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -34,12 +34,12 @@ public class EbeanLocalRelationshipQueryDAO {
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
-  private final boolean _nonDollarVirtualColumnsEnabled;
+  private final EBeanDAOConfig _eBeanDAOConfig;
 
-  public EbeanLocalRelationshipQueryDAO(EbeanServer server, EBeanDAOConfig config) {
+  public EbeanLocalRelationshipQueryDAO(EbeanServer server, EBeanDAOConfig eBeanDAOConfig) {
     _server = server;
+    _eBeanDAOConfig = eBeanDAOConfig;
     _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS);
-    _nonDollarVirtualColumnsEnabled = config.isNonDollarVirtualColumnsEnabled();
   }
 
   static final Map<Condition, String> SUPPORTED_CONDITIONS =
@@ -73,7 +73,8 @@ public class EbeanLocalRelationshipQueryDAO {
     final StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("SELECT * FROM ").append(tableName);
     if (filter.hasCriteria() && filter.getCriteria().size() > 0) {
-      sqlBuilder.append(" WHERE ").append(SQLStatementUtils.whereClause(filter, SUPPORTED_CONDITIONS, null, _nonDollarVirtualColumnsEnabled));
+      sqlBuilder.append(" WHERE ").append(SQLStatementUtils.whereClause(filter, SUPPORTED_CONDITIONS, null,
+          _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled()));
     }
     sqlBuilder.append(" ORDER BY urn LIMIT ").append(Math.max(1, count)).append(" OFFSET ").append(Math.max(0, offset));
 
@@ -98,7 +99,8 @@ public class EbeanLocalRelationshipQueryDAO {
     final String srcEntityTable = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(sourceEntityClass));
     final String destEntityTable = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(destinationEntityClass));
     final String sql = _sqlGenerator.multiHopTraversalSql(minHops, maxHops, Math.max(1, count), Math.max(0, offset), relationshipTable,
-        srcEntityTable, destEntityTable, relationshipFilter, sourceEntityFilter, destinationEntityFilter, _nonDollarVirtualColumnsEnabled);
+        srcEntityTable, destEntityTable, relationshipFilter, sourceEntityFilter, destinationEntityFilter,
+        _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
 
     final Class snapshotClass = relationshipFilter.getDirection() == RelationshipDirection.INCOMING ? sourceEntityClass : destinationEntityClass;
 
@@ -249,7 +251,8 @@ public class EbeanLocalRelationshipQueryDAO {
     }
 
     sqlBuilder.append("WHERE deleted_ts is NULL");
-    String whereClause = SQLStatementUtils.whereClause(SUPPORTED_CONDITIONS, _nonDollarVirtualColumnsEnabled,
+    String whereClause = SQLStatementUtils.whereClause(SUPPORTED_CONDITIONS,
+        _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled(),
         new Pair<>(sourceEntityFilter, "st"),
         new Pair<>(destinationEntityFilter, "dt"),
         new Pair<>(relationshipFilter, "rt"));

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -45,6 +45,10 @@ public class EbeanLocalRelationshipQueryDAO {
     _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
   }
 
+  public boolean isNonDollarVirtualColumnsEnabled() {
+    return _nonDollarVirtualColumnsEnabled;
+  }
+
   static final Map<Condition, String> SUPPORTED_CONDITIONS =
       Collections.unmodifiableMap(new HashMap<Condition, String>() {
         {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -34,19 +34,12 @@ public class EbeanLocalRelationshipQueryDAO {
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
-  private boolean _nonDollarVirtualColumnsEnabled = false;
+  private final boolean _nonDollarVirtualColumnsEnabled;
 
-  public EbeanLocalRelationshipQueryDAO(EbeanServer server) {
+  public EbeanLocalRelationshipQueryDAO(EbeanServer server, EBeanDAOConfig config) {
     _server = server;
     _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS);
-  }
-
-  public void setNonDollarVirtualColumnsEnabled(boolean nonDollarVirtualColumnsEnabled) {
-    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
-  }
-
-  public boolean isNonDollarVirtualColumnsEnabled() {
-    return _nonDollarVirtualColumnsEnabled;
+    _nonDollarVirtualColumnsEnabled = config.isNonDollarVirtualColumnsEnabled();
   }
 
   static final Map<Condition, String> SUPPORTED_CONDITIONS =

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -86,6 +86,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param indexSortCriterion {@link IndexSortCriterion} sorting criterion to be applied
    * @param lastUrn last urn of the previous fetched page. For the first page, this should be set as NULL
    * @param pageSize maximum number of distinct urns to return
+   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return List of urns from local secondary index that satisfy the given filter conditions
    */
   List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
@@ -112,6 +113,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * Gets the count of an aggregation specified by the aspect and field to group on.
    * @param indexFilter {@link IndexFilter} that defines the filter conditions
    * @param indexGroupByCriterion {@link IndexGroupByCriterion} that defines the aspect to group by
+   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return map of the field to the count
    */
   @Nonnull

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -115,8 +115,14 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @return map of the field to the count
    */
   @Nonnull
-  Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
-      @Nonnull IndexGroupByCriterion indexGroupByCriterion);
+  default Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
+      @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
+        return countAggregate(indexFilter, indexGroupByCriterion, false);
+      }
+
+    @Nonnull
+    Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
+      @Nonnull IndexGroupByCriterion indexGroupByCriterion, boolean nonDollarVirtualColumnsEnabled);
 
   /**
    * Paginates over all URNs for entities that have a specific aspect. This does not include the urn(s) for which the

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -86,21 +86,20 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param indexSortCriterion {@link IndexSortCriterion} sorting criterion to be applied
    * @param lastUrn last urn of the previous fetched page. For the first page, this should be set as NULL
    * @param pageSize maximum number of distinct urns to return
-   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return List of urns from local secondary index that satisfy the given filter conditions
    */
   List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-      @Nullable URN lastUrn, int pageSize, boolean nonDollarVirtualColumnsEnabled);
+      @Nullable URN lastUrn, int pageSize);
 
   /**
-   * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int, boolean)} but returns a list result with pagination
+   * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int)} but returns a list result with pagination
    * information.
    *
    * @param start the starting offset of the page
    * @return a {@link ListResult} containing a list of urns and other pagination information
    */
   ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-      int start, int pageSize, boolean nonDollarVirtualColumnsEnabled);
+      int start, int pageSize);
 
   /**
    * Returns a boolean representing if an Urn has any Aspects associated with it (i.e. if it exists in the DB).
@@ -113,12 +112,11 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * Gets the count of an aggregation specified by the aspect and field to group on.
    * @param indexFilter {@link IndexFilter} that defines the filter conditions
    * @param indexGroupByCriterion {@link IndexGroupByCriterion} that defines the aspect to group by
-   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return map of the field to the count
    */
   @Nonnull
   Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
-      @Nonnull IndexGroupByCriterion indexGroupByCriterion, boolean nonDollarVirtualColumnsEnabled);
+      @Nonnull IndexGroupByCriterion indexGroupByCriterion);
 
   /**
    * Paginates over all URNs for entities that have a specific aspect. This does not include the urn(s) for which the

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -89,17 +89,17 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @return List of urns from local secondary index that satisfy the given filter conditions
    */
   List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-      @Nullable URN lastUrn, int pageSize);
+      @Nullable URN lastUrn, int pageSize, boolean nonDollarVirtualColumnsEnabled);
 
   /**
-   * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int)} but returns a list result with pagination
+   * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int, boolean)} but returns a list result with pagination
    * information.
    *
    * @param start the starting offset of the page
    * @return a {@link ListResult} containing a list of urns and other pagination information
    */
   ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-      int start, int pageSize);
+      int start, int pageSize, boolean nonDollarVirtualColumnsEnabled);
 
   /**
    * Returns a boolean representing if an Urn has any Aspects associated with it (i.e. if it exists in the DB).
@@ -109,19 +109,13 @@ public interface IEbeanLocalAccess<URN extends Urn> {
   boolean exists(@Nonnull URN urn);
 
   /**
-   *  Gets the count of an aggregation specified by the aspect and field to group on.
+   * Gets the count of an aggregation specified by the aspect and field to group on.
    * @param indexFilter {@link IndexFilter} that defines the filter conditions
    * @param indexGroupByCriterion {@link IndexGroupByCriterion} that defines the aspect to group by
    * @return map of the field to the count
    */
   @Nonnull
-  default Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
-      @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
-        return countAggregate(indexFilter, indexGroupByCriterion, false);
-      }
-
-    @Nonnull
-    Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
+  Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion, boolean nonDollarVirtualColumnsEnabled);
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -66,6 +66,7 @@ public class SQLIndexFilterUtils {
   /**
    * Parse {@link IndexSortCriterion} into SQL syntax.
    * @param indexSortCriterion filter sorting criterion
+   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return SQL statement of sorting, e.g. ORDER BY ... DESC ..etc.
    */
   public static String parseSortCriteria(@Nullable IndexSortCriterion indexSortCriterion, boolean nonDollarVirtualColumnsEnabled) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -68,12 +68,14 @@ public class SQLIndexFilterUtils {
    * @param indexSortCriterion filter sorting criterion
    * @return SQL statement of sorting, e.g. ORDER BY ... DESC ..etc.
    */
-  public static String parseSortCriteria(@Nullable IndexSortCriterion indexSortCriterion) {
+  public static String parseSortCriteria(@Nullable IndexSortCriterion indexSortCriterion, boolean nonDollarVirtualColumnsEnabled) {
     if (indexSortCriterion == null) {
       // Default to order by urn if user does not provide sort criterion.
       return "ORDER BY URN";
     }
-    final String indexColumn = SQLSchemaUtils.getGeneratedColumnName(indexSortCriterion.getAspect(), indexSortCriterion.getPath());
+    final String indexColumn =
+        SQLSchemaUtils.getGeneratedColumnName(indexSortCriterion.getAspect(), indexSortCriterion.getPath(),
+            nonDollarVirtualColumnsEnabled);
 
     if (!indexSortCriterion.hasOrder()) {
       return "ORDER BY " + indexColumn;
@@ -84,10 +86,12 @@ public class SQLIndexFilterUtils {
 
   /**
    * Parse {@link IndexFilter} into MySQL syntax.
-   * @param indexFilter index filter
+   *
+   * @param indexFilter                    index filter
+   * @param nonDollarVirtualColumnsEnabled whether to enable non-dollar virtual columns
    * @return translated SQL condition expression, e.g. WHERE ...
    */
-  public static String parseIndexFilter(@Nullable IndexFilter indexFilter) {
+  public static String parseIndexFilter(@Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled) {
     List<String> sqlFilters = new ArrayList<>();
 
     if (indexFilter == null || !indexFilter.hasCriteria()) {
@@ -107,7 +111,7 @@ public class SQLIndexFilterUtils {
       if (pathParams != null) {
         validateConditionAndValue(indexCriterion);
         final Condition condition = pathParams.getCondition();
-        final String indexColumn = getGeneratedColumnName(aspect, pathParams.getPath());
+        final String indexColumn = getGeneratedColumnName(aspect, pathParams.getPath(), nonDollarVirtualColumnsEnabled);
         sqlFilters.add(parseSqlFilter(indexColumn, condition, pathParams.getValue()));
       }
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLSchemaUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLSchemaUtils.java
@@ -88,12 +88,13 @@ public class SQLSchemaUtils {
    * Get generated column name from aspect and path.
    */
   @Nonnull
-  public static String getGeneratedColumnName(@Nonnull String aspect, @Nonnull String path) {
+  public static String getGeneratedColumnName(@Nonnull String aspect, @Nonnull String path, boolean nonDollarVirtualColumnsEnabled) {
+    char delimiter = nonDollarVirtualColumnsEnabled ? '0' : '$';
     if (isUrn(aspect)) {
-      return INDEX_PREFIX + "urn" + processPath(path);
+      return INDEX_PREFIX + "urn" + processPath(path, delimiter);
     }
 
-    return INDEX_PREFIX + getColumnNameFromAnnotation(aspect) + processPath(path);
+    return INDEX_PREFIX + getColumnNameFromAnnotation(aspect) + processPath(path, delimiter);
   }
 
   /**
@@ -106,13 +107,14 @@ public class SQLSchemaUtils {
   /**
    * process 'path' into mysql column name convention.
    * @param path path in string e.g. /name/value, /name
-   * @return $name$value or $name
+   * @param delimiter delimiter i.e '$' or '0'
+   * @return $name$value or $name or 0name$value or 0name
    */
   @Nonnull
-  public static String processPath(@Nonnull String path) {
-    path = path.replace("/", "$");
-    if (!path.startsWith("$")) {
-      path = "$" + path;
+  public static String processPath(@Nonnull String path, char delimiter) {
+    path = path.replace("/", String.valueOf(delimiter));
+    if (!path.startsWith(String.valueOf(delimiter))) {
+      path = delimiter + path;
     }
     return path;
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -341,7 +341,6 @@ public class SQLStatementUtils {
         andClauses.add("(" + whereClause(filter.getValue0(), supportedCondition, filter.getValue1(), nonDollarVirtualColumnsEnabled) + ")");
       }
     }
-    System.out.println("andClauses: " + andClauses);
     if (andClauses.isEmpty()) {
       return null;
     } else if (andClauses.size() == 1) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -236,8 +236,8 @@ public class SQLStatementUtils {
    * @param hasTotalCount whether to calculate total count in SQL.
    * @return translated SQL where statement
    */
-  public static String createFilterSql(String tableName, @Nullable IndexFilter indexFilter, boolean hasTotalCount) {
-    String whereClause = parseIndexFilter(indexFilter);
+  public static String createFilterSql(String tableName, @Nullable IndexFilter indexFilter, boolean hasTotalCount, boolean nonDollarVirtualColumnsEnabled) {
+    String whereClause = parseIndexFilter(indexFilter, nonDollarVirtualColumnsEnabled);
     String totalCountSql = String.format("SELECT COUNT(urn) FROM %s %s", tableName, whereClause);
     StringBuilder sb = new StringBuilder();
 
@@ -260,12 +260,12 @@ public class SQLStatementUtils {
    * @return translated group by SQL
    */
   public static String createGroupBySql(String tableName, @Nullable IndexFilter indexFilter,
-      @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
-    final String columnName = getGeneratedColumnName(indexGroupByCriterion.getAspect(), indexGroupByCriterion.getPath());
+      @Nonnull IndexGroupByCriterion indexGroupByCriterion, boolean nonDollarVirtualColumnsEnabled) {
+    final String columnName = getGeneratedColumnName(indexGroupByCriterion.getAspect(), indexGroupByCriterion.getPath(), nonDollarVirtualColumnsEnabled);
     StringBuilder sb = new StringBuilder();
     sb.append(String.format(INDEX_GROUP_BY_CRITERION, columnName, tableName));
     sb.append("\n");
-    sb.append(parseIndexFilter(indexFilter));
+    sb.append(parseIndexFilter(indexFilter, nonDollarVirtualColumnsEnabled));
     sb.append("\nGROUP BY ");
     sb.append(columnName);
     return sb.toString();
@@ -330,15 +330,15 @@ public class SQLStatementUtils {
    */
   @SafeVarargs
   @Nullable
-  public static String whereClause(@Nonnull Map<Condition, String> supportedCondition,
+  public static String whereClause(@Nonnull Map<Condition, String> supportedCondition, boolean nonDollarVirtualColumnsEnabled,
       @Nonnull Pair<LocalRelationshipFilter, String>... filters) {
     List<String> andClauses = new ArrayList<>();
     for (Pair<LocalRelationshipFilter, String> filter : filters) {
       if (filter.getValue0().hasCriteria() && filter.getValue0().getCriteria().size() > 0) {
-        andClauses.add("(" + whereClause(filter.getValue0(), supportedCondition, filter.getValue1()) + ")");
+        andClauses.add("(" + whereClause(filter.getValue0(), supportedCondition, filter.getValue1(), nonDollarVirtualColumnsEnabled) + ")");
       }
     }
-
+    System.out.println("andClauses: " + andClauses);
     if (andClauses.isEmpty()) {
       return null;
     } else if (andClauses.size() == 1) {
@@ -353,10 +353,13 @@ public class SQLStatementUtils {
    * @param filter contains field, condition and value
    * @param supportedCondition contains supported conditions such as EQUAL.
    * @param tablePrefix Table prefix append to the field name. Useful during SQL joining across multiple tables.
+   * @param nonDollarVirtualColumnsEnabled whether to use dollar sign in virtual column names.
    * @return sql that can be appended after where clause.
    */
   @Nonnull
-  public static String whereClause(@Nonnull LocalRelationshipFilter filter, @Nonnull Map<Condition, String> supportedCondition, @Nullable String tablePrefix) {
+  public static String whereClause(@Nonnull LocalRelationshipFilter filter,
+      @Nonnull Map<Condition, String> supportedCondition, @Nullable String tablePrefix,
+      boolean nonDollarVirtualColumnsEnabled) {
     if (!filter.hasCriteria() || filter.getCriteria().size() == 0) {
       throw new IllegalArgumentException("Empty filter cannot construct where clause.");
     }
@@ -364,7 +367,7 @@ public class SQLStatementUtils {
     // Group the conditions by field.
     Map<String, List<Pair<Condition, LocalRelationshipValue>>> groupByField = new HashMap<>();
     filter.getCriteria().forEach(criterion -> {
-      String field = parseLocalRelationshipField(criterion, tablePrefix);
+      String field = parseLocalRelationshipField(criterion, tablePrefix, nonDollarVirtualColumnsEnabled);
       List<Pair<Condition, LocalRelationshipValue>> group = groupByField.getOrDefault(field, new ArrayList<>());
       group.add(new Pair<>(criterion.getCondition(), criterion.getValue()));
       groupByField.put(field, group);
@@ -390,7 +393,6 @@ public class SQLStatementUtils {
         andClauses.add("(" + String.join(" OR ", orClauses) + ")");
       }
     }
-
     if (andClauses.size() == 1) {
       String andClause = andClauses.get(0);
       if (andClauses.get(0).startsWith("(")) {
@@ -402,20 +404,24 @@ public class SQLStatementUtils {
     return String.join(" AND ", andClauses);
   }
 
-  private static String parseLocalRelationshipField(@Nonnull final LocalRelationshipCriterion localRelationshipCriterion, @Nullable String tablePrefix) {
+  private static String parseLocalRelationshipField(
+      @Nonnull final LocalRelationshipCriterion localRelationshipCriterion, @Nullable String tablePrefix,
+      boolean nonDollarVirtualColumnsEnabled) {
     tablePrefix = tablePrefix == null ? "" : tablePrefix + ".";
     LocalRelationshipCriterion.Field field = localRelationshipCriterion.getField();
+    char delimiter = nonDollarVirtualColumnsEnabled ? '0' : '$';
 
     if (field.isUrnField()) {
       return tablePrefix + field.getUrnField().getName();
     }
 
     if (field.isRelationshipField()) {
-      return tablePrefix + field.getRelationshipField().getName() + SQLSchemaUtils.processPath(field.getRelationshipField().getPath());
+      return tablePrefix + field.getRelationshipField().getName() + SQLSchemaUtils.processPath(field.getRelationshipField().getPath(), delimiter);
     }
 
     if (field.isAspectField()) {
-      return tablePrefix + SQLSchemaUtils.getGeneratedColumnName(field.getAspectField().getAspect(), field.getAspectField().getPath());
+      return tablePrefix + SQLSchemaUtils.getGeneratedColumnName(field.getAspectField().getAspect(),
+          field.getAspectField().getPath(), nonDollarVirtualColumnsEnabled);
     }
 
     throw new IllegalArgumentException("Unrecognized field type");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -234,6 +234,7 @@ public class SQLStatementUtils {
    * @param tableName table name
    * @param indexFilter index filter
    * @param hasTotalCount whether to calculate total count in SQL.
+   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return translated SQL where statement
    */
   public static String createFilterSql(String tableName, @Nullable IndexFilter indexFilter, boolean hasTotalCount, boolean nonDollarVirtualColumnsEnabled) {
@@ -257,6 +258,7 @@ public class SQLStatementUtils {
    * @param tableName table name
    * @param indexFilter index filter
    * @param indexGroupByCriterion group by
+   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return translated group by SQL
    */
   public static String createGroupBySql(String tableName, @Nullable IndexFilter indexFilter,
@@ -325,6 +327,7 @@ public class SQLStatementUtils {
   /**
    * Construct where clause SQL from multiple filters. Return null if all filters are empty.
    * @param supportedCondition contains supported conditions such as EQUAL.
+   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @param filters An array of pairs which are filter and table prefix.
    * @return sql that can be appended after where clause.
    */

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -59,6 +59,7 @@ public class EbeanLocalAccessTest {
   private static IEbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
   private static long _now;
   private final boolean _nonDollarVirtualColumnsEnabled;
+  private EBeanDAOConfig config;
   private static final LocalRelationshipFilter EMPTY_FILTER = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray());
 
   @Factory(dataProvider = "inputList")
@@ -86,6 +87,9 @@ public class EbeanLocalAccessTest {
         BurgerUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
     _ebeanLocalAccessFoo.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
     _now = System.currentTimeMillis();
+    config = new EBeanDAOConfig();
+    config.setNonDollarVirtualColumnsEnabled(_nonDollarVirtualColumnsEnabled);
+
   }
 
   @BeforeMethod
@@ -361,7 +365,7 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessBar.add(barUrn3, new AspectFoo().setValue("3"), AspectFoo.class, auditStamp, null);
 
     // Verify local relationships and entity are added.
-    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);
+    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, config);
     List<BelongsTo> relationships = ebeanLocalRelationshipQueryDAO.findRelationships(
         BarSnapshot.class, EMPTY_FILTER, FooSnapshot.class, EMPTY_FILTER, BelongsTo.class, EMPTY_FILTER, 0, 10);
 
@@ -430,7 +434,7 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessBar.add(barUrn3, new AspectFoo().setValue("3"), AspectFoo.class, auditStamp, null);
 
     // Verify that NO local relationships were added
-    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);
+    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, config);
     List<BelongsTo> relationships = ebeanLocalRelationshipQueryDAO.findRelationships(
         BarSnapshot.class, EMPTY_FILTER, FooSnapshot.class, EMPTY_FILTER, BelongsTo.class, EMPTY_FILTER, 0, 10);
     assertEquals(0, relationships.size());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -56,26 +56,34 @@ public class EbeanLocalAccessTest {
   private static IEbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
   private static IEbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
   private static long _now;
+
+  //run these tests with nonDollarVirtualColumnsEnabled = false and true
+  private final boolean _nonDollarVirtualColumnsEnabled = false;
   private static final LocalRelationshipFilter EMPTY_FILTER = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray());
 
   @BeforeClass
   public void init() {
     _server = EmbeddedMariaInstance.getServer(EbeanLocalAccessTest.class.getSimpleName());
     _ebeanLocalAccessFoo = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        FooUrn.class, new FooUrnPathExtractor());
+        FooUrn.class, new FooUrnPathExtractor(), _nonDollarVirtualColumnsEnabled);
     _ebeanLocalAccessBar = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BarUrn.class, new BarUrnPathExtractor());
+        BarUrn.class, new BarUrnPathExtractor(), _nonDollarVirtualColumnsEnabled);
     _ebeanLocalAccessBurger = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BurgerUrn.class, new EmptyPathExtractor<>());
+        BurgerUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
     _ebeanLocalAccessFoo.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
     _now = System.currentTimeMillis();
   }
 
   @BeforeMethod
   public void setupTest() throws IOException {
-    _server.execute(Ebean.createSqlUpdate(
-        Resources.toString(Resources.getResource("ebean-local-access-create-all.sql"), StandardCharsets.UTF_8)));
-
+    if (!_nonDollarVirtualColumnsEnabled) {
+      _server.execute(Ebean.createSqlUpdate(
+          Resources.toString(Resources.getResource("ebean-local-access-create-all.sql"), StandardCharsets.UTF_8)));
+    } else {
+      _server.execute(Ebean.createSqlUpdate(Resources.toString(
+          Resources.getResource("ebean-local-access-create-all-with-non-dollar-virtual-column-names.sql"),
+          StandardCharsets.UTF_8)));
+    }
     // initialize data with metadata_entity_foo table with fooUrns from 0 ~ 99
     int numOfRecords = 100;
     for (int i = 0; i < numOfRecords; i++) {
@@ -144,7 +152,7 @@ public class EbeanLocalAccessTest {
 
     // When: list out results with start = 5 and pageSize = 5
 
-    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 5, 5, false);
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 5, 5);
 
     assertEquals(5, listUrns.getValues().size());
     assertEquals(5, listUrns.getPageSize());
@@ -178,7 +186,7 @@ public class EbeanLocalAccessTest {
     FooUrn lastUrn = new FooUrn(29);
 
     // When: list out results with lastUrn = 'urn:li:foo:29' and pageSize = 5
-    List<FooUrn> result1 = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5, false);
+    List<FooUrn> result1 = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5);
 
     // Expect: 5 rows are returns (30~34) and the first element is 'urn:li:foo:30'
     assertEquals(5, result1.size());
@@ -190,14 +198,14 @@ public class EbeanLocalAccessTest {
     IndexCriterion indexCriterion3 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
     indexCriterionArray = new IndexCriterionArray(Collections.singleton(indexCriterion3));
     IndexFilter filter = new IndexFilter().setCriteria(indexCriterionArray);
-    List<FooUrn> result2 = _ebeanLocalAccessFoo.listUrns(filter, indexSortCriterion, lastUrn, 5, false);
+    List<FooUrn> result2 = _ebeanLocalAccessFoo.listUrns(filter, indexSortCriterion, lastUrn, 5);
 
     // Expect: 5 rows are returns (35~39) and the first element is 'urn:li:foo:35'
     assertEquals(5, result2.size());
     assertEquals("35", result2.get(0).getId());
 
     // When: list urns with no filter, no sorting criterion, no last urn.
-    List<FooUrn> result3 = _ebeanLocalAccessFoo.listUrns(null, null, null, 10, false);
+    List<FooUrn> result3 = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
 
     // 0, 1, 10, 11, 12, 13, 14, 15, 16, 17
     assertEquals(result3.size(), 10);
@@ -205,7 +213,7 @@ public class EbeanLocalAccessTest {
     assertEquals(result3.get(9).getId(), "17");
 
     // When: list urns with no filter, no sorting criterion
-    List<FooUrn> result4 = _ebeanLocalAccessFoo.listUrns(null, null, new FooUrn(17), 10, false);
+    List<FooUrn> result4 = _ebeanLocalAccessFoo.listUrns(null, null, new FooUrn(17), 10);
 
     // 18, 19, 2, 20, 21, 22, 23, 24, 25, 26
     assertEquals(result4.size(), 10);
@@ -273,7 +281,7 @@ public class EbeanLocalAccessTest {
     IndexGroupByCriterion indexGroupByCriterion = new IndexGroupByCriterion();
     indexGroupByCriterion.setPath("/value");
     indexGroupByCriterion.setAspect(AspectFoo.class.getCanonicalName());
-    Map<String, Long> countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion, false);
+    Map<String, Long> countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion);
 
     // Expect: there is 1 count for value 25
     assertEquals(countMap.get("25"), Long.valueOf(1));
@@ -285,7 +293,7 @@ public class EbeanLocalAccessTest {
     aspectFoo.setValue(String.valueOf(25));
     AuditStamp auditStamp = makeAuditStamp("foo", System.currentTimeMillis());
     _ebeanLocalAccessFoo.add(fooUrn, aspectFoo, AspectFoo.class, auditStamp, null);
-    countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion, false);
+    countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion);
 
     // Expect: there are 2 counts for value 25
     assertEquals(countMap.get("25"), Long.valueOf(2));
@@ -377,8 +385,13 @@ public class EbeanLocalAccessTest {
     AspectFoo foo1 = new AspectFoo().setValue("foo");
     _ebeanLocalAccessFoo.add(urn1, foo1, AspectFoo.class, makeAuditStamp("actor", _now), null);
 
+    List<SqlRow> results;
     // get content of virtual column
-    List<SqlRow> results = _server.createSqlQuery("SELECT i_urn$fooId as id FROM metadata_entity_foo").findList();
+    if (_nonDollarVirtualColumnsEnabled) {
+      results = _server.createSqlQuery("SELECT i_urn0fooId as id FROM metadata_entity_foo").findList();
+    } else {
+      results = _server.createSqlQuery("SELECT i_urn$fooId as id FROM metadata_entity_foo").findList();
+    }
     assertEquals(100, results.size());
 
     // ensure content is as expected
@@ -473,8 +486,12 @@ public class EbeanLocalAccessTest {
   @Test
   public void testCheckColumnExists() {
     assertTrue(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "a_aspectfoo"));
-    assertTrue(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "i_aspectfoo$value"));
     assertFalse(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "a_aspect_not_exist"));
     assertFalse(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_notexist", "a_aspectfoo"));
+    if (!_nonDollarVirtualColumnsEnabled) {
+      assertTrue(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "i_aspectfoo$value"));
+    } else {
+      assertTrue(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "i_aspectfoo0value"));
+    }
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import static com.linkedin.common.AuditStamps.*;
@@ -56,10 +58,22 @@ public class EbeanLocalAccessTest {
   private static IEbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
   private static IEbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
   private static long _now;
-
-  //run these tests with nonDollarVirtualColumnsEnabled = false and true
-  private final boolean _nonDollarVirtualColumnsEnabled = false;
+  private final boolean _nonDollarVirtualColumnsEnabled;
   private static final LocalRelationshipFilter EMPTY_FILTER = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray());
+
+  @Factory(dataProvider = "inputList")
+  public EbeanLocalAccessTest(boolean nonDollarVirtualColumnsEnabled) {
+    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
+  }
+
+  @DataProvider(name = "inputList")
+  public static Object[][] inputList() {
+    return new Object[][] {
+        { true },
+        { false }
+    };
+  }
+
 
   @BeforeClass
   public void init() {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -144,7 +144,7 @@ public class EbeanLocalAccessTest {
 
     // When: list out results with start = 5 and pageSize = 5
 
-    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 5, 5);
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 5, 5, false);
 
     assertEquals(5, listUrns.getValues().size());
     assertEquals(5, listUrns.getPageSize());
@@ -178,7 +178,7 @@ public class EbeanLocalAccessTest {
     FooUrn lastUrn = new FooUrn(29);
 
     // When: list out results with lastUrn = 'urn:li:foo:29' and pageSize = 5
-    List<FooUrn> result1 = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5);
+    List<FooUrn> result1 = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5, false);
 
     // Expect: 5 rows are returns (30~34) and the first element is 'urn:li:foo:30'
     assertEquals(5, result1.size());
@@ -190,14 +190,14 @@ public class EbeanLocalAccessTest {
     IndexCriterion indexCriterion3 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
     indexCriterionArray = new IndexCriterionArray(Collections.singleton(indexCriterion3));
     IndexFilter filter = new IndexFilter().setCriteria(indexCriterionArray);
-    List<FooUrn> result2 = _ebeanLocalAccessFoo.listUrns(filter, indexSortCriterion, lastUrn, 5);
+    List<FooUrn> result2 = _ebeanLocalAccessFoo.listUrns(filter, indexSortCriterion, lastUrn, 5, false);
 
     // Expect: 5 rows are returns (35~39) and the first element is 'urn:li:foo:35'
     assertEquals(5, result2.size());
     assertEquals("35", result2.get(0).getId());
 
     // When: list urns with no filter, no sorting criterion, no last urn.
-    List<FooUrn> result3 = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
+    List<FooUrn> result3 = _ebeanLocalAccessFoo.listUrns(null, null, null, 10, false);
 
     // 0, 1, 10, 11, 12, 13, 14, 15, 16, 17
     assertEquals(result3.size(), 10);
@@ -205,7 +205,7 @@ public class EbeanLocalAccessTest {
     assertEquals(result3.get(9).getId(), "17");
 
     // When: list urns with no filter, no sorting criterion
-    List<FooUrn> result4 = _ebeanLocalAccessFoo.listUrns(null, null, new FooUrn(17), 10);
+    List<FooUrn> result4 = _ebeanLocalAccessFoo.listUrns(null, null, new FooUrn(17), 10, false);
 
     // 18, 19, 2, 20, 21, 22, 23, 24, 25, 26
     assertEquals(result4.size(), 10);
@@ -273,7 +273,7 @@ public class EbeanLocalAccessTest {
     IndexGroupByCriterion indexGroupByCriterion = new IndexGroupByCriterion();
     indexGroupByCriterion.setPath("/value");
     indexGroupByCriterion.setAspect(AspectFoo.class.getCanonicalName());
-    Map<String, Long> countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion);
+    Map<String, Long> countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion, false);
 
     // Expect: there is 1 count for value 25
     assertEquals(countMap.get("25"), Long.valueOf(1));
@@ -285,7 +285,7 @@ public class EbeanLocalAccessTest {
     aspectFoo.setValue(String.valueOf(25));
     AuditStamp auditStamp = makeAuditStamp("foo", System.currentTimeMillis());
     _ebeanLocalAccessFoo.add(fooUrn, aspectFoo, AspectFoo.class, auditStamp, null);
-    countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion);
+    countMap = _ebeanLocalAccessFoo.countAggregate(indexFilter, indexGroupByCriterion, false);
 
     // Expect: there are 2 counts for value 25
     assertEquals(countMap.get("25"), Long.valueOf(2));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -58,12 +58,12 @@ public class EbeanLocalAccessTest {
   private static IEbeanLocalAccess<BarUrn> _ebeanLocalAccessBar;
   private static IEbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
   private static long _now;
-  private final EBeanDAOConfig config = new EBeanDAOConfig();
+  private final EBeanDAOConfig _ebeanConfig = new EBeanDAOConfig();
   private static final LocalRelationshipFilter EMPTY_FILTER = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray());
 
   @Factory(dataProvider = "inputList")
   public EbeanLocalAccessTest(boolean nonDollarVirtualColumnsEnabled) {
-    config.setNonDollarVirtualColumnsEnabled(nonDollarVirtualColumnsEnabled);
+    _ebeanConfig.setNonDollarVirtualColumnsEnabled(nonDollarVirtualColumnsEnabled);
   }
 
   @DataProvider(name = "inputList")
@@ -79,18 +79,18 @@ public class EbeanLocalAccessTest {
   public void init() {
     _server = EmbeddedMariaInstance.getServer(EbeanLocalAccessTest.class.getSimpleName());
     _ebeanLocalAccessFoo = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        FooUrn.class, new FooUrnPathExtractor(), config.isNonDollarVirtualColumnsEnabled());
+        FooUrn.class, new FooUrnPathExtractor(), _ebeanConfig.isNonDollarVirtualColumnsEnabled());
     _ebeanLocalAccessBar = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BarUrn.class, new BarUrnPathExtractor(), config.isNonDollarVirtualColumnsEnabled());
+        BarUrn.class, new BarUrnPathExtractor(), _ebeanConfig.isNonDollarVirtualColumnsEnabled());
     _ebeanLocalAccessBurger = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BurgerUrn.class, new EmptyPathExtractor<>(), config.isNonDollarVirtualColumnsEnabled());
+        BurgerUrn.class, new EmptyPathExtractor<>(), _ebeanConfig.isNonDollarVirtualColumnsEnabled());
     _ebeanLocalAccessFoo.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
     _now = System.currentTimeMillis();
   }
 
   @BeforeMethod
   public void setupTest() throws IOException {
-    if (!config.isNonDollarVirtualColumnsEnabled()) {
+    if (!_ebeanConfig.isNonDollarVirtualColumnsEnabled()) {
       _server.execute(Ebean.createSqlUpdate(
           Resources.toString(Resources.getResource("ebean-local-access-create-all.sql"), StandardCharsets.UTF_8)));
     } else {
@@ -361,7 +361,7 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessBar.add(barUrn3, new AspectFoo().setValue("3"), AspectFoo.class, auditStamp, null);
 
     // Verify local relationships and entity are added.
-    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, config);
+    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _ebeanConfig);
     List<BelongsTo> relationships = ebeanLocalRelationshipQueryDAO.findRelationships(
         BarSnapshot.class, EMPTY_FILTER, FooSnapshot.class, EMPTY_FILTER, BelongsTo.class, EMPTY_FILTER, 0, 10);
 
@@ -401,7 +401,7 @@ public class EbeanLocalAccessTest {
 
     List<SqlRow> results;
     // get content of virtual column
-    if (config.isNonDollarVirtualColumnsEnabled()) {
+    if (_ebeanConfig.isNonDollarVirtualColumnsEnabled()) {
       results = _server.createSqlQuery("SELECT i_urn0fooId as id FROM metadata_entity_foo").findList();
     } else {
       results = _server.createSqlQuery("SELECT i_urn$fooId as id FROM metadata_entity_foo").findList();
@@ -430,7 +430,7 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessBar.add(barUrn3, new AspectFoo().setValue("3"), AspectFoo.class, auditStamp, null);
 
     // Verify that NO local relationships were added
-    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, config);
+    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _ebeanConfig);
     List<BelongsTo> relationships = ebeanLocalRelationshipQueryDAO.findRelationships(
         BarSnapshot.class, EMPTY_FILTER, FooSnapshot.class, EMPTY_FILTER, BelongsTo.class, EMPTY_FILTER, 0, 10);
     assertEquals(0, relationships.size());
@@ -502,7 +502,7 @@ public class EbeanLocalAccessTest {
     assertTrue(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "a_aspectfoo"));
     assertFalse(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "a_aspect_not_exist"));
     assertFalse(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_notexist", "a_aspectfoo"));
-    if (!config.isNonDollarVirtualColumnsEnabled()) {
+    if (!_ebeanConfig.isNonDollarVirtualColumnsEnabled()) {
       assertTrue(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "i_aspectfoo$value"));
     } else {
       assertTrue(_ebeanLocalAccessFoo.checkColumnExists("metadata_entity_foo", "i_aspectfoo0value"));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -221,7 +221,6 @@ public class EbeanLocalDAOTest {
     }
     dao.setEmitAuditEvent(true);
     dao.setChangeLogEnabled(_enableChangeLog);
-    dao.setNonDollarVirtualColumnsEnabled(_nonDollarVirtualColumnEnabled);
     return dao;
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -180,7 +180,6 @@ public class EbeanLocalDAOTest {
 
   @BeforeMethod
   public void setupTest() {
-    System.out.println("setupTest Invoked");
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       _server.execute(Ebean.createSqlUpdate(readSQLfromFile(GMA_DROP_ALL_SQL)));
       _server.execute(Ebean.createSqlUpdate(readSQLfromFile(GMA_CREATE_ALL_SQL)));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -129,16 +129,19 @@ public class EbeanLocalDAOTest {
   private final FindMethodology _findMethodology;
 
   private final boolean _enableChangeLog;
+  private final boolean _nonDollarVirtualColumnEnabled;
 
   private static final String NEW_SCHEMA_CREATE_ALL_SQL = "ebean-local-dao-create-all.sql";
   private static final String GMA_CREATE_ALL_SQL = "gma-create-all.sql";
   private static final String GMA_DROP_ALL_SQL = "gma-drop-all.sql";
 
   @Factory(dataProvider = "inputList")
-  public EbeanLocalDAOTest(SchemaConfig schemaConfig, FindMethodology findMethodology, boolean enableChangeLog) {
+  public EbeanLocalDAOTest(SchemaConfig schemaConfig, FindMethodology findMethodology, boolean enableChangeLog,
+      boolean nonDollarVirtualColumnEnabled) {
     _schemaConfig = schemaConfig;
     _findMethodology = findMethodology;
     _enableChangeLog = enableChangeLog;
+    _nonDollarVirtualColumnEnabled = nonDollarVirtualColumnEnabled;
   }
 
   @Nonnull
@@ -155,20 +158,21 @@ public class EbeanLocalDAOTest {
     return new Object[][]{
 
         // tests with change history enabled (legacy mode)
-        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, true},
-        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, true},
-        {SchemaConfig.DUAL_SCHEMA, FindMethodology.UNIQUE_ID, true},
-        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, true},
-        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, true},
-        {SchemaConfig.DUAL_SCHEMA, FindMethodology.DIRECT_SQL, true},
+        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, true, true},
+        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, true, true},
+        {SchemaConfig.DUAL_SCHEMA, FindMethodology.UNIQUE_ID, true, true},
+        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, true, false},
+        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, true, false},
+        {SchemaConfig.DUAL_SCHEMA, FindMethodology.DIRECT_SQL, true, false},
 
         // tests with change history disabled (cold-archive mode)
-        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, false},
-        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, false},
-        {SchemaConfig.DUAL_SCHEMA, FindMethodology.UNIQUE_ID, false},
-        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, false},
-        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, false},
-        {SchemaConfig.DUAL_SCHEMA, FindMethodology.DIRECT_SQL, false},
+        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, false, true},
+        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.UNIQUE_ID, false, true},
+        {SchemaConfig.DUAL_SCHEMA, FindMethodology.UNIQUE_ID, false, true},
+        {SchemaConfig.OLD_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, false, false},
+        {SchemaConfig.NEW_SCHEMA_ONLY, FindMethodology.DIRECT_SQL, false, false},
+        {SchemaConfig.DUAL_SCHEMA, FindMethodology.DIRECT_SQL, false, false},
+
     };
   }
 
@@ -2997,7 +3001,7 @@ public class EbeanLocalDAOTest {
     */
 
     String aspectColumnName = isUrn(aspectName) ? null : SQLSchemaUtils.getAspectColumnName(aspectName); // e.g. a_aspectfoo;
-    String fullIndexColumnName = SQLSchemaUtils.getGeneratedColumnName(aspectName, pathName); // e.g. i_aspectfoo$path1$value1
+    String fullIndexColumnName = SQLSchemaUtils.getGeneratedColumnName(aspectName, pathName, false); // e.g. i_aspectfoo$path1$value1
 
     String checkColumnExistance = String.format("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '%s' AND"
         + " TABLE_NAME = '%s' AND COLUMN_NAME = '%s'", _server.getName(), getTableName(urn), fullIndexColumnName);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -210,7 +210,7 @@ public class EbeanLocalDAOTest {
   private <URN extends Urn> EbeanLocalDAO<EntityAspectUnion, URN> createDao(@Nonnull EbeanServer server,
       @Nonnull Class<URN> urnClass) {
     EbeanLocalDAO<EntityAspectUnion, URN> dao = new EbeanLocalDAO<>(EntityAspectUnion.class, _mockProducer, server,
-        EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()), urnClass, _schemaConfig, _findMethodology);
+        EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()), urnClass, _schemaConfig, _findMethodology, _nonDollarVirtualColumnEnabled);
     // Since we added a_urn columns to both metadata_entity_foo and metadata_entity_bar tables in the SQL initialization scripts,
     // it is required that we set non-default UrnPathExtractors for the corresponding DAOs when initialized.
     if (urnClass == FooUrn.class) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -60,6 +60,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
   private EbeanLocalRelationshipQueryDAO _localRelationshipQueryDAO;
   private IEbeanLocalAccess<FooUrn> _fooUrnEBeanLocalAccess;
   private IEbeanLocalAccess<BarUrn> _barUrnEBeanLocalAccess;
+  // run the tests 1 time for each of nonDollarVirtualColumnsEnabled values (2 total, true and false)
+  private boolean _nonDollarVirtualColumnsEnabled = true;
 
   @BeforeClass
   public void init() {
@@ -70,12 +72,18 @@ public class EbeanLocalRelationshipQueryDAOTest {
         FooUrn.class, new EmptyPathExtractor<>());
     _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
         BarUrn.class, new EmptyPathExtractor<>());
+    _localRelationshipQueryDAO.setNonDollarVirtualColumnsEnabled(_nonDollarVirtualColumnsEnabled);
   }
 
   @BeforeMethod
   public void recreateTables() throws IOException {
-    _server.execute(Ebean.createSqlUpdate(
-        Resources.toString(Resources.getResource("ebean-local-relationship-dao-create-all.sql"), StandardCharsets.UTF_8)));
+    if (!_localRelationshipQueryDAO.isNonDollarVirtualColumnsEnabled()) {
+      _server.execute(Ebean.createSqlUpdate(
+          Resources.toString(Resources.getResource("ebean-local-relationship-dao-create-all.sql"), StandardCharsets.UTF_8)));
+    } else {
+      _server.execute(Ebean.createSqlUpdate(
+          Resources.toString(Resources.getResource("ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql"), StandardCharsets.UTF_8)));
+    }
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -63,12 +63,11 @@ public class EbeanLocalRelationshipQueryDAOTest {
   private EbeanLocalRelationshipQueryDAO _localRelationshipQueryDAO;
   private IEbeanLocalAccess<FooUrn> _fooUrnEBeanLocalAccess;
   private IEbeanLocalAccess<BarUrn> _barUrnEBeanLocalAccess;
-  private EBeanDAOConfig _eBeanDAOConfig;
-  private final boolean _nonDollarVirtualColumnsEnabled;
+  private final EBeanDAOConfig _eBeanDAOConfig = new EBeanDAOConfig();
 
   @Factory(dataProvider = "inputList")
   public EbeanLocalRelationshipQueryDAOTest(boolean nonDollarVirtualColumnsEnabled) {
-    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
+    _eBeanDAOConfig.setNonDollarVirtualColumnsEnabled(nonDollarVirtualColumnsEnabled);
   }
 
   @DataProvider(name = "inputList")
@@ -81,20 +80,18 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
   @BeforeClass
   public void init() {
-    _eBeanDAOConfig = new EBeanDAOConfig();
-    _eBeanDAOConfig.setNonDollarVirtualColumnsEnabled(_nonDollarVirtualColumnsEnabled);
     _server = EmbeddedMariaInstance.getServer(EbeanLocalRelationshipQueryDAOTest.class.getSimpleName());
     _localRelationshipWriterDAO = new EbeanLocalRelationshipWriterDAO(_server);
     _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
     _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        FooUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
+        FooUrn.class, new EmptyPathExtractor<>(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BarUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
+        BarUrn.class, new EmptyPathExtractor<>(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
   }
 
   @BeforeMethod
   public void recreateTables() throws IOException {
-    if (!_nonDollarVirtualColumnsEnabled) {
+    if (!_eBeanDAOConfig.isNonDollarVirtualColumnsEnabled()) {
       _server.execute(Ebean.createSqlUpdate(
           Resources.toString(Resources.getResource("ebean-local-relationship-dao-create-all.sql"), StandardCharsets.UTF_8)));
     } else {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -5,6 +5,7 @@ import com.google.common.io.Resources;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.dao.EBeanDAOConfig;
 import com.linkedin.metadata.dao.EbeanLocalAccess;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipWriterDAO;
@@ -62,6 +63,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
   private EbeanLocalRelationshipQueryDAO _localRelationshipQueryDAO;
   private IEbeanLocalAccess<FooUrn> _fooUrnEBeanLocalAccess;
   private IEbeanLocalAccess<BarUrn> _barUrnEBeanLocalAccess;
+  private EBeanDAOConfig _eBeanDAOConfig;
   private final boolean _nonDollarVirtualColumnsEnabled;
 
   @Factory(dataProvider = "inputList")
@@ -79,19 +81,20 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
   @BeforeClass
   public void init() {
+    _eBeanDAOConfig = new EBeanDAOConfig();
+    _eBeanDAOConfig.setNonDollarVirtualColumnsEnabled(_nonDollarVirtualColumnsEnabled);
     _server = EmbeddedMariaInstance.getServer(EbeanLocalRelationshipQueryDAOTest.class.getSimpleName());
     _localRelationshipWriterDAO = new EbeanLocalRelationshipWriterDAO(_server);
-    _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);
+    _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
     _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
         FooUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
     _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
         BarUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
-    _localRelationshipQueryDAO.setNonDollarVirtualColumnsEnabled(_nonDollarVirtualColumnsEnabled);
   }
 
   @BeforeMethod
   public void recreateTables() throws IOException {
-    if (!_localRelationshipQueryDAO.isNonDollarVirtualColumnsEnabled()) {
+    if (!_nonDollarVirtualColumnsEnabled) {
       _server.execute(Ebean.createSqlUpdate(
           Resources.toString(Resources.getResource("ebean-local-relationship-dao-create-all.sql"), StandardCharsets.UTF_8)));
     } else {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -48,6 +48,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import static com.linkedin.testing.TestUtils.*;
@@ -60,8 +62,20 @@ public class EbeanLocalRelationshipQueryDAOTest {
   private EbeanLocalRelationshipQueryDAO _localRelationshipQueryDAO;
   private IEbeanLocalAccess<FooUrn> _fooUrnEBeanLocalAccess;
   private IEbeanLocalAccess<BarUrn> _barUrnEBeanLocalAccess;
-  // run the tests 1 time for each of nonDollarVirtualColumnsEnabled values (2 total, true and false)
-  private boolean _nonDollarVirtualColumnsEnabled = false;
+  private final boolean _nonDollarVirtualColumnsEnabled;
+
+  @Factory(dataProvider = "inputList")
+  public EbeanLocalRelationshipQueryDAOTest(boolean nonDollarVirtualColumnsEnabled) {
+    _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
+  }
+
+  @DataProvider(name = "inputList")
+  public static Object[][] inputList() {
+    return new Object[][] {
+        { true },
+        { false }
+    };
+  }
 
   @BeforeClass
   public void init() {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -61,7 +61,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
   private IEbeanLocalAccess<FooUrn> _fooUrnEBeanLocalAccess;
   private IEbeanLocalAccess<BarUrn> _barUrnEBeanLocalAccess;
   // run the tests 1 time for each of nonDollarVirtualColumnsEnabled values (2 total, true and false)
-  private boolean _nonDollarVirtualColumnsEnabled = true;
+  private boolean _nonDollarVirtualColumnsEnabled = false;
 
   @BeforeClass
   public void init() {
@@ -69,9 +69,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipWriterDAO = new EbeanLocalRelationshipWriterDAO(_server);
     _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);
     _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        FooUrn.class, new EmptyPathExtractor<>());
+        FooUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
     _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BarUrn.class, new EmptyPathExtractor<>());
+        BarUrn.class, new EmptyPathExtractor<>(), _nonDollarVirtualColumnsEnabled);
     _localRelationshipQueryDAO.setNonDollarVirtualColumnsEnabled(_nonDollarVirtualColumnsEnabled);
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
@@ -22,12 +22,18 @@ public class SQLIndexFilterUtilsTest {
     assertEquals(indexSortCriterion.getOrder(), SortOrder.ASCENDING);
     assertEquals(indexSortCriterion.getAspect(), AspectFoo.class.getCanonicalName());
 
-    String sql = SQLIndexFilterUtils.parseSortCriteria(indexSortCriterion);
-    assertEquals(sql, "ORDER BY i_aspectfoo$id ASC");
+    String sql1 = SQLIndexFilterUtils.parseSortCriteria(indexSortCriterion, false);
+    assertEquals(sql1, "ORDER BY i_aspectfoo$id ASC");
+
+    String sql2 = SQLIndexFilterUtils.parseSortCriteria(indexSortCriterion, true);
+    assertEquals(sql2, "ORDER BY i_aspectfoo0id ASC");
 
     indexSortCriterion.setOrder(SortOrder.DESCENDING);
-    sql = SQLIndexFilterUtils.parseSortCriteria(indexSortCriterion);
-    assertEquals(sql, "ORDER BY i_aspectfoo$id DESC");
+    sql1 = SQLIndexFilterUtils.parseSortCriteria(indexSortCriterion, false);
+    assertEquals(sql1, "ORDER BY i_aspectfoo$id DESC");
+
+    sql2 = SQLIndexFilterUtils.parseSortCriteria(indexSortCriterion, true);
+    assertEquals(sql2, "ORDER BY i_aspectfoo0id DESC");
   }
 
   @Test
@@ -39,7 +45,10 @@ public class SQLIndexFilterUtilsTest {
     indexCriterionArray.add(indexCriterion);
     indexFilter.setCriteria(indexCriterionArray);
 
-    String sql = SQLIndexFilterUtils.parseIndexFilter(indexFilter);
+    String sql = SQLIndexFilterUtils.parseIndexFilter(indexFilter, false);
     assertEquals(sql, "WHERE a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo$id < 12");
+
+    sql = SQLIndexFilterUtils.parseIndexFilter(indexFilter, true);
+    assertEquals(sql, "WHERE a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo0id < 12");
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLSchemaUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLSchemaUtilsTest.java
@@ -11,8 +11,11 @@ public class SQLSchemaUtilsTest {
 
   @Test
   public void testGetGeneratedColumnName() {
-    String generatedColumnName = getGeneratedColumnName(AspectFoo.class.getCanonicalName(), "/value");
+    String generatedColumnName = getGeneratedColumnName(AspectFoo.class.getCanonicalName(), "/value", false);
     assertEquals(generatedColumnName, "i_aspectfoo$value");
+
+    generatedColumnName = getGeneratedColumnName(AspectFoo.class.getCanonicalName(), "/value", true);
+    assertEquals(generatedColumnName, "i_aspectfoo0value");
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all-with-non-dollar-virtual-column-names.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS metadata_entity_burger;
 DROP TABLE IF EXISTS metadata_aspect;
 DROP TABLE IF EXISTS metadata_id;
 DROP TABLE IF EXISTS metadata_index;
+DROP TABLE IF EXISTS metadata_relationship_belongsto;
 
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (
@@ -23,26 +24,13 @@ CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
     );
 
--- initialize bar entity table
+-- initialize burger entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     urn VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
     CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
-    );
-
-CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata LONGTEXT NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
-    source_type VARCHAR(100) NOT NULL,
-    destination VARCHAR(1000) NOT NULL,
-    destination_type VARCHAR(100) NOT NULL,
-    lastmodifiedon TIMESTAMP NOT NULL,
-    lastmodifiedby VARCHAR(255) NOT NULL,
-    deleted_ts DATETIME(6) DEFAULT NULL,
-    PRIMARY KEY (id)
     );
 
 CREATE TABLE metadata_id (
@@ -52,7 +40,7 @@ CREATE TABLE metadata_id (
 );
 
 CREATE TABLE metadata_aspect (
-                                 urn VARCHAR(500) NOT NULL,
+                                 urn VARCHAR(100) NOT NULL,
                                  aspect VARCHAR(200) NOT NULL,
                                  version BIGINT NOT NULL,
                                  metadata VARCHAR(500) NOT NULL,
@@ -62,11 +50,30 @@ CREATE TABLE metadata_aspect (
                                  CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn,aspect,version)
 );
 
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata JSON NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
 ALTER TABLE metadata_entity_foo ADD a_urn JSON;
 ALTER TABLE metadata_entity_bar ADD a_urn JSON;
 
+ALTER TABLE metadata_entity_foo ADD COLUMN i_urn0fooId VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_urn, '$."\\\/fooId"')));
+
 -- add foo aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectfoo JSON;
+
+-- add foo aspect to bar entity
+ALTER TABLE metadata_entity_bar ADD a_aspectfoo JSON;
 
 -- add bar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
@@ -74,15 +81,25 @@ ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
 -- add foobar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
 
--- add array aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectattributes JSON;
-
--- add new index virtual column 'attributes'
-ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectattributes0attributes VARCHAR(255)
-    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_aspectattributes, '$.aspect.attributes')));
-
--- add baz aspect to foo entity
-ALTER TABLE metadata_entity_foo ADD a_aspectbaz JSON;
-
 -- add foo aspect to burger entity
 ALTER TABLE metadata_entity_burger ADD a_aspectfoo JSON;
+
+-- add new index virtual column 'value'
+ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectbar0value VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_aspectbar, '$.aspect.value')));
+
+-- add new index virtual column 'value'
+ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectfoo0value VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_aspectfoo, '$.aspect.value')));
+
+-- create index for index column
+CREATE INDEX i_aspectfoo0value ON metadata_entity_foo (urn(50), i_aspectfoo0value);
+
+-- create index for index column
+CREATE INDEX i_aspectbar0value ON metadata_entity_foo (urn(50), i_aspectbar0value);
+
+
+-- create index idx_long_val on metadata_index (aspect,path(50),longval,urn(50));
+-- create index idx_string_val on metadata_index (aspect,path(50),stringval,urn(50));
+-- create index idx_double_val on metadata_index (aspect,path(50),doubleval,urn(50));
+-- create index idx_urn on metadata_index (urn(50));

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
@@ -1,0 +1,88 @@
+DROP TABLE IF EXISTS metadata_entity_foo;
+DROP TABLE IF EXISTS metadata_entity_bar;
+DROP TABLE IF EXISTS metadata_entity_burger;
+DROP TABLE IF EXISTS metadata_aspect;
+DROP TABLE IF EXISTS metadata_id;
+DROP TABLE IF EXISTS metadata_index;
+
+-- initialize foo entity table
+CREATE TABLE IF NOT EXISTS metadata_entity_foo (
+    urn VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    createdfor VARCHAR(255),
+    CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
+    );
+
+-- initialize bar entity table
+CREATE TABLE IF NOT EXISTS metadata_entity_bar (
+    urn VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    createdfor VARCHAR(255),
+    CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
+    );
+
+-- initialize bar entity table
+CREATE TABLE IF NOT EXISTS metadata_entity_burger (
+    urn VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    createdfor VARCHAR(255),
+    CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
+    );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata LONGTEXT NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE metadata_id (
+                             namespace VARCHAR(255) NOT NULL,
+                             id BIGINT NOT NULL,
+                             CONSTRAINT uq_metadata_id_namespace_id UNIQUE (namespace,id)
+);
+
+CREATE TABLE metadata_aspect (
+                                 urn VARCHAR(500) NOT NULL,
+                                 aspect VARCHAR(200) NOT NULL,
+                                 version BIGINT NOT NULL,
+                                 metadata VARCHAR(500) NOT NULL,
+                                 createdon DATETIME(6) NOT NULL,
+                                 createdby VARCHAR(255) NOT NULL,
+                                 createdfor VARCHAR(255),
+                                 CONSTRAINT pk_metadata_aspect PRIMARY KEY (urn,aspect,version)
+);
+
+ALTER TABLE metadata_entity_foo ADD a_urn JSON;
+ALTER TABLE metadata_entity_bar ADD a_urn JSON;
+
+-- add foo aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectfoo JSON;
+
+-- add bar aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
+
+-- add foobar aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
+
+-- add array aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectattributes JSON;
+
+-- add new index virtual column 'attributes'
+ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectattributes0attributes VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_aspectattributes, '$.aspect.attributes')));
+
+-- add baz aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectbaz JSON;
+
+-- add baz aspect to burger entity
+ALTER TABLE metadata_entity_burger ADD a_aspectfoo JSON;

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
@@ -1,0 +1,115 @@
+DROP TABLE IF EXISTS metadata_relationship_belongsto;
+DROP TABLE IF EXISTS metadata_relationship_reportsto;
+DROP TABLE IF EXISTS metadata_relationship_pairswith;
+DROP TABLE IF EXISTS metadata_relationship_versionof;
+DROP TABLE IF EXISTS metadata_relationship_consumefrom;
+DROP TABLE IF EXISTS metadata_entity_foo;
+DROP TABLE IF EXISTS metadata_entity_bar;
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata LONGTEXT NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata JSON NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_pairswith (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata JSON NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_versionof (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata JSON NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_consumefrom (
+                                                                 id BIGINT NOT NULL AUTO_INCREMENT,
+                                                                 metadata JSON NOT NULL,
+                                                                 source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+-- initialize foo entity table
+CREATE TABLE IF NOT EXISTS metadata_entity_foo (
+    urn VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    createdfor VARCHAR(255),
+    CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
+    );
+
+-- initialize foo entity table
+CREATE TABLE IF NOT EXISTS metadata_entity_bar (
+    urn VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    createdfor VARCHAR(255),
+    CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
+    );
+
+-- add foo aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectfoo JSON;
+
+-- add foo aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
+
+-- add new index virtual column 'value'
+ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectfoo0value VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_aspectfoo, '$.aspect.value')));
+
+-- add new index virtual column 'value'
+ALTER TABLE metadata_entity_foo ADD COLUMN i_aspectbar0value VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_aspectbar, '$.aspect.value')));
+
+-- add foo aspect to bar entity
+ALTER TABLE metadata_entity_bar ADD a_aspectfoo JSON;
+
+-- add new index virtual column 'value'
+ALTER TABLE metadata_entity_bar ADD COLUMN i_aspectfoo0value VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(a_aspectfoo, '$.aspect.value')));
+
+-- add new virtual column 'value' to relationship table
+ALTER TABLE metadata_relationship_consumefrom ADD COLUMN metadata0environment VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.environment')));


### PR DESCRIPTION
## Summary
Adding support for having non-dollar('$') character in the MySQL virtual(generated) columns. Currently, the virtual columns are named as 'i_urn$platform' now we can also use '0' as the delimiter i.e the virtual column could be named 'i_urn0platform'. 

## Testing Done
./gradlew build
Added unit tests for all the changes.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
