### PR TITLE
feat: add error name into the dimension

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/TrackingUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/TrackingUtils.java
@@ -111,7 +111,8 @@ public class TrackingUtils {
    */
   public enum Dimension {
     ASPECT_TYPE("aspectType"),
-    ERROR_TYPE("errorType"),
+    ERROR_TYPE("errorType"), // category of the error, e.g., client vs server error
+    ERROR_NAME("errorName"), // name of the error, e.g., NullPointerException
     ORIGINAL_EMIT_TIME("originalEmitTime"),
     PLATFORM_TYPE("platformType");
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/TrackingUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/TrackingUtils.java
@@ -112,7 +112,7 @@ public class TrackingUtils {
   public enum Dimension {
     ASPECT_TYPE("aspectType"),
     ERROR_TYPE("errorType"), // category of the error, e.g., client vs server error
-    ERROR_NAME("errorName"), // name of the error, e.g., NullPointerException
+    EXCEPTION("exception"), // exception name of the error, e.g., NullPointerException
     ORIGINAL_EMIT_TIME("originalEmitTime"),
     PLATFORM_TYPE("platformType");
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,6 +72,10 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
+          configurationBuilder.setBaseDir("/opt/homebrew");
+          configurationBuilder.setUnpackingFromClasspath(false);
+          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,10 +72,6 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
-          configurationBuilder.setBaseDir("/opt/homebrew");
-          configurationBuilder.setUnpackingFromClasspath(false);
-          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
-
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {


### PR DESCRIPTION
## Summary
- Add a dimension `errorName`. With this change, one should use `errorType` to represent the category, and use `errorName` for the specific name of the exception.

## Testing Done
./gradlew build

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
