### PR TITLE
fix(proto_optional_fields): loosen schema validators to only check fo…

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -281,7 +281,7 @@ public class RecordUtils {
    * @param valueClass the expected type for the value
    * @return the value for the field
    */
-  @Nonnull
+  @Nullable
   public static <T extends RecordTemplate, V> V getRecordTemplateField(@Nonnull T recordTemplate,
       @Nonnull String fieldName, @Nonnull Class<V> valueClass) {
 
@@ -300,7 +300,7 @@ public class RecordUtils {
    * @param valueClass the expected type for the value
    * @return the value for the field
    */
-  @Nonnull
+  @Nullable
   public static <T extends RecordTemplate, V extends DataTemplate> V getRecordTemplateWrappedField(
       @Nonnull T recordTemplate, @Nonnull String fieldName, @Nonnull Class<V> valueClass) {
 
@@ -389,7 +389,7 @@ public class RecordUtils {
     }
   }
 
-  @Nonnull
+  @Nullable
   private static <T> T invokeProtectedMethod(Object object, Method method, Object... args) {
     try {
       method.setAccessible(true);

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -3,19 +3,25 @@ package com.linkedin.metadata.dao.utils;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.CommonTestAspect;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.validator.NullFieldException;
 import com.linkedin.testing.AspectAttributes;
 import com.linkedin.testing.AspectUnionWithSoftDeletedAspect;
 import com.linkedin.testing.DeltaUnionAlias;
 import com.linkedin.testing.EntityAspectUnionAliasArray;
 import com.linkedin.testing.EntityDeltaAlias;
 import com.linkedin.testing.EntityFoo;
+import com.linkedin.testing.EntityFooInvalid;
+import com.linkedin.testing.EntityFooOptionalUrn;
 import com.linkedin.testing.EntitySnapshotAlias;
+import com.linkedin.testing.EntitySnapshotAliasOptionalFields;
 import com.linkedin.testing.EntityUnion;
 import com.linkedin.testing.EntityUnionAlias;
 import com.linkedin.testing.PizzaInfo;
 import com.linkedin.testing.PizzaOrder;
 import com.linkedin.testing.SnapshotUnionAlias;
+import com.linkedin.testing.SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields;
 import com.linkedin.testing.TyperefPizzaAspect;
 import com.linkedin.testing.localrelationship.AspectFooBar;
 import com.linkedin.testing.urn.PizzaUrn;
@@ -31,14 +37,19 @@ import com.linkedin.testing.EntityAspectUnionArray;
 import com.linkedin.testing.EntityBar;
 import com.linkedin.testing.EntityDelta;
 import com.linkedin.testing.EntityDocument;
+import com.linkedin.testing.EntityDocumentInvalid;
+import com.linkedin.testing.EntityDocumentOptionalUrn;
 import com.linkedin.testing.EntitySnapshot;
+import com.linkedin.testing.EntitySnapshotInvalid;
+import com.linkedin.testing.EntitySnapshotOptionalFields;
 import com.linkedin.testing.InvalidAspectUnion;
 import com.linkedin.testing.RelationshipFoo;
+import com.linkedin.testing.RelationshipFooOptionalFields;
 import com.linkedin.testing.RelationshipUnion;
 import com.linkedin.testing.RelationshipUnionAlias;
 import com.linkedin.testing.SnapshotUnion;
+import com.linkedin.testing.SnapshotUnionWithEntitySnapshotOptionalFields;
 import com.linkedin.testing.urn.FooUrn;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
@@ -118,6 +129,12 @@ public class ModelUtilsTest {
   }
 
   @Test
+  public void testGetNullUrnFromSnapshot() {
+    EntitySnapshotOptionalFields snapshot = new EntitySnapshotOptionalFields().setUrn(null, SetMode.IGNORE_NULL);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getUrnFromSnapshot(snapshot));
+  }
+
+  @Test
   public void testGetUrnFromSnapshotUnion() {
     Urn expected = makeUrn(1);
     EntitySnapshot snapshot = new EntitySnapshot().setUrn(expected);
@@ -180,12 +197,24 @@ public class ModelUtilsTest {
   }
 
   @Test
+  public void testGetNullUrnFromDocument() {
+    EntityDocumentOptionalUrn document = new EntityDocumentOptionalUrn().setUrn(null, SetMode.IGNORE_NULL);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getUrnFromDocument(document));
+  }
+
+  @Test
   public void testGetUrnFromEntity() {
     FooUrn expected = makeFooUrn(1);
     EntityFoo entity = new EntityFoo().setUrn(expected);
 
     Urn urn = ModelUtils.getUrnFromEntity(entity);
     assertEquals(urn, expected);
+  }
+
+  @Test
+  public void testGetNullUrnFromEntity() {
+    EntityFooOptionalUrn entity = new EntityFooOptionalUrn().setUrn(null, SetMode.IGNORE_NULL);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getUrnFromEntity(entity));
   }
 
   @Test
@@ -201,7 +230,16 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testGetAspectsFromSnapshot() throws IOException {
+  public void testGetNullUrnFromRelationship() {
+    RelationshipFooOptionalFields relationship = new RelationshipFooOptionalFields()
+        .setSource(null, SetMode.IGNORE_NULL)
+        .setDestination(null, SetMode.IGNORE_NULL);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getSourceUrnFromRelationship(relationship));
+    assertThrows(NullFieldException.class, () -> ModelUtils.getDestinationUrnFromRelationship(relationship));
+  }
+
+  @Test
+  public void testGetAspectsFromSnapshot() {
     EntitySnapshot snapshot = new EntitySnapshot();
     snapshot.setAspects(new EntityAspectUnionArray());
     snapshot.getAspects().add(new EntityAspectUnion());
@@ -215,7 +253,14 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testGetAspectsFromSnapshotAlias() throws IOException {
+  public void testGetNullAspectsFromSnapshot() {
+    EntitySnapshotOptionalFields snapshot = new EntitySnapshotOptionalFields();
+    snapshot.setAspects(null, SetMode.IGNORE_NULL);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getAspectsFromSnapshot(snapshot));
+  }
+
+  @Test
+  public void testGetAspectsFromSnapshotAlias() {
     EntitySnapshotAlias snapshot = new EntitySnapshotAlias();
     snapshot.setAspects(new EntityAspectUnionAliasArray());
     AspectFoo foo = new AspectFoo();
@@ -235,7 +280,14 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testGetAspectFromSnapshot() throws IOException {
+  public void testGetNullAspectsFromSnapshotAlias() {
+    EntitySnapshotAliasOptionalFields snapshot = new EntitySnapshotAliasOptionalFields();
+    snapshot.setAspects(null, SetMode.IGNORE_NULL);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getAspectsFromSnapshot(snapshot));
+  }
+
+  @Test
+  public void testGetAspectFromSnapshot() {
     EntitySnapshot snapshot = new EntitySnapshot();
     snapshot.setAspects(new EntityAspectUnionArray());
     snapshot.getAspects().add(new EntityAspectUnion());
@@ -251,7 +303,14 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testGetAspectsFromSnapshotUnion() throws IOException {
+  public void testGetNullAspectFromSnapshot() {
+    EntitySnapshotOptionalFields snapshot = new EntitySnapshotOptionalFields();
+    snapshot.setAspects(null, SetMode.IGNORE_NULL);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getAspectFromSnapshot(snapshot, AspectFoo.class));
+  }
+
+  @Test
+  public void testGetAspectsFromSnapshotUnion() {
     EntitySnapshot snapshot = new EntitySnapshot();
     snapshot.setAspects(new EntityAspectUnionArray());
     snapshot.getAspects().add(new EntityAspectUnion());
@@ -267,7 +326,16 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testGetAspectsFromSnapshotUnionAlias() throws IOException {
+  public void testGetNullAspectsFromSnapshotUnion() {
+    EntitySnapshotOptionalFields snapshot = new EntitySnapshotOptionalFields();
+    snapshot.setAspects(null, SetMode.IGNORE_NULL);
+    SnapshotUnionWithEntitySnapshotOptionalFields snapshotUnion = new SnapshotUnionWithEntitySnapshotOptionalFields();
+    snapshotUnion.setEntitySnapshotOptionalFields(snapshot);
+    assertThrows(NullFieldException.class, () -> ModelUtils.getAspectsFromSnapshotUnion(snapshotUnion));
+  }
+
+  @Test
+  public void testGetAspectsFromSnapshotUnionAlias() {
     EntitySnapshotAlias snapshot = new EntitySnapshotAlias();
     snapshot.setAspects(new EntityAspectUnionAliasArray());
     snapshot.getAspects().add(new EntityAspectUnionAlias());
@@ -282,6 +350,15 @@ public class ModelUtilsTest {
     assertEquals(aspects.get(0), foo);
   }
 
+  public void testGetNullAspectsFromSnapshotUnionAlias() {
+    EntitySnapshotAliasOptionalFields snapshot = new EntitySnapshotAliasOptionalFields();
+    snapshot.setAspects(null, SetMode.IGNORE_NULL);
+    SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields snapshotUnion = new SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields();
+    snapshotUnion.setEntity(snapshot);
+
+    assertThrows(NullFieldException.class, () -> ModelUtils.getAspectsFromSnapshotUnion(snapshotUnion));
+  }
+
   @Test
   public void testNewSnapshot() {
     Urn urn = makeUrn(1);
@@ -294,6 +371,16 @@ public class ModelUtilsTest {
     assertEquals(snapshot.getUrn(), urn);
     assertEquals(snapshot.getAspects().size(), 1);
     assertEquals(snapshot.getAspects().get(0).getAspectFoo(), foo);
+  }
+
+  @Test
+  public void testNewSnapshotInvalidSchema() {
+    Urn urn = makeUrn(1);
+    AspectFoo foo = new AspectFoo().setValue("foo");
+    EntityAspectUnion aspectUnion = new EntityAspectUnion();
+    aspectUnion.setAspectFoo(foo);
+
+    assertThrows(InvalidSchemaException.class, () -> ModelUtils.newSnapshot(EntitySnapshotInvalid.class, urn, Lists.newArrayList(aspectUnion)));
   }
 
   @Test
@@ -320,13 +407,28 @@ public class ModelUtilsTest {
   }
 
   @Test
+  public void testAspectClassForSnapshotInvalidSchema() {
+    assertThrows(InvalidSchemaException.class, () -> ModelUtils.aspectClassForSnapshot(EntitySnapshotInvalid.class));
+  }
+
+  @Test
   public void testUrnClassForEntity() {
     assertEquals(ModelUtils.urnClassForEntity(EntityBar.class), BarUrn.class);
   }
 
   @Test
+  public void testUrnClassForEntityInvalidSchema() {
+    assertThrows(InvalidSchemaException.class, () -> ModelUtils.urnClassForEntity(EntityFooInvalid.class));
+  }
+
+  @Test
   public void testUrnClassForSnapshot() {
     assertEquals(ModelUtils.urnClassForSnapshot(EntitySnapshot.class), Urn.class);
+  }
+
+  @Test
+  public void testUrnClassForSnapshotInvalidSchema() {
+    assertThrows(InvalidSchemaException.class, () -> ModelUtils.urnClassForSnapshot(EntitySnapshotInvalid.class));
   }
 
   @Test
@@ -337,6 +439,11 @@ public class ModelUtilsTest {
   @Test
   public void testUrnClassForDocument() {
     assertEquals(ModelUtils.urnClassForDocument(EntityDocument.class), Urn.class);
+  }
+
+  @Test
+  public void testUrnClassForDocumentInvalidSchema() {
+    assertThrows(InvalidSchemaException.class, () -> ModelUtils.urnClassForDocument(EntityDocumentInvalid.class));
   }
 
   @Test(expectedExceptions = InvalidSchemaException.class)
@@ -356,7 +463,7 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testNewRelatioshipUnion() {
+  public void testNewRelationshipUnion() {
     RelationshipFoo foo = new RelationshipFoo().setDestination(makeFooUrn(1)).setSource(makeFooUrn(2));
 
     RelationshipUnion relationshipUnion = ModelUtils.newRelationshipUnion(RelationshipUnion.class, foo);
@@ -365,7 +472,7 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testNewRelatioshipUnionAlias() {
+  public void testNewRelationshipUnionAlias() {
     RelationshipFoo foo = new RelationshipFoo().setDestination(makeFooUrn(1)).setSource(makeFooUrn(2));
 
     RelationshipUnionAlias relationshipUnion = ModelUtils.newRelationshipUnion(RelationshipUnionAlias.class, foo);

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDocumentInvalid.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDocumentInvalid.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+record EntityDocumentInvalid {
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDocumentOptionalUrn.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityDocumentOptionalUrn.pdl
@@ -1,0 +1,19 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+record EntityDocumentOptionalUrn {
+
+  /**
+   * For unit tests
+   */
+  urn: optional Urn
+
+  /**
+   * For unit tests
+   */
+  value: optional string
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityFooInvalid.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityFooInvalid.pdl
@@ -1,0 +1,7 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+record EntityFooInvalid {
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityFooOptionalUrn.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityFooOptionalUrn.pdl
@@ -1,0 +1,17 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+record EntityFooOptionalUrn {
+
+  /**
+   * For unit tests
+   */
+  urn: optional FooUrn
+
+  /**
+   * For unit tests
+   */
+  value: optional string
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotAliasOptionalFields.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotAliasOptionalFields.pdl
@@ -1,0 +1,19 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+record EntitySnapshotAliasOptionalFields {
+
+  /**
+   * For unit tests
+   */
+  urn: optional Urn
+
+  /**
+   * For unit tests
+   */
+  aspects: optional array[EntityAspectUnionAlias]
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotInvalid.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotInvalid.pdl
@@ -1,0 +1,7 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+record EntitySnapshotInvalid {
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotOptionalFields.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntitySnapshotOptionalFields.pdl
@@ -1,0 +1,19 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+record EntitySnapshotOptionalFields {
+
+  /**
+   * For unit tests
+   */
+  urn: optional Urn
+
+  /**
+   * For unit tests
+   */
+  aspects: optional array[EntityAspectUnion]
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/RelationshipFooOptionalFields.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/RelationshipFooOptionalFields.pdl
@@ -1,0 +1,33 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+@pairings = [ {
+  "destination" : "com.linkedin.common.urn.Urn",
+  "source" : "com.linkedin.common.urn.Urn"
+} ]
+record RelationshipFooOptionalFields {
+
+  /**
+   * Urn of the source entity
+   */
+  source: optional Urn
+
+  /**
+   * Urn of the destination entity
+   */
+  destination: optional Urn
+
+  /**
+   * Type attribute of the relationship
+   */
+  type: optional string
+
+  /**
+   * Integer field as a relationship attribute
+   */
+  intField: optional int
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit testing
+ */
+typeref SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields = union[
+  entity: EntitySnapshotAliasOptionalFields
+]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/SnapshotUnionWithEntitySnapshotOptionalFields.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/SnapshotUnionWithEntitySnapshotOptionalFields.pdl
@@ -1,0 +1,6 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit testing
+ */
+typeref SnapshotUnionWithEntitySnapshotOptionalFields = union[EntitySnapshotOptionalFields]

--- a/validators/src/main/java/com/linkedin/metadata/validator/DocumentValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/DocumentValidator.java
@@ -38,16 +38,12 @@ public final class DocumentValidator {
     final String className = schema.getBindingName();
 
     if (!ValidationUtils.schemaHasExactlyOneSuchField(schema, ValidationUtils::isValidUrnField)) {
-      ValidationUtils.invalidSchema("Document '%s' must contain an non-optional 'urn' field of URN type", className);
+      ValidationUtils.invalidSchema("Document '%s' must contain an 'urn' field of URN type", className);
     }
 
     ValidationUtils.fieldsUsingInvalidType(schema, ValidationUtils.PRIMITIVE_TYPES).forEach(field -> {
       ValidationUtils.invalidSchema("Document '%s' contains a field '%s' that makes use of a disallowed type '%s'.",
           className, field.getName(), field.getType().getType());
-    });
-
-    ValidationUtils.nonOptionalFields(schema, NON_OPTIONAL_FIELDS).forEach(field -> {
-      ValidationUtils.invalidSchema("Document '%s' must contain an optional '%s' field", className, field.getName());
     });
   }
 

--- a/validators/src/main/java/com/linkedin/metadata/validator/EntityValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/EntityValidator.java
@@ -4,8 +4,6 @@ import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
@@ -15,13 +13,6 @@ import javax.annotation.Nonnull;
  * Utility class to validate entity schemas.
  */
 public final class EntityValidator {
-
-  // Allowed non-optional fields. All other fields must be optional.
-  private static final Set<String> NON_OPTIONAL_FIELDS = Collections.unmodifiableSet(new HashSet<String>() {
-    {
-      add("urn");
-    }
-  });
 
   // A cache of validated classes
   private static final Set<Class<? extends RecordTemplate>> VALIDATED = ConcurrentHashMap.newKeySet();
@@ -44,16 +35,12 @@ public final class EntityValidator {
     final String className = schema.getBindingName();
 
     if (!ValidationUtils.schemaHasExactlyOneSuchField(schema, ValidationUtils::isValidUrnField)) {
-      ValidationUtils.invalidSchema("Entity '%s' must contain a non-optional 'urn' field of URN type", className);
+      ValidationUtils.invalidSchema("Entity '%s' must contain an 'urn' field of URN type", className);
     }
 
     ValidationUtils.fieldsUsingInvalidType(schema, ValidationUtils.PRIMITIVE_TYPES).forEach(field -> {
       ValidationUtils.invalidSchema("Entity '%s' contains a field '%s' that makes use of a disallowed type '%s'.",
           className, field.getName(), field.getType().getType());
-    });
-
-    ValidationUtils.nonOptionalFields(schema, NON_OPTIONAL_FIELDS).forEach(field -> {
-      ValidationUtils.invalidSchema("Entity '%s' must contain an optional '%s' field", className, field.getName());
     });
   }
 

--- a/validators/src/main/java/com/linkedin/metadata/validator/NullFieldException.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/NullFieldException.java
@@ -1,0 +1,11 @@
+package com.linkedin.metadata.validator;
+
+/**
+ * Thrown when a field which is not supposed to be null is null.
+ */
+public class NullFieldException extends RuntimeException {
+
+  public NullFieldException(String message) {
+    super(message);
+  }
+}

--- a/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/RelationshipValidator.java
@@ -44,13 +44,13 @@ public class RelationshipValidator {
 
     if (!ValidationUtils.schemaHasExactlyOneSuchField(schema,
         field -> ValidationUtils.isValidUrnField(field, "source"))) {
-      ValidationUtils.invalidSchema("Relationship '%s' must contain an non-optional 'source' field of URN type",
+      ValidationUtils.invalidSchema("Relationship '%s' must contain a 'source' field of URN type",
           className);
     }
 
     if (!ValidationUtils.schemaHasExactlyOneSuchField(schema,
         field -> ValidationUtils.isValidUrnField(field, "destination"))) {
-      ValidationUtils.invalidSchema("Relationship '%s' must contain an non-optional 'destination' field of URN type",
+      ValidationUtils.invalidSchema("Relationship '%s' must contain a 'destination' field of URN type",
           className);
     }
 

--- a/validators/src/main/java/com/linkedin/metadata/validator/SnapshotValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/SnapshotValidator.java
@@ -33,11 +33,11 @@ public class SnapshotValidator {
     final String className = schema.getBindingName();
 
     if (!ValidationUtils.schemaHasExactlyOneSuchField(schema, ValidationUtils::isValidUrnField)) {
-      ValidationUtils.invalidSchema("Snapshot '%s' must contain an non-optional 'urn' field of URN type", className);
+      ValidationUtils.invalidSchema("Snapshot '%s' must contain an 'urn' field of URN type", className);
     }
 
     if (!ValidationUtils.schemaHasExactlyOneSuchField(schema, SnapshotValidator::isValidAspectsField)) {
-      ValidationUtils.invalidSchema("Snapshot '%s' must contain an non-optional 'aspects' field of ARRAY type",
+      ValidationUtils.invalidSchema("Snapshot '%s' must contain an 'aspects' field of ARRAY type",
           className);
     }
 
@@ -75,7 +75,7 @@ public class SnapshotValidator {
   }
 
   private static boolean isValidAspectsField(@Nonnull RecordDataSchema.Field field) {
-    return field.getName().equals("aspects") && !field.getOptional()
+    return field.getName().equals("aspects")
         && field.getType().getType() == DataSchema.Type.ARRAY;
   }
 

--- a/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -199,6 +199,6 @@ public final class ValidationUtils {
   }
 
   public static void throwNullFieldException(String field) {
-    throw new NullFieldException(String.format("The %s field cannot be null.", field));
+    throw new NullFieldException(String.format("The '%s' field cannot be null.", field));
   }
 }

--- a/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -89,10 +89,10 @@ public final class ValidationUtils {
   }
 
   /**
-   * Returns true if the non-optional field matches the field name and has a URN type.
+   * Returns true if the passed-in field matches the field name and is of URN type.
    */
   public static boolean isValidUrnField(@Nonnull RecordDataSchema.Field field, @Nonnull String fieldName) {
-    return field.getName().equals(fieldName) && !field.getOptional()
+    return field.getName().equals(fieldName)
         && field.getType().getType() == DataSchema.Type.TYPEREF && Urn.class.isAssignableFrom(getUrnClass(field));
   }
 
@@ -196,5 +196,9 @@ public final class ValidationUtils {
       return type.getDereferencedType();
     }
     return type.getType();
+  }
+
+  public static void throwNullFieldException(String field) {
+    throw new NullFieldException(String.format("The %s field cannot be null.", field));
   }
 }


### PR DESCRIPTION
…r existence of previously required fields



## Summary

Doc with more context and info: https://docs.google.com/document/d/1_yFcP8PWHEvrgpTLA_7fAYsxBlqQrBDQfD6J18DC7jE/edit?usp=sharing

Tl;dr: Due to LI's Protobuf migration, the "required" concept is no longer available in Proto3 (versus PDL). GMA previously relies on schema validators to check that model definitions contain certain required fields, notably "urn" and "aspects" fields. As such, the schema validation check requirements must be loosened to support the transition to Proto3.

For all cases where schema validation happens, do a check to make sure that the previously required field indeed exists, but do not check if it's an optional or required field. In the case that an expected field does not even exist, throw an InvalidSchemaException.

Where possible, enforce that the "urn" and "aspects" fields are non-null. These runtime checks will help to ensure that bad data does not get ingested or created. In the case that a non-null field is found to be null, throw a NullFieldException.
## Testing Done

Unit tests are added to cover all of the new use cases where null fields or missing fields could happen.
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
