### PR TITLE
feat: add deserialize method for Urn java classes

### DIFF
--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/BarUrn.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/BarUrn.java
@@ -40,4 +40,8 @@ public final class BarUrn extends Urn {
 
     return new BarUrn(urn.getIdAsInt());
   }
+
+  public static BarUrn deserialize(String serializedUrn) throws URISyntaxException {
+    return createFromString(serializedUrn);
+  }
 }

--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/BazUrn.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/BazUrn.java
@@ -39,4 +39,8 @@ public final class BazUrn extends Urn {
 
     return new BazUrn(urn.getIdAsInt());
   }
+
+  public static BazUrn deserialize(String serializedUrn) throws URISyntaxException {
+    return createFromString(serializedUrn);
+  }
 }

--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/BurgerUrn.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/BurgerUrn.java
@@ -40,4 +40,8 @@ public final class BurgerUrn extends Urn {
 
     return new BurgerUrn(urn.getId());
   }
+
+  public static BurgerUrn deserialize(String serializedUrn) throws URISyntaxException {
+    return createFromString(serializedUrn);
+  }
 }

--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/FooUrn.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/FooUrn.java
@@ -39,4 +39,8 @@ public final class FooUrn extends Urn {
 
     return new FooUrn(urn.getIdAsInt());
   }
+
+  public static FooUrn deserialize(String serializedUrn) throws URISyntaxException {
+    return createFromString(serializedUrn);
+  }
 }

--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/PizzaUrn.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/PizzaUrn.java
@@ -40,4 +40,8 @@ public final class PizzaUrn extends Urn {
 
     return new PizzaUrn(urn.getIdAsInt());
   }
+
+  public static PizzaUrn deserialize(String serializedUrn) throws URISyntaxException {
+    return createFromString(serializedUrn);
+  }
 }

--- a/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/SingleAspectEntityUrn.java
+++ b/testing/test-models/src/main/javaPegasus/com/linkedin/testing/urn/SingleAspectEntityUrn.java
@@ -15,4 +15,8 @@ public final class SingleAspectEntityUrn extends Urn {
   public static SingleAspectEntityUrn createFromString(String rawUrn) throws URISyntaxException {
     return new SingleAspectEntityUrn(Urn.createFromString(rawUrn).getIdAsInt());
   }
+
+  public static SingleAspectEntityUrn deserialize(String serializedUrn) throws URISyntaxException {
+    return createFromString(serializedUrn);
+  }
 }


### PR DESCRIPTION
This PR adds deserialize method in Urn java class to match with the Urn classes generated internally in Linkedin.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
