### PR TITLE
feat: Move BaseSemanticVersion to top level schema

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseSemanticVersion.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseSemanticVersion.pdl
@@ -1,0 +1,18 @@
+namespace com.linkedin.metadata.aspect
+
+record BaseSemanticVersion {
+  /**
+   * The major version of this version. This is the x in x.y.z.
+   */
+  major: int
+
+  /**
+   * The minor version of this version. This is the y in x.y.z
+   */
+  minor: int
+
+  /**
+  * The patch version of this version. This is the z in x.y.z
+  */
+  patch: int
+}

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/aspect/BaseVersionedAspect.pdl
@@ -9,20 +9,5 @@ record BaseVersionedAspect {
  /**
   * The version of the metadata aspect
   */
- baseSemanticVersion: optional record BaseSemanticVersion {
-   /**
-    * The major version of this version. This is the x in x.y.z.
-    */
-   major: int
-
-   /**
-    * The minor version of this version. This is the y in x.y.z
-    */
-   minor: int
-
-   /**
-   * The patch version of this version. This is the z in x.y.z
-   */
-   patch: int
- }
+ baseSemanticVersion: optional BaseSemanticVersion
 }


### PR DESCRIPTION
This is required to use the BaseSemanticVersion directly as fieldType instead of BaseVersionedAspect.BaseSemanticVersion
This change should be backward compatible as the generated java class for BaseSemanticVersion would still be `com/linkedin/metadata/aspect/BaseSemanticVersion.java` 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
