### PR TITLE
add searchV2 in restli

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
@@ -114,6 +114,33 @@ public abstract class BaseSearchableEntityResource<
         () -> getSearchQueryCollectionResult(searchResult, aspectNames));
   }
 
+  /**
+   * The v2 version of search method which supports preference parameter and returns the right search result metadata
+   * when there are more than one filter criteria.
+   * @param input search query
+   * @param aspectNames list of aspect names that need to be returned
+   * @param filter {@link Filter} to filter the search results
+   * @param sortCriterion {@link SortCriterion} to sort the search results
+   * @param preference preference of the shard copy on which to execute the search
+   * @param pagingContext pagination context
+   * @return list of all {@link VALUE} objects along with search result metadata
+   */
+  @Finder(FINDER_SEARCH)
+  @Nonnull
+  public Task<CollectionResult<VALUE, SearchResultMetadata>> searchV2(@QueryParam(PARAM_INPUT) @Nonnull String input,
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
+      @QueryParam(PARAM_FILTER) @Optional @Nullable Filter filter,
+      @QueryParam(PARAM_SORT) @Optional @Nullable SortCriterion sortCriterion,
+      @QueryParam(PARAM_PREFERENCE) @Optional @Nullable String preference,
+      @PagingContextParam @Nonnull PagingContext pagingContext) {
+
+    final Filter searchFilter = filter != null ? filter : QueryUtils.EMPTY_FILTER;
+    final SearchResult<DOCUMENT> searchResult =
+        getSearchDAO().searchV2(input, searchFilter, sortCriterion, preference, pagingContext.getStart(), pagingContext.getCount());
+    return RestliUtils.toTask(
+        () -> getSearchQueryCollectionResult(searchResult, aspectNames));
+  }
+
   @Action(name = ACTION_AUTOCOMPLETE)
   @Nonnull
   public Task<AutoCompleteResult> autocomplete(@ActionParam(PARAM_QUERY) @Nonnull String query,

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -45,4 +45,5 @@ public final class RestliConstants {
   public static final String PARAM_TRACKING_CONTEXT = "trackingContext";
 
   public static final String PARAM_ENTITY_TYPE = "entityType";
+  public static final String PARAM_PREFERENCE = "preference";
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSearchableEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSearchableEntityResourceTest.java
@@ -178,7 +178,7 @@ public class BaseSearchableEntityResourceTest extends BaseEngineTest {
     SearchResultMetadata  searchResultMetadataWithOneFilterCriteria = makeSearchResultMetadata(new AggregationMetadata().setName("agg")
         .setAggregations(new LongMap(ImmutableMap.of("bucket1", 1L, "bucket2", 2L))));
 
-    when(_mockSearchDAO.searchV2("bar", filterWithTwoCriteria, null, null,0, 10)).thenReturn(
+    when(_mockSearchDAO.searchV2("bar", filterWithTwoCriteria, null, null, 0, 10)).thenReturn(
         makeSearchResult(ImmutableList.of(makeDocument(urn1), makeDocument(urn2)), 3, searchResultMetadataWithOneFilterCriteria));
 
     String[] aspectNames = new String[]{ModelUtils.getAspectName(AspectFoo.class)};


### PR DESCRIPTION
## This PR is to add the searchV2 in the restli module for dependent service to use. 

The searchV2 was created to support running the search (ES) with supporting more than 1 filter criteria. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)




