### PR TITLE
feat: start to block PR that decreases the coverage of the repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
+## Summary
+
+## Testing Done
+
 ## Checklist
 
 - [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
 - [ ] Links to related issues (if applicable)
-- [ ] Tests for the changes have been added/updated (if applicable)
 - [ ] Docs related to the changes have been added/updated (if applicable)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![release](https://img.shields.io/github/v/release/linkedin/datahub-gma)](https://github.com/linkedin/datahub-gma/releases/)
 [![build & test](https://github.com/linkedin/datahub-gma/workflows/build%20&%20test/badge.svg?branch=master&event=push)](https://github.com/linkedin/datahub-gma/actions?query=workflow%3A%22build+%26+test%22+branch%3Amaster+event%3Apush)
+[![codecov](https://codecov.io/gh/linkedin/datahub-gma/graph/badge.svg?token=VYJOBVTD00)](https://codecov.io/gh/linkedin/datahub-gma)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/datahubspace/shared_invite/zt-dkzbxfck-dzNl96vBzB06pJpbRwP6RA)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/linkedin/datahub-gma/blob/master/docs/CONTRIBUTING.md)
 [![License](https://img.shields.io/github/license/linkedin/datahub-gma)](LICENSE)

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,9 @@ coverage:
 github_checks:
   annotations: false
 
+ignore:
+  - "core-models"
+
 
 # When modifying this file, please validate using
 # curl -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
         # adjust accordingly based on how flaky your tests are
         # this allows a 0% drop from the previous base commit coverage
         threshold: 0%
+        only_pulls: true # no status will be posted for commits not on a pull request
 
 github_checks:
   annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,13 @@ coverage:
   status:
     project:
       default:
-        informational: true # set informational to true to not fail the build if coverage is below threshold
-    patch:
-      default:
-        informational: true # set informational to true to not fail the build if coverage is below threshold
+        target: auto # auto compares coverage to the previous base commit
+        # adjust accordingly based on how flaky your tests are
+        # this allows a 0% drop from the previous base commit coverage
+        threshold: 0%
+
+github_checks:
+  annotations: false
 
 
 # When modifying this file, please validate using


### PR DESCRIPTION
## Summary
- update codecov file to block PRs that decrease the coverage of the repo
- update pr template file
- add a badge for codecov in readme

## Testing Done
- ./gradlew build

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
