### PR TITLE
Added querycount to getWithExtraInfo

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -79,7 +79,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   protected final EbeanServer _server;
   protected final Class<URN> _urnClass;
-  private int _queryKeysCount = 100;
+
+  private final static int DEFAULT_BATCH_SIZE = 50;
+  private int _queryKeysCount = DEFAULT_BATCH_SIZE;
   private IEbeanLocalAccess<URN> _localAccess;
   private UrnPathExtractor<URN> _urnPathExtractor;
   private SchemaConfig _schemaConfig = SchemaConfig.OLD_SCHEMA_ONLY;
@@ -949,12 +951,13 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   public void setQueryKeysCount(int keysCount) {
     if (keysCount < 0) {
       throw new IllegalArgumentException("Query keys count must be non-negative: " + keysCount);
+    } else if (keysCount > DEFAULT_BATCH_SIZE) {
+      log.warn("Setting query keys count greater than " + DEFAULT_BATCH_SIZE
+          + " may cause performance issues. Defaulting to " + DEFAULT_BATCH_SIZE + ".");
+      _queryKeysCount = DEFAULT_BATCH_SIZE;
+    } else {
+      _queryKeysCount = keysCount;
     }
-    if (keysCount > 100) {
-      log.warn("Setting query keys count greater than 100 may cause performance issues: " + keysCount + "Defaulting to 100.");
-      _queryKeysCount = 100;
-    }
-    _queryKeysCount = keysCount;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -946,7 +946,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Sets the max keys allowed for each single query.
+   * Sets the max keys allowed for each single query, not allowed more than the default batch size.
    */
   public void setQueryKeysCount(int keysCount) {
     if (keysCount < 0) {


### PR DESCRIPTION
### Summary
Fixed the `getWithExtraInfo` which was not using pagination, which was creating queries with 5000 Union statements. Also set the default value of queryCount as 100, and set the limitation on the setter method to not set above 100.

**In conversation with MySQL team to know the ideal pagination count, they suggested 12. 12 seems too low looking at the 5000 union ran today. Working with them to test it on test server or prod read-replica**
#### Update:
MySQL team suggested to have any number between 12-100, it's all guesses and it's difficult to get the exact one without proper metrics. Yang suggested to go with 50 for now, but we can change it one way or the other.

### Testing
./gradlew build

#### Tested locally on metadata-store

Made few changes to TMS:
- Added `dao.setQueryKeysCount(2);` to BaseLocalDaoFactory
- Commented ` dao.setQueryKeysCount(cfg.queryKeysCount);` in DatasetLocalDaoFactory

#### Ingested some dummy records

```
curli "http://localhost:1472/datasets?action=ingestWithTracking" 
-H 'X-RestLi-Method:action' -H 'Accept:application/json' 
-H 'Content-Type:application/json' -H 'X-RestLi-Protocol-Version:2.0.0' 
--data '{
     "snapshot": {
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test1,EI)",
         "aspects": [
             {
                 "com.linkedin.common.Status": {
                     "removed": false
                 }
             }
         ]
     },
     "trackingContext": {
         "emitter": "urn:li:corpuser:tester",
         "emitTime": 1708479115661
     }
 },{
     "snapshot": {
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test2,EI)",
         "aspects": [
             {
                 "com.linkedin.common.Status": {
                     "removed": false
                 }
             }
         ]
     },
     "trackingContext": {
         "emitter": "urn:li:corpuser:tester",
         "emitTime": 1708479115662
     }
 },
{
     "snapshot": {
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test3,EI)",
         "aspects": [
             {
                 "com.linkedin.common.Status": {
                     "removed": false
                 }
             }
         ]
     },
     "trackingContext": {
         "emitter": "urn:li:corpuser:tester",
         "emitTime": 1708479115663
     }
 }'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   757    0     0  100   757      0   6060 --:--:-- --:--:-- --:--:--  6104
```
#### Run batchGet to get Status aspect for the dummy records

```
 curli "http://localhost:1472/datasets?
aspects=List(com.linkedin.common.Status)&
ids=List((\$params:(),name:rakagraw_test2,origin:EI,platform:urn%3Ali%3AdataPlatform%3Ahdfs),
(\$params:(),name:rakagraw_test1,origin:EI,platform:urn%3Ali%3AdataPlatform%3Ahdfs),
(\$params:(),name:rakagraw_test3,origin:EI,platform:urn%3Ali%3AdataPlatform%3Ahdfs))" 
-X GET 
 -H 'Accept:application/json' -H 'Content-Type:application/json' -H 'X-RestLi-Protocol-Version:2.0.0'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1484  100  1484    0     0  26269      0 --:--:-- --:--:-- --:--:-- 26500
{
    "statuses": {},
    "results": {
        "(name:rakagraw_test2,origin:EI,platform:urn%3Ali%3AdataPlatform%3Ahdfs)": {
            "removed": false,
            "created": {
                "actor": "urn:li:corpuser:UNKNOWN",
                "time": 1709082679047
            },
            "origin": "EI",
            "name": "rakagraw_test2",
            "description": "",
            "lastModified": {
                "actor": "urn:li:corpuser:UNKNOWN",
                "time": 1709082679047
            },
            "id": 1,
            "deploymentInfos": [
                {
                    "dataLocation": {
                        "cluster": "default",
                        "fabricGroup": "EI"
                    }
                }
            ],
            "$URN": "urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test2,EI)",
            "platform": "urn:li:dataPlatform:hdfs",
            "tags": [],
            "status": {
                "removed": false
            }
        },
        "(name:rakagraw_test3,origin:EI,platform:urn%3Ali%3AdataPlatform%3Ahdfs)": {
            "created": {
                "actor": "urn:li:corpuser:UNKNOWN",
                "time": 1709082679039
            },
            "origin": "EI",
            "name": "rakagraw_test3",
            "description": "",
            "lastModified": {
                "actor": "urn:li:corpuser:UNKNOWN",
                "time": 1709082679039
            },
            "id": 1,
            "deploymentInfos": [],
            "$URN": "urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test3,EI)",
            "platform": "urn:li:dataPlatform:hdfs",
            "tags": []
        },
        "(name:rakagraw_test1,origin:EI,platform:urn%3Ali%3AdataPlatform%3Ahdfs)": {
            "removed": false,
            "created": {
                "actor": "urn:li:corpuser:UNKNOWN",
                "time": 1709082679041
            },
            "origin": "EI",
            "name": "rakagraw_test1",
            "description": "",
            "lastModified": {
                "actor": "urn:li:corpuser:UNKNOWN",
                "time": 1709082679041
            },
            "id": 1,
            "deploymentInfos": [
                {
                    "dataLocation": {
                        "cluster": "default",
                        "fabricGroup": "EI"
                    }
                }
            ],
            "$URN": "urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test1,EI)",
            "platform": "urn:li:dataPlatform:hdfs",
            "tags": [],
            "status": {
                "removed": false
            }
        }
    },
    "errors": {}
}
```
#### Checked the log on metagalaxy_local mysql.general_log table
 Ran these two commands to enable general_log before running batch get
```
SET GLOBAL log_output = 'TABLE';
SET GLOBAL general_log = 'ON';
```
Now, checked the general_log to see UNION of size 2, please scroll right to argument column

```
MariaDB [metagalaxy_local]> select * from mysql.general_log where argument like 'SELECT urn%';
+----------------------------+--------------------------+-----------+-----------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| event_time                 | user_host                | thread_id | server_id | command_type | argument                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+----------------------------+--------------------------+-----------+-----------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 2024-02-27 17:11:19.031531 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn, a_status, lastmodifiedon, lastmodifiedby FROM metadata_entity_dataset WHERE urn = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test3,EI)' AND JSON_EXTRACT(a_status, '$.gma_deleted') IS NULL UNION ALL SELECT urn, a_status, lastmodifiedon, lastmodifiedby FROM metadata_entity_dataset WHERE urn = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test1,EI)' AND JSON_EXTRACT(a_status, '$.gma_deleted') IS NULL |
| 2024-02-27 17:11:19.038086 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn, a_status, lastmodifiedon, lastmodifiedby FROM metadata_entity_dataset WHERE urn = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test2,EI)' AND JSON_EXTRACT(a_status, '$.gma_deleted') IS NULL                                                                                                                                                                                                                           |
| 2024-02-27 17:11:19.040336 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn FROM metadata_entity_datasetinstance
WHERE i_urn$dataset = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test3,EI)'
ORDER BY URN LIMIT 1024                                                                                                                                                                                                                                                                               |
| 2024-02-27 17:11:19.041369 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn FROM metadata_entity_datasetinstance
WHERE i_urn$dataset = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test1,EI)'
ORDER BY URN LIMIT 1024                                                                                                                                                                                                                                                                               |
| 2024-02-27 17:11:19.043222 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn, a_status, lastmodifiedon, lastmodifiedby FROM metadata_entity_datasetinstance WHERE urn = 'urn:li:datasetInstance:(urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test1,EI),default)' AND JSON_EXTRACT(a_status, '$.gma_deleted') IS NULL                                                                                                                                                                                  |
| 2024-02-27 17:11:19.046011 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn, a_deploymentinfo, lastmodifiedon, lastmodifiedby FROM metadata_entity_datasetinstance WHERE urn = 'urn:li:datasetInstance:(urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test1,EI),default)' AND JSON_EXTRACT(a_deploymentinfo, '$.gma_deleted') IS NULL                                                                                                                                                                  |
| 2024-02-27 17:11:19.048432 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn FROM metadata_entity_datasetinstance
WHERE i_urn$dataset = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test2,EI)'
ORDER BY URN LIMIT 1024                                                                                                                                                                                                                                                                               |
| 2024-02-27 17:11:19.050202 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn, a_status, lastmodifiedon, lastmodifiedby FROM metadata_entity_datasetinstance WHERE urn = 'urn:li:datasetInstance:(urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test2,EI),default)' AND JSON_EXTRACT(a_status, '$.gma_deleted') IS NULL                                                                                                                                                                                  |
| 2024-02-27 17:11:19.051668 | [user] @ localhost [::1] |        31 |         1 | Query        | SELECT urn, a_deploymentinfo, lastmodifiedon, lastmodifiedby FROM metadata_entity_datasetinstance WHERE urn = 'urn:li:datasetInstance:(urn:li:dataset:(urn:li:dataPlatform:hdfs,rakagraw_test2,EI),default)' AND JSON_EXTRACT(a_deploymentinfo, '$.gma_deleted') IS NULL                                                                                                                                                                  |
+----------------------------+--------------------------+-----------+-----------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
9 rows in set (0.002 sec)



```


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
