### PR TITLE
feat: generate BackfillItemArray with schema

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillModels.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillModels.pdl
@@ -1,0 +1,13 @@
+namespace com.linkedin.metadata.backfill
+
+/**
+ * A class for generating the pegasus schema for models used in backfill. DO NOT USE THIS CLASS DIRECTLY.
+ */
+record BackfillModels {
+
+  /**
+   * An array of com.linkedin.metadata.backfill.BackfillItem. This field is added for generating the class
+   * BackfillItemArray with schema in pegasus.
+   */
+  backfillItems: array[BackfillItem]
+}


### PR DESCRIPTION
## Summary
- this PR added a `BackfillModels.pdl` that has `backfillItems: array[BackfillItem]`. It is for generating the class `BackfillItemArray` with the pegasus schema which is needed for development and yet does not exist in the project.

## Test
- ./gradlew build
- verified generated class:
```
@Generated(value = "com.linkedin.pegasus.generator.JavaCodeUtil", comments = "Rest.li Data Template. Generated from dao-api/src/main/pegasus/com/linkedin/metadata/backfill/BackfillModels.pdl.")
public class BackfillItemArray
    extends WrappingArrayTemplate<BackfillItem>
{

    private final static ArrayDataSchema SCHEMA = ((ArrayDataSchema) DataTemplateUtil.parseSchema("array[{namespace com.linkedin.metadata.backfill/**A model that represents an item in a backfill action.*/record BackfillItem{/**The urn to backfill.*/urn:string/**The list of aspects to backfill.*/aspects:array[string]=[]}}]", SchemaFormatType.PDL));

    public BackfillItemArray() {
        this(new DataList());
    }

    public BackfillItemArray(int initialCapacity) {
        this(new DataList(initialCapacity));
    }

    public BackfillItemArray(Collection<BackfillItem> c) {
        this(new DataList(c.size()));
        addAll(c);
    }

    public BackfillItemArray(DataList data) {
        super(data, SCHEMA, BackfillItem.class);
    }
...
```

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
