### PR TITLE
feat. attempt to enable codecov for datahub-gma

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,12 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: test-reports
-          path: /home/runner/work/datahub-gma/datahub-gma/dao-impl/ebean-dao/build/reports/tests/test/**  
+          path: /home/runner/work/datahub-gma/datahub-gma/dao-impl/ebean-dao/build/reports/tests/test/**
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: linkedin/datahub-gma
       - name: Slack failure notification
         if: failure() && github.event_name == 'push'
         uses: kpritam/slack-job-status-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ allprojects {
 
 subprojects { sp ->
   apply plugin: 'maven'
+  apply plugin: 'jacoco'
 
   plugins.withType(JavaPlugin) {
     dependencies {
@@ -116,12 +117,24 @@ subprojects { sp ->
       useTestNG()
     }
 
+    test {
+      finalizedBy jacocoTestReport
+    }
+
     checkstyle {
       configDirectory = file("${project.rootDir}/gradle/checkstyle")
       sourceSets = [ getProject().sourceSets.main, getProject().sourceSets.test ]
       toolVersion = "8.35"
       maxWarnings = 0
       ignoreFailures = false
+    }
+
+    jacocoTestReport {
+      reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+      }
     }
   }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true # set informational to true to not fail the build if coverage is below threshold
+    patch:
+      default:
+        informational: true # set informational to true to not fail the build if coverage is below threshold
+
+
+# When modifying this file, please validate using
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate


### PR DESCRIPTION
## Summary
- This pr attempts to enable the code coverage report for changes in datahub-gma. For now, it does not block merging even if a change decreases the overall test coverage of the project.
- Here is what the coverage report should look like: https://docs.codecov.com/docs/quick-start#step-5-get-coverage-analysis-from-codecov
- Reference: https://docs.codecov.com/docs/quick-start

## Testing
- ./gradlew build

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
