### PR TITLE
gradle-plugin: add property annotation to make task compatible with Gradle 7+

### DIFF
--- a/gradle-plugins/metadata-events-generator-plugin/src/main/java/com/linkedin/metadata/gradle/tasks/GenerateMetadataEventsTask.java
+++ b/gradle-plugins/metadata-events-generator-plugin/src/main/java/com/linkedin/metadata/gradle/tasks/GenerateMetadataEventsTask.java
@@ -12,6 +12,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectories;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -53,6 +54,7 @@ public class GenerateMetadataEventsTask extends DefaultTask {
   }
 
   @Nonnull
+  @Internal
   public Property<GmaEntitiesAnnotationAllowList> getEntitiesAnnotationAllowList() {
     return _allowList;
   }


### PR DESCRIPTION
Starting from Gradle 7, all task getter must be annotated with their usage. Since the getEntitiesAnnotationAllowList getter is not annotated currently, the @Internal is the best matching backward compatible annotation for it

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

# Testing Done

Manually tested that the task works on Gradle 7