### PR TITLE
Made nonDollarVirtualColumnsEnabled member of SQLSchemaUtils

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -34,17 +34,14 @@ public class EbeanLocalRelationshipQueryDAO {
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
-  private final EBeanDAOConfig _eBeanDAOConfig;
-
   public EbeanLocalRelationshipQueryDAO(EbeanServer server, EBeanDAOConfig eBeanDAOConfig) {
     _server = server;
-    _eBeanDAOConfig = eBeanDAOConfig;
+    SQLSchemaUtils.setNonDollarVirtualColumnsEnabled(eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS);
   }
 
   public EbeanLocalRelationshipQueryDAO(EbeanServer server) {
     _server = server;
-    _eBeanDAOConfig = new EBeanDAOConfig();
     _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS);
   }
 
@@ -79,8 +76,7 @@ public class EbeanLocalRelationshipQueryDAO {
     final StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("SELECT * FROM ").append(tableName);
     if (filter.hasCriteria() && filter.getCriteria().size() > 0) {
-      sqlBuilder.append(" WHERE ").append(SQLStatementUtils.whereClause(filter, SUPPORTED_CONDITIONS, null,
-          _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled()));
+      sqlBuilder.append(" WHERE ").append(SQLStatementUtils.whereClause(filter, SUPPORTED_CONDITIONS, null));
     }
     sqlBuilder.append(" ORDER BY urn LIMIT ").append(Math.max(1, count)).append(" OFFSET ").append(Math.max(0, offset));
 
@@ -105,8 +101,7 @@ public class EbeanLocalRelationshipQueryDAO {
     final String srcEntityTable = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(sourceEntityClass));
     final String destEntityTable = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(destinationEntityClass));
     final String sql = _sqlGenerator.multiHopTraversalSql(minHops, maxHops, Math.max(1, count), Math.max(0, offset), relationshipTable,
-        srcEntityTable, destEntityTable, relationshipFilter, sourceEntityFilter, destinationEntityFilter,
-        _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
+        srcEntityTable, destEntityTable, relationshipFilter, sourceEntityFilter, destinationEntityFilter);
 
     final Class snapshotClass = relationshipFilter.getDirection() == RelationshipDirection.INCOMING ? sourceEntityClass : destinationEntityClass;
 
@@ -258,7 +253,6 @@ public class EbeanLocalRelationshipQueryDAO {
 
     sqlBuilder.append("WHERE deleted_ts is NULL");
     String whereClause = SQLStatementUtils.whereClause(SUPPORTED_CONDITIONS,
-        _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled(),
         new Pair<>(sourceEntityFilter, "st"),
         new Pair<>(destinationEntityFilter, "dt"),
         new Pair<>(relationshipFilter, "rt"));

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/MultiHopsTraversalSqlGenerator.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/MultiHopsTraversalSqlGenerator.java
@@ -27,7 +27,7 @@ public class MultiHopsTraversalSqlGenerator {
   @ParametersAreNonnullByDefault
   public String multiHopTraversalSql(int minHop, int maxHop, int count, int offset, String relationshipTable,
       String srcEntityTable, String destEntityTable, LocalRelationshipFilter relationshipFilter, LocalRelationshipFilter srcFilter,
-      LocalRelationshipFilter destFilter, boolean nonDollarVirtualColumnsEnabled) {
+      LocalRelationshipFilter destFilter) {
 
     /*
      * For now, only one-hop traversal is supported because multi-hops traversal using SQL is expensive
@@ -48,13 +48,13 @@ public class MultiHopsTraversalSqlGenerator {
     if (relationshipFilter.getDirection() == RelationshipDirection.INCOMING
         || relationshipFilter.getDirection() == RelationshipDirection.OUTGOING) {
       String urnSql = firstHopUrnsDirected(relationshipTable, srcEntityTable, destEntityTable, relationshipFilter, srcFilter,
-          destFilter, relationshipFilter.getDirection(), nonDollarVirtualColumnsEnabled);
+          destFilter, relationshipFilter.getDirection());
       return String.format("SELECT * FROM %s WHERE urn IN (%s) ORDER BY urn LIMIT %d OFFSET %d", entityTable, urnSql, count, offset);
     }
 
     // Relationship is undirected.
-    String urnSql = firstHopUrnsUndirected(relationshipTable, entityTable, relationshipFilter, srcFilter, nonDollarVirtualColumnsEnabled);
-    return findEntitiesUndirected(entityTable, relationshipTable, urnSql, destFilter, nonDollarVirtualColumnsEnabled);
+    String urnSql = firstHopUrnsUndirected(relationshipTable, entityTable, relationshipFilter, srcFilter);
+    return findEntitiesUndirected(entityTable, relationshipTable, urnSql, destFilter);
   }
 
   /**
@@ -64,8 +64,7 @@ public class MultiHopsTraversalSqlGenerator {
   @Nonnull
   @ParametersAreNonnullByDefault
   private String firstHopUrnsDirected(String relationshipTable, String srcEntityTable, String destEntityTable,
-      LocalRelationshipFilter relationshipFilter, LocalRelationshipFilter srcFilter, LocalRelationshipFilter destFilter, RelationshipDirection direction,
-      boolean nonDollarVirtualColumnsEnabled) {
+      LocalRelationshipFilter relationshipFilter, LocalRelationshipFilter srcFilter, LocalRelationshipFilter destFilter, RelationshipDirection direction) {
 
     String urnColumn = "destination";
     if (direction == RelationshipDirection.INCOMING) {
@@ -76,7 +75,7 @@ public class MultiHopsTraversalSqlGenerator {
         String.format("SELECT rt.%s FROM %s rt INNER JOIN %s dt ON rt.destination=dt.urn INNER JOIN %s st ON rt.source=st.urn WHERE rt.deleted_ts IS NULL",
             urnColumn, relationshipTable, destEntityTable, srcEntityTable));
 
-    String whereClause = SQLStatementUtils.whereClause(_supportedConditions,  nonDollarVirtualColumnsEnabled,
+    String whereClause = SQLStatementUtils.whereClause(_supportedConditions,
         new Pair<>(relationshipFilter, "rt"),
         new Pair<>(destFilter, "dt"),
         new Pair<>(srcFilter, "st"));
@@ -94,7 +93,7 @@ public class MultiHopsTraversalSqlGenerator {
   @Nonnull
   @ParametersAreNonnullByDefault
   private String firstHopUrnsUndirected(String relationshipTable, String entityTable, LocalRelationshipFilter relationshipFilter,
-      LocalRelationshipFilter srcFilter, boolean nonDollarVirtualColumnsEnabled) {
+      LocalRelationshipFilter srcFilter) {
 
     StringBuilder sourceUrnsSql = new StringBuilder(
         String.format("SELECT rt.source FROM %s rt INNER JOIN %s et ON rt.source=et.urn WHERE rt.deleted_ts IS NULL",
@@ -104,7 +103,7 @@ public class MultiHopsTraversalSqlGenerator {
         String.format("SELECT rt.destination FROM %s rt INNER JOIN %s et ON rt.destination=et.urn WHERE rt.deleted_ts IS NULL",
             relationshipTable, entityTable));
 
-    String whereClause = SQLStatementUtils.whereClause(_supportedConditions, nonDollarVirtualColumnsEnabled,
+    String whereClause = SQLStatementUtils.whereClause(_supportedConditions,
         new Pair<>(relationshipFilter, "rt"),
         new Pair<>(srcFilter, "et"));
 
@@ -121,9 +120,8 @@ public class MultiHopsTraversalSqlGenerator {
    */
   @Nonnull
   @ParametersAreNonnullByDefault
-  private String findEntitiesUndirected(String entityTable, String relationshipTable, String firstHopUrnSql, LocalRelationshipFilter destFilter,
-  boolean nonDollarVirtualColumnsEnabled) {
-    String whereClause = SQLStatementUtils.whereClause(_supportedConditions, nonDollarVirtualColumnsEnabled, new Pair<>(destFilter, "et"));
+  private String findEntitiesUndirected(String entityTable, String relationshipTable, String firstHopUrnSql, LocalRelationshipFilter destFilter) {
+    String whereClause = SQLStatementUtils.whereClause(_supportedConditions, new Pair<>(destFilter, "et"));
 
     StringBuilder sourceEntitySql = new StringBuilder(
         String.format("SELECT et.* FROM %s et INNER JOIN %s rt ON et.urn=rt.source WHERE rt.destination IN (%s)",

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -66,17 +66,15 @@ public class SQLIndexFilterUtils {
   /**
    * Parse {@link IndexSortCriterion} into SQL syntax.
    * @param indexSortCriterion filter sorting criterion
-   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
    * @return SQL statement of sorting, e.g. ORDER BY ... DESC ..etc.
    */
-  public static String parseSortCriteria(@Nullable IndexSortCriterion indexSortCriterion, boolean nonDollarVirtualColumnsEnabled) {
+  public static String parseSortCriteria(@Nullable IndexSortCriterion indexSortCriterion) {
     if (indexSortCriterion == null) {
       // Default to order by urn if user does not provide sort criterion.
       return "ORDER BY URN";
     }
     final String indexColumn =
-        SQLSchemaUtils.getGeneratedColumnName(indexSortCriterion.getAspect(), indexSortCriterion.getPath(),
-            nonDollarVirtualColumnsEnabled);
+        SQLSchemaUtils.getGeneratedColumnName(indexSortCriterion.getAspect(), indexSortCriterion.getPath());
 
     if (!indexSortCriterion.hasOrder()) {
       return "ORDER BY " + indexColumn;
@@ -89,10 +87,9 @@ public class SQLIndexFilterUtils {
    * Parse {@link IndexFilter} into MySQL syntax.
    *
    * @param indexFilter                    index filter
-   * @param nonDollarVirtualColumnsEnabled whether to enable non-dollar virtual columns
    * @return translated SQL condition expression, e.g. WHERE ...
    */
-  public static String parseIndexFilter(@Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled) {
+  public static String parseIndexFilter(@Nullable IndexFilter indexFilter) {
     List<String> sqlFilters = new ArrayList<>();
 
     if (indexFilter == null || !indexFilter.hasCriteria()) {
@@ -112,7 +109,7 @@ public class SQLIndexFilterUtils {
       if (pathParams != null) {
         validateConditionAndValue(indexCriterion);
         final Condition condition = pathParams.getCondition();
-        final String indexColumn = getGeneratedColumnName(aspect, pathParams.getPath(), nonDollarVirtualColumnsEnabled);
+        final String indexColumn = getGeneratedColumnName(aspect, pathParams.getPath());
         sqlFilters.add(parseSqlFilter(indexColumn, condition, pathParams.getValue()));
       }
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLSchemaUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLSchemaUtils.java
@@ -8,6 +8,8 @@ import com.linkedin.metadata.aspect.AspectColumnMetadata;
 import com.linkedin.metadata.dao.exception.MissingAnnotationException;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
@@ -22,6 +24,10 @@ public class SQLSchemaUtils {
   public static final String INDEX_PREFIX = "i_";
 
   private static final int MYSQL_MAX_COLUMN_NAME_LENGTH = 64 - ASPECT_PREFIX.length();
+
+  @Getter
+  @Setter
+  private static boolean nonDollarVirtualColumnsEnabled = false; // default value
 
   private SQLSchemaUtils() {
   }
@@ -88,13 +94,13 @@ public class SQLSchemaUtils {
    * Get generated column name from aspect and path.
    */
   @Nonnull
-  public static String getGeneratedColumnName(@Nonnull String aspect, @Nonnull String path, boolean nonDollarVirtualColumnsEnabled) {
+  public static String getGeneratedColumnName(@Nonnull String aspect, @Nonnull String path) {
     char delimiter = nonDollarVirtualColumnsEnabled ? '0' : '$';
     if (isUrn(aspect)) {
-      return INDEX_PREFIX + "urn" + processPath(path, delimiter);
+      return INDEX_PREFIX + "urn" + processPath(path);
     }
 
-    return INDEX_PREFIX + getColumnNameFromAnnotation(aspect) + processPath(path, delimiter);
+    return INDEX_PREFIX + getColumnNameFromAnnotation(aspect) + processPath(path);
   }
 
   /**
@@ -107,11 +113,11 @@ public class SQLSchemaUtils {
   /**
    * process 'path' into mysql column name convention.
    * @param path path in string e.g. /name/value, /name
-   * @param delimiter delimiter i.e '$' or '0'
    * @return $name$value or $name or 0name$value or 0name
    */
   @Nonnull
-  public static String processPath(@Nonnull String path, char delimiter) {
+  public static String processPath(@Nonnull String path) {
+    char delimiter = nonDollarVirtualColumnsEnabled ? '0' : '$';
     path = path.replace("/", String.valueOf(delimiter));
     if (!path.startsWith(String.valueOf(delimiter))) {
       path = delimiter + path;

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -142,6 +142,7 @@ public class EbeanLocalDAOTest {
   public EbeanLocalDAOTest(SchemaConfig schemaConfig, FindMethodology findMethodology, boolean enableChangeLog,
       boolean nonDollarVirtualColumnEnabled) {
     _eBeanDAOConfig.setNonDollarVirtualColumnsEnabled(nonDollarVirtualColumnEnabled);
+    SQLSchemaUtils.setNonDollarVirtualColumnsEnabled(nonDollarVirtualColumnEnabled);
     _schemaConfig = schemaConfig;
     _findMethodology = findMethodology;
     _enableChangeLog = enableChangeLog;
@@ -3070,8 +3071,7 @@ public class EbeanLocalDAOTest {
     */
 
     String aspectColumnName = isUrn(aspectName) ? null : SQLSchemaUtils.getAspectColumnName(aspectName); // e.g. a_aspectfoo;
-    String fullIndexColumnName = SQLSchemaUtils.getGeneratedColumnName(aspectName, pathName,
-        _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled()); // e.g. i_aspectfoo$path1$value1
+    String fullIndexColumnName = SQLSchemaUtils.getGeneratedColumnName(aspectName, pathName); // e.g. i_aspectfoo$path1$value1
 
     String checkColumnExistance = String.format("SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '%s' AND"
         + " TABLE_NAME = '%s' AND COLUMN_NAME = '%s'", _server.getName(), getTableName(urn), fullIndexColumnName);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLSchemaUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLSchemaUtilsTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.metadata.dao.utils;
 
 import com.linkedin.testing.AspectFoo;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
@@ -9,13 +11,27 @@ import static org.testng.Assert.*;
 
 public class SQLSchemaUtilsTest {
 
+  @Factory(dataProvider = "inputList")
+  public SQLSchemaUtilsTest(boolean nonDollarVirtualColumnsEnabled) {
+    SQLSchemaUtils.setNonDollarVirtualColumnsEnabled(nonDollarVirtualColumnsEnabled);
+  }
+
+  @DataProvider(name = "inputList")
+  public static Object[][] inputList() {
+    return new Object[][] {
+        { true },
+        { false }
+    };
+  }
+
   @Test
   public void testGetGeneratedColumnName() {
-    String generatedColumnName = getGeneratedColumnName(AspectFoo.class.getCanonicalName(), "/value", false);
-    assertEquals(generatedColumnName, "i_aspectfoo$value");
-
-    generatedColumnName = getGeneratedColumnName(AspectFoo.class.getCanonicalName(), "/value", true);
-    assertEquals(generatedColumnName, "i_aspectfoo0value");
+    String generatedColumnName = getGeneratedColumnName(AspectFoo.class.getCanonicalName(), "/value");
+    if (!SQLSchemaUtils.isNonDollarVirtualColumnsEnabled()) {
+      assertEquals(generatedColumnName, "i_aspectfoo$value");
+    } else {
+      assertEquals(generatedColumnName, "i_aspectfoo0value");
+    }
   }
 
   @Test


### PR DESCRIPTION
The other GMS could have used the methods defined in SQLSchemaUtils. The last change to add `boolean nonDollarVirtualColumnsEnabled` will break those GMSes once they bump their version.

I have made nonDollarVirtualColumnsEnabled a static member of SQLSchemaUtils which can be initialized when we create an instance of EbeanLocalAccess to set the value of nonDollarVirtualColumnsEnabled and be consistent with the whole instance.

### Testing
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
