### PR TITLE
fix: toLowerCase when checking column existance

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -547,12 +547,12 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
       final List<SqlRow> rows = _server.createSqlQuery(SQLStatementUtils.getAllColumnForTable(tableName)).findList();
       Set<String> columns = new HashSet<>();
       for (SqlRow row : rows) {
-        columns.add(row.getString("COLUMN_NAME"));
+        columns.add(row.getString("COLUMN_NAME").toLowerCase());
       }
       tableColumns.put(tableName, columns);
     }
 
-    return tableColumns.get(tableName).contains(columnName);
+    return tableColumns.get(tableName).contains(columnName.toLowerCase());
   }
 
   /**


### PR DESCRIPTION
MySQL columns are case insensitive. So `abc` and `aBC` are essentially same columns.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
