### PR TITLE
Added default constructor for EbeanLocalRelationshipQueryDAO for backward compatibility

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -42,6 +42,12 @@ public class EbeanLocalRelationshipQueryDAO {
     _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS);
   }
 
+  public EbeanLocalRelationshipQueryDAO(EbeanServer server) {
+    _server = server;
+    _eBeanDAOConfig = new EBeanDAOConfig();
+    _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS);
+  }
+
   static final Map<Condition, String> SUPPORTED_CONDITIONS =
       Collections.unmodifiableMap(new HashMap<Condition, String>() {
         {


### PR DESCRIPTION
Added a default constructor to `EbeanLocalRelationshipQueryDAO` to keep it backward compatible for other GMSes.

## Testing
./gradlew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
