### PR TITLE
Introduce BaseAspectV3Resource

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/AspectKey.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/AspectKey.java
@@ -10,13 +10,13 @@ import lombok.Value;
  * A value class that holds the components of a key for metadata retrieval.
  */
 @Value
-public class AspectKey<URN extends Urn, ASPECT extends RecordTemplate> {
+public class AspectKey<ASPECT extends RecordTemplate> {
 
   @NonNull
   Class<ASPECT> aspectClass;
 
   @NonNull
-  URN urn;
+  Urn urn;
 
   @NonNull
   Long version;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -176,7 +176,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   protected final BaseTrackingMetadataEventProducer _trackingProducer;
   protected final LocalDAOStorageConfig _storageConfig;
   protected final BaseTrackingManager _trackingManager;
-  protected UrnPathExtractor<URN> _urnPathExtractor;
+  protected UrnPathExtractor _urnPathExtractor;
 
   private LambdaFunctionRegistry _lambdaFunctionRegistry;
 
@@ -220,7 +220,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param urnClass class of the URN type
    */
   public BaseLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
-      @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+      @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor urnPathExtractor) {
     super(aspectUnionClass);
     _producer = producer;
     _storageConfig = LocalDAOStorageConfig.builder().build();
@@ -241,7 +241,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param urnClass class of the URN type
    */
   public BaseLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseTrackingMetadataEventProducer trackingProducer,
-      @Nonnull BaseTrackingManager trackingManager, @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+      @Nonnull BaseTrackingManager trackingManager, @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor urnPathExtractor) {
     super(aspectUnionClass);
     _producer = null;
     _storageConfig = LocalDAOStorageConfig.builder().build();
@@ -260,7 +260,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param urnClass class of the URN type
    */
   public BaseLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull LocalDAOStorageConfig storageConfig,
-      @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+      @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor urnPathExtractor) {
     super(storageConfig.getAspectStorageConfigMap().keySet());
     _producer = producer;
     _storageConfig = storageConfig;
@@ -281,7 +281,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *
    */
   public BaseLocalDAO(@Nonnull BaseTrackingMetadataEventProducer trackingProducer, @Nonnull LocalDAOStorageConfig storageConfig,
-      @Nonnull BaseTrackingManager trackingManager, @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+      @Nonnull BaseTrackingManager trackingManager, @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor urnPathExtractor) {
     super(storageConfig.getAspectStorageConfigMap().keySet());
     _producer = null;
     _storageConfig = storageConfig;
@@ -449,7 +449,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}
    * @return {@link AddResult} corresponding to the old and new value of metadata
    */
-  private <ASPECT extends RecordTemplate> AddResult<ASPECT> addCommon(@Nonnull URN urn,
+  private <ASPECT extends RecordTemplate> AddResult<ASPECT> addCommon(@Nonnull Urn urn,
       @Nonnull AspectEntry<ASPECT> latest, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp, @Nonnull EqualityTester<ASPECT> equalityTester,
       @Nullable IngestionTrackingContext trackingContext, @Nonnull IngestionParams ingestionParams) {
@@ -586,7 +586,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     return addMany(urn, aspectUpdateLambdas, auditStamp, DEFAULT_MAX_TRANSACTION_RETRY, trackingContext);
   }
 
-  private <ASPECT extends RecordTemplate> AddResult<ASPECT> aspectUpdateHelper(URN urn, AspectUpdateLambda<ASPECT> updateTuple,
+  private <ASPECT extends RecordTemplate> AddResult<ASPECT> aspectUpdateHelper(Urn urn, AspectUpdateLambda<ASPECT> updateTuple,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext) {
     AspectEntry<ASPECT> latest = getLatest(urn, updateTuple.getAspectClass());
 
@@ -630,7 +630,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     return ModelUtils.newEntityUnion(_aspectUnionClass, rawResult);
   }
 
-  private <ASPECT extends RecordTemplate> ASPECT unwrapAddResult(URN urn, AddResult<ASPECT> result, @Nonnull AuditStamp auditStamp,
+  private <ASPECT extends RecordTemplate> ASPECT unwrapAddResult(Urn urn, AddResult<ASPECT> result, @Nonnull AuditStamp auditStamp,
       @Nullable IngestionTrackingContext trackingContext) {
     if (trackingContext != null) {
       trackingContext.setBackfill(false); // reset backfill since MAE won't be a backfill event
@@ -689,7 +689,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return {@link RecordTemplate} of the new value of aspect
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Function<Optional<ASPECT>, ASPECT> updateLambda, @Nonnull AuditStamp auditStamp,
       int maxTransactionRetry) {
     return add(urn, aspectClass, updateLambda, auditStamp, maxTransactionRetry, null);
@@ -699,7 +699,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Same as {@link #add(Urn, Class, Function, AuditStamp, int)} but with tracking context.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Function<Optional<ASPECT>, ASPECT> updateLambda, @Nonnull AuditStamp auditStamp,
       int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext) {
     return add(urn, new AspectUpdateLambda<>(aspectClass, updateLambda), auditStamp, maxTransactionRetry, trackingContext);
@@ -709,7 +709,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Same as {@link #add(Urn, Class, Function, AuditStamp, int, IngestionTrackingContext)} but with ingestion parameters.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Function<Optional<ASPECT>, ASPECT> updateLambda, @Nonnull AuditStamp auditStamp,
       int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext, @Nonnull IngestionParams ingestionParams) {
     return add(urn, new AspectUpdateLambda<>(aspectClass, updateLambda, ingestionParams), auditStamp, maxTransactionRetry, trackingContext);
@@ -732,7 +732,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return the new value of the aspect
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, AspectUpdateLambda<ASPECT> updateLambda,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, AspectUpdateLambda<ASPECT> updateLambda,
       @Nonnull AuditStamp auditStamp, int maxTransactionRetry) {
     return add(urn, updateLambda, auditStamp, maxTransactionRetry, null);
   }
@@ -741,7 +741,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Same as above {@link #add(Urn, AspectUpdateLambda, AuditStamp, int)} but with tracking context.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, AspectUpdateLambda<ASPECT> updateLambda,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, AspectUpdateLambda<ASPECT> updateLambda,
       @Nonnull AuditStamp auditStamp, int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext) {
     checkValidAspect(updateLambda.getAspectClass());
 
@@ -800,7 +800,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Same as above {@link #add(Urn, Class, Function, AuditStamp)} but with tracking context.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Function<Optional<ASPECT>, ASPECT> updateLambda, @Nonnull AuditStamp auditStamp,
       @Nullable IngestionTrackingContext trackingContext, @Nonnull IngestionParams ingestionParams) {
     return add(urn, aspectClass, updateLambda, auditStamp, DEFAULT_MAX_TRANSACTION_RETRY, trackingContext, ingestionParams);
@@ -811,7 +811,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @VisibleForTesting
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull ASPECT newValue,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull ASPECT newValue,
       @Nonnull AuditStamp auditStamp) {
     return add(urn, newValue, auditStamp, null, null);
   }
@@ -820,7 +820,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Same as above {@link #add(Urn, RecordTemplate, AuditStamp)} but with tracking context.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull ASPECT newValue,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull ASPECT newValue,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionParams ingestionParams) {
     final IngestionParams nonNullIngestionParams = ingestionParams == null ? new IngestionParams().setIngestionMode(IngestionMode.LIVE) : ingestionParams;
     return add(urn, (Class<ASPECT>) newValue.getClass(), ignored -> newValue, auditStamp, trackingContext, nonNullIngestionParams);
@@ -844,7 +844,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     delete(urn, aspectClass, auditStamp, DEFAULT_MAX_TRANSACTION_RETRY, trackingContext);
   }
 
-  private <ASPECT extends RecordTemplate> void applyRetention(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  private <ASPECT extends RecordTemplate> void applyRetention(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Retention retention, long largestVersion) {
     if (retention instanceof IndefiniteRetention) {
       return;
@@ -873,7 +873,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param isSoftDeleted flag to indicate if the previous latest value of aspect was soft deleted
    * @return the largest version
    */
-  protected abstract <ASPECT extends RecordTemplate> long saveLatest(@Nonnull URN urn,
+  protected abstract <ASPECT extends RecordTemplate> long saveLatest(@Nonnull Urn urn,
       @Nonnull Class<ASPECT> aspectClass, @Nullable ASPECT oldEntry, @Nullable AuditStamp oldAuditStamp,
       @Nullable ASPECT newEntry, @Nonnull AuditStamp newAuditStamp, boolean isSoftDeleted,
       @Nullable IngestionTrackingContext trackingContext);
@@ -885,7 +885,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param urn the URN for the entity the aspect is attached to
    * @param aspectClass class of the aspect to backfill
    */
-  public abstract <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass);
+  public abstract <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass);
 
   /**
    * Backfill local relationships from the new schema entity tables. This method is new/dual schema only. It should NOT
@@ -913,10 +913,10 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return List of urns from local secondary index that satisfy the given filter conditions
    */
   @Nonnull
-  public abstract List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-      @Nullable URN lastUrn, int pageSize);
+  public abstract List<Urn> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+      @Nullable Urn lastUrn, int pageSize);
 
-  public List<URN> listUrns(@Nullable String lastUrn, int pageSize, @Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion) {
+  public List<Urn> listUrns(@Nullable String lastUrn, int pageSize, @Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion) {
     return listUrns(indexFilter, indexSortCriterion, getUrnFromString(lastUrn, _urnClass), pageSize);
   }
 
@@ -924,7 +924,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int)} but sorts lexicographically by the URN.
    */
   @Nonnull
-  public List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
+  public List<Urn> listUrns(@Nullable IndexFilter indexFilter, @Nullable Urn lastUrn, int pageSize) {
     return listUrns(indexFilter, null, lastUrn, pageSize);
   }
 
@@ -936,14 +936,14 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return a {@link ListResult} containing a list of urns and other pagination information
    */
   @Nonnull
-  public abstract <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nullable IndexFilter indexFilter,
+  public abstract <ASPECT extends RecordTemplate> ListResult<Urn> listUrns(@Nullable IndexFilter indexFilter,
       @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize);
 
   /**
    * Similar to {@link #listUrns(IndexFilter, Urn, int)}. This is to get all urns with type URN.
    */
   @Nonnull
-  public List<URN> listUrns(@Nonnull Class<URN> urnClazz, @Nullable URN lastUrn, int pageSize) {
+  public List<Urn> listUrns(@Nonnull Class<?> urnClazz, @Nullable Urn lastUrn, int pageSize) {
     final IndexFilter indexFilter = new IndexFilter().setCriteria(
         new IndexCriterionArray(new IndexCriterion().setAspect(urnClazz.getCanonicalName())));
     return listUrns(indexFilter, lastUrn, pageSize);
@@ -957,13 +957,13 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return list of latest versions of aspects along with urns
    */
   @Nonnull
-  private List<UrnAspectEntry<URN>> getUrnAspectEntries(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      @Nonnull List<URN> urns) {
-    final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnAspectMap =
+  private List<UrnAspectEntry> getUrnAspectEntries(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
+      @Nonnull List<Urn> urns) {
+    final Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnAspectMap =
         get(aspectClasses, new HashSet<>(urns));
 
-    final Map<URN, List<RecordTemplate>> urnListAspectMap = new LinkedHashMap<>();
-    for (URN urn : urns) {
+    final Map<Urn, List<RecordTemplate>> urnListAspectMap = new LinkedHashMap<>();
+    for (Urn urn : urns) {
       final Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspectMap = urnAspectMap.get(urn);
       urnListAspectMap.compute(urn, (k, v) -> {
         if (v == null) {
@@ -978,7 +978,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     return urnListAspectMap.entrySet()
         .stream()
-        .map(entry -> new UrnAspectEntry<>(entry.getKey(), entry.getValue()))
+        .map(entry -> new UrnAspectEntry(entry.getKey(), entry.getValue()))
         .collect(Collectors.toList());
   }
 
@@ -996,11 +996,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *        satisfying given filter conditions
    */
   @Nonnull
-  public List<UrnAspectEntry<URN>> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      @Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, @Nullable URN lastUrn,
+  public List<UrnAspectEntry> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
+      @Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, @Nullable Urn lastUrn,
       int pageSize) {
 
-    final List<URN> urns = listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize);
+    final List<Urn> urns = listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize);
 
     return getUrnAspectEntries(aspectClasses, urns);
   }
@@ -1010,7 +1010,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * but sorts lexicographically by the URN.
    */
   @Nonnull
-  public List<UrnAspectEntry<URN>> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
+  public List<UrnAspectEntry> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
       @Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
     return getAspects(aspectClasses, indexFilter, null, lastUrn, pageSize);
   }
@@ -1024,15 +1024,15 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *        local secondary index satisfying given filter conditions and pagination information
    */
   @Nonnull
-  public ListResult<UrnAspectEntry<URN>> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
+  public ListResult<UrnAspectEntry> getAspects(@Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
       @Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
 
-    final ListResult<URN> listResult = listUrns(indexFilter, indexSortCriterion, start, pageSize);
-    final List<URN> urns = listResult.getValues();
+    final ListResult<Urn> listResult = listUrns(indexFilter, indexSortCriterion, start, pageSize);
+    final List<Urn> urns = listResult.getValues();
 
-    final List<UrnAspectEntry<URN>> urnAspectEntries = getUrnAspectEntries(aspectClasses, urns);
+    final List<UrnAspectEntry> urnAspectEntries = getUrnAspectEntries(aspectClasses, urns);
 
-    return ListResult.<UrnAspectEntry<URN>>builder().values(urnAspectEntries)
+    return ListResult.<UrnAspectEntry>builder().values(urnAspectEntries)
         .metadata(listResult.getMetadata())
         .nextStart(listResult.getNextStart())
         .havingMore(listResult.isHavingMore())
@@ -1061,7 +1061,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return {@link AspectEntry} corresponding to the latest version of specific aspect, if it exists
    */
   @Nonnull
-  protected abstract <ASPECT extends RecordTemplate> AspectEntry<ASPECT> getLatest(@Nonnull URN urn,
+  protected abstract <ASPECT extends RecordTemplate> AspectEntry<ASPECT> getLatest(@Nonnull Urn urn,
       @Nonnull Class<ASPECT> aspectClass);
 
   /**
@@ -1071,7 +1071,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param aspectClass the type of aspect to get
    * @return the next version number to use, or {@link #LATEST_VERSION} if there's no previous versions
    */
-  protected abstract <ASPECT extends RecordTemplate> long getNextVersion(@Nonnull URN urn,
+  protected abstract <ASPECT extends RecordTemplate> long getNextVersion(@Nonnull Urn urn,
       @Nonnull Class<ASPECT> aspectClass);
 
   /**
@@ -1083,7 +1083,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param auditStamp the {@link AuditStamp} for the aspect
    * @param version the version for the aspect
    */
-  protected abstract <ASPECT extends RecordTemplate> void insert(@Nonnull URN urn, @Nullable RecordTemplate value,
+  protected abstract <ASPECT extends RecordTemplate> void insert(@Nonnull Urn urn, @Nullable RecordTemplate value,
       @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp, long version,
       @Nullable IngestionTrackingContext trackingContext);
 
@@ -1097,7 +1097,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param version the version for the aspect
    * @param oldTimestamp the timestamp for the old aspect
    */
-  protected abstract <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull URN urn,
+  protected abstract <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull Urn urn,
       @Nullable RecordTemplate value, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp newAuditStamp,
       long version, @Nonnull Timestamp oldTimestamp, @Nullable IngestionTrackingContext trackingContext);
 
@@ -1117,7 +1117,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param largestVersion the largest version number for the aspect type
    */
   protected abstract <ASPECT extends RecordTemplate> void applyVersionBasedRetention(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull URN urn, @Nonnull VersionBasedRetention retention, long largestVersion);
+      @Nonnull Urn urn, @Nonnull VersionBasedRetention retention, long largestVersion);
 
   /**
    * Applies time-based retention against a specific aspect type for an entity.
@@ -1128,7 +1128,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param currentTime the current timestamp
    */
   protected abstract <ASPECT extends RecordTemplate> void applyTimeBasedRetention(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull URN urn, @Nonnull TimeBasedRetention retention, long currentTime);
+      @Nonnull Urn urn, @Nonnull TimeBasedRetention retention, long currentTime);
 
   /**
    * Emits backfill MAE for the latest version of an aspect and also backfills SCSI (if it exists and is enabled).
@@ -1141,7 +1141,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull URN urn) {
+      @Nonnull Urn urn) {
     return backfill(BackfillMode.BACKFILL_ALL, aspectClass, urn);
   }
 
@@ -1152,7 +1152,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   private <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull BackfillMode mode,
-      @Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn) {
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull Urn urn) {
     checkValidAspect(aspectClass);
     Optional<ASPECT> aspect = get(aspectClass, urn, LATEST_VERSION);
     aspect.ifPresent(value -> backfill(mode, value, urn));
@@ -1167,8 +1167,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return map of urn to their backfilled aspect values
    */
   @Nonnull
-  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
+  public Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<Urn> urns) {
     return backfill(BackfillMode.BACKFILL_ALL, aspectClasses, urns);
   }
 
@@ -1183,8 +1183,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Deprecated
   @Nonnull
-  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillWithNewValue(
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
+  public Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillWithNewValue(
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<Urn> urns) {
     return backfill(BackfillMode.MAE_ONLY_WITH_OLD_VALUE_NULL, aspectClasses, urns);
   }
 
@@ -1196,12 +1196,12 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param urns  set of urns to backfill
    */
   @Nonnull
-  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
-      @Nonnull BackfillMode mode, @Nullable Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
+  public Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
+      @Nonnull BackfillMode mode, @Nullable Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<Urn> urns) {
     Set<Class<? extends RecordTemplate>> aspectToBackfill =
         aspectClasses == null ? getValidAspectTypes(_aspectUnionClass) : aspectClasses;
     checkValidAspects(aspectToBackfill);
-    final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnToAspects =
+    final Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnToAspects =
         get(aspectToBackfill, urns);
     urnToAspects.forEach((urn, aspects) -> {
       aspects.forEach((aspectClass, aspect) -> aspect.ifPresent(value -> backfill(mode, value, urn)));
@@ -1225,7 +1225,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     if (_urnClass == null) { // _urnClass can be null in testing scenarios
       throw new IllegalStateException("urn class is null, unable to convert string to urn");
     }
-    final Set<URN> urnSet = urns.stream().map(x -> getUrnFromString(x, _urnClass)).collect(Collectors.toSet());
+    final Set<Urn> urnSet = urns.stream().map(x -> getUrnFromString(x, _urnClass)).collect(Collectors.toSet());
 
     // convert string to aspect class
     Set<Class<? extends RecordTemplate>> aspectSet = null;
@@ -1238,8 +1238,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   @Nonnull
-  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillEntityTables(
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
+  public Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillEntityTables(
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<Urn> urns) {
     urns.forEach(urn -> aspectClasses.forEach(aspect -> updateEntityTables(urn, aspect)));
     return get(aspectClasses, urns);
   }
@@ -1258,9 +1258,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   @Nonnull
   public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
       @Nonnull BackfillMode mode, @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      @Nonnull Class<URN> urnClazz, @Nullable URN lastUrn, int pageSize) {
+      @Nonnull Class<?> urnClazz, @Nullable Urn lastUrn, int pageSize) {
 
-    final List<URN> urnList = listUrns(urnClazz, lastUrn, pageSize);
+    final List<Urn> urnList = listUrns(urnClazz, lastUrn, pageSize);
     return backfill(mode, aspectClasses, new HashSet(urnList));
   }
 
@@ -1273,7 +1273,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
    */
   private <ASPECT extends RecordTemplate> void backfill(@Nonnull BackfillMode mode, @Nonnull ASPECT aspect,
-      @Nonnull URN urn) {
+      @Nonnull Urn urn) {
 
     if (mode == BackfillMode.MAE_ONLY
         || mode == BackfillMode.BACKFILL_ALL
@@ -1379,15 +1379,15 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return a mapping of given keys to the corresponding metadata aspect and {@link ExtraInfo}.
    */
   @Nonnull
-  public abstract Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
-      @Nonnull Set<AspectKey<URN, ? extends RecordTemplate>> keys);
+  public abstract Map<AspectKey<? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
+      @Nonnull Set<AspectKey<? extends RecordTemplate>> keys);
 
   /**
    * Similar to {@link #getWithExtraInfo(Set)} but only using only one {@link AspectKey}.
    */
   @Nonnull
   public <ASPECT extends RecordTemplate> Optional<AspectWithExtraInfo<ASPECT>> getWithExtraInfo(
-      @Nonnull AspectKey<URN, ASPECT> key) {
+      @Nonnull AspectKey<ASPECT> key) {
     if (getWithExtraInfo(Collections.singleton(key)).containsKey(key)) {
       return Optional.of((AspectWithExtraInfo<ASPECT>) getWithExtraInfo(Collections.singleton(key)).get(key));
     }
@@ -1399,7 +1399,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   public <ASPECT extends RecordTemplate> Optional<AspectWithExtraInfo<ASPECT>> getWithExtraInfo(
-      @Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn, long version) {
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull Urn urn, long version) {
     return getWithExtraInfo(new AspectKey<>(aspectClass, urn, version));
   }
 
@@ -1457,9 +1457,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    */
   @Nonnull
   protected Map<String, Set<String>> transformBackfillResultsToStringMap(
-      @Nonnull Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillResults) {
+      @Nonnull Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillResults) {
     Map<String, Set<String>> mapToReturn = new HashMap<>();
-    for (URN urn: backfillResults.keySet()) {
+    for (Urn urn: backfillResults.keySet()) {
       Set<String> aspectFqcnSetToReturn = new HashSet<>();
       Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspectClassToMetadataMap = backfillResults.get(urn);
 
@@ -1537,7 +1537,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * The logic determines if we will update the aspect.
    */
-  private <ASPECT extends RecordTemplate> boolean shouldUpdateAspect(IngestionMode ingestionMode, URN urn, ASPECT oldValue,
+  private <ASPECT extends RecordTemplate> boolean shouldUpdateAspect(IngestionMode ingestionMode, Urn urn, ASPECT oldValue,
       ASPECT newValue, Class<ASPECT> aspectClass, AuditStamp auditStamp, EqualityTester<ASPECT> equalityTester) {
 
     final boolean oldAndNewEqual = (oldValue == null && newValue == null) || (oldValue != null && newValue != null && equalityTester.equals(
@@ -1595,7 +1595,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Update the aspect value with pre-defined lambda functions.
    */
   @Nonnull
-  protected <ASPECT extends RecordTemplate> ASPECT updatePreIngestionLambdas(@Nonnull URN urn,
+  protected <ASPECT extends RecordTemplate> ASPECT updatePreIngestionLambdas(@Nonnull Urn urn,
       @Nullable Optional<ASPECT> oldValue, @Nonnull ASPECT newValue) {
     for (final BaseLambdaFunction function : _lambdaFunctionRegistry.getLambdaFunctions(newValue)) {
       newValue = (ASPECT) function.apply(urn, oldValue, newValue);

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 
-public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate> {
+public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn> {
 
   public static final long FIRST_VERSION = 0;
   public static final long LATEST_VERSION = 0;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 
-public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn> {
+public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate> {
 
   public static final long FIRST_VERSION = 0;
   public static final long LATEST_VERSION = 0;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
@@ -41,14 +41,14 @@ public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extend
    * @return a mapping of given keys to the corresponding metadata aspect.
    */
   @Nonnull
-  public abstract Map<AspectKey<URN, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
-      @Nonnull Set<AspectKey<URN, ? extends RecordTemplate>> keys);
+  public abstract Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
+      @Nonnull Set<AspectKey<? extends RecordTemplate>> keys);
 
   /**
    * Similar to {@link #get(Set)} but only using only one {@link AspectKey}.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> Optional<ASPECT> get(@Nonnull AspectKey<URN, ASPECT> key) {
+  public <ASPECT extends RecordTemplate> Optional<ASPECT> get(@Nonnull AspectKey<ASPECT> key) {
     return (Optional<ASPECT>) get(Collections.singleton(key)).get(key);
   }
 
@@ -56,7 +56,7 @@ public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extend
    * Similar to {@link #get(AspectKey)} but with each component of the key broken out as arguments.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> Optional<ASPECT> get(@Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn,
+  public <ASPECT extends RecordTemplate> Optional<ASPECT> get(@Nonnull Class<ASPECT> aspectClass, @Nonnull Urn urn,
       long version) {
     return get(new AspectKey<>(aspectClass, urn, version));
   }
@@ -65,7 +65,7 @@ public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extend
    * Similar to {@link #get(Class, Urn, long)} but always retrieves the latest version.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> Optional<ASPECT> get(@Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn) {
+  public <ASPECT extends RecordTemplate> Optional<ASPECT> get(@Nonnull Class<ASPECT> aspectClass, @Nonnull Urn urn) {
     return get(aspectClass, urn, LATEST_VERSION);
   }
 
@@ -75,21 +75,21 @@ public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extend
    * <p>The returned {@link Map} contains all the .
    */
   @Nonnull
-  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> get(
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
+  public Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> get(
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<Urn> urns) {
 
 
-    final Set<AspectKey<URN, ? extends RecordTemplate>> keys = new HashSet<>();
-    for (URN urn : urns) {
+    final Set<AspectKey<? extends RecordTemplate>> keys = new HashSet<>();
+    for (Urn urn : urns) {
       for (Class<? extends RecordTemplate> aspect : aspectClasses) {
         keys.add(new AspectKey<>(aspect, urn, LATEST_VERSION));
       }
     }
 
-    final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> results = new HashMap<>();
+    final Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> results = new HashMap<>();
     get(keys).entrySet().forEach(entry -> {
-      final AspectKey<URN, ? extends RecordTemplate> key = entry.getKey();
-      final URN urn = key.getUrn();
+      final AspectKey<? extends RecordTemplate> key = entry.getKey();
+      final Urn urn = key.getUrn();
       results.putIfAbsent(urn, new HashMap<>());
       results.get(urn).put(key.getAspectClass(), entry.getValue());
     });
@@ -102,9 +102,9 @@ public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extend
    */
   @Nonnull
   public Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull URN urn) {
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Urn urn) {
 
-    Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> results =
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> results =
         get(aspectClasses, Collections.singleton(urn));
     if (!results.containsKey(urn)) {
       throw new IllegalStateException("Results should contain " + urn);
@@ -117,8 +117,8 @@ public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extend
    * Similar to {@link #get(Set, Set)} but only for one aspect.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> Map<URN, Optional<ASPECT>> get(
-      @Nonnull Class<ASPECT> aspectClass, @Nonnull Set<URN> urns) {
+  public <ASPECT extends RecordTemplate> Map<Urn, Optional<ASPECT>> get(
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull Set<Urn> urns) {
 
     return get(Collections.singleton(aspectClass), urns).entrySet()
         .stream()

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/UrnAspectEntry.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/UrnAspectEntry.java
@@ -11,10 +11,10 @@ import lombok.Value;
  * A value class that holds urn of a given entity and list of aspects (as {@link RecordTemplate}) associated with the urn.
  */
 @Value
-public class UrnAspectEntry<URN extends Urn> {
+public class UrnAspectEntry {
 
   @NonNull
-  URN urn;
+  Urn urn;
 
   @NonNull
   List<RecordTemplate> aspects;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/urnpath/EmptyPathExtractor.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/urnpath/EmptyPathExtractor.java
@@ -9,10 +9,10 @@ import javax.annotation.Nonnull;
 /**
  * A path extractor which does nothing.
  */
-public final class EmptyPathExtractor<URN extends Urn> implements UrnPathExtractor<URN> {
+public final class EmptyPathExtractor implements UrnPathExtractor {
   @Nonnull
   @Override
-  public Map<String, Object> extractPaths(@Nonnull URN urn) {
+  public Map<String, Object> extractPaths(@Nonnull Urn urn) {
     return Collections.emptyMap();
   }
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/urnpath/UrnPathExtractor.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/urnpath/UrnPathExtractor.java
@@ -21,9 +21,8 @@ import javax.annotation.Nonnull;
  *   /origin -&gt; %ORIGIN%
  * </pre>
  *
- * @param <URN> the concrete URN type this can extract paths from
  */
-public interface UrnPathExtractor<URN extends Urn> {
+public interface UrnPathExtractor {
   @Nonnull
-  Map<String, Object> extractPaths(@Nonnull URN urn);
+  Map<String, Object> extractPaths(@Nonnull Urn urn);
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOAspectVersionTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOAspectVersionTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao;
 import static com.linkedin.metadata.dao.BaseLocalDAOTest.DummyLocalDAO;
 import static com.linkedin.metadata.dao.BaseLocalDAOTest.DummyTransactionRunner;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.producer.BaseMetadataEventProducer;
@@ -36,7 +37,7 @@ public class BaseLocalDAOAspectVersionTest {
   private BaseMetadataEventProducer _mockEventProducer;
   private BaseTrackingMetadataEventProducer _mockTrackingEventProducer;
   private BaseTrackingManager _mockTrackingManager;
-  private BiFunction<FooUrn, Class<? extends RecordTemplate>, BaseLocalDAO.AspectEntry> _mockGetLatestFunction;
+  private BiFunction<Urn, Class<? extends RecordTemplate>, BaseLocalDAO.AspectEntry> _mockGetLatestFunction;
   private DummyTransactionRunner _mockTransactionRunner;
 
   @BeforeMethod
@@ -62,7 +63,7 @@ public class BaseLocalDAOAspectVersionTest {
     return new BaseLocalDAO.AspectEntry<>(aspect, extraInfo);
   }
 
-  private <T extends RecordTemplate> void expectGetLatest(FooUrn urn, Class<T> aspectClass,
+  private <T extends RecordTemplate> void expectGetLatest(Urn urn, Class<T> aspectClass,
       List<BaseLocalDAO.AspectEntry<T>> returnValues) {
     OngoingStubbing<BaseLocalDAO.AspectEntry<T>> ongoing = when(_mockGetLatestFunction.apply(urn, aspectClass));
     for (BaseLocalDAO.AspectEntry<T> value : returnValues) {

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.dao;
 
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.UnionTemplate;
@@ -59,32 +60,32 @@ public class BaseLocalDAOTest {
 
   static class DummyLocalDAO<ENTITY_ASPECT_UNION extends UnionTemplate> extends BaseLocalDAO<ENTITY_ASPECT_UNION, FooUrn> {
 
-    private final BiFunction<FooUrn, Class<? extends RecordTemplate>, AspectEntry> _getLatestFunction;
+    private final BiFunction<Urn, Class<? extends RecordTemplate>, AspectEntry> _getLatestFunction;
     private final DummyTransactionRunner _transactionRunner;
 
-    public DummyLocalDAO(Class<ENTITY_ASPECT_UNION> aspectClass, BiFunction<FooUrn, Class<? extends RecordTemplate>, AspectEntry> getLatestFunction,
+    public DummyLocalDAO(Class<ENTITY_ASPECT_UNION> aspectClass, BiFunction<Urn, Class<? extends RecordTemplate>, AspectEntry> getLatestFunction,
         BaseMetadataEventProducer eventProducer, DummyTransactionRunner transactionRunner) {
-      super(aspectClass, eventProducer, FooUrn.class, new EmptyPathExtractor<>());
+      super(aspectClass, eventProducer, FooUrn.class, new EmptyPathExtractor());
       _getLatestFunction = getLatestFunction;
       _transactionRunner = transactionRunner;
     }
 
-    public DummyLocalDAO(Class<ENTITY_ASPECT_UNION> aspectClass, BiFunction<FooUrn, Class<? extends RecordTemplate>, AspectEntry> getLatestFunction,
+    public DummyLocalDAO(Class<ENTITY_ASPECT_UNION> aspectClass, BiFunction<Urn, Class<? extends RecordTemplate>, AspectEntry> getLatestFunction,
         BaseTrackingMetadataEventProducer eventProducer, BaseTrackingManager trackingManager, DummyTransactionRunner transactionRunner) {
-      super(aspectClass, eventProducer, trackingManager, FooUrn.class, new EmptyPathExtractor<>());
+      super(aspectClass, eventProducer, trackingManager, FooUrn.class, new EmptyPathExtractor());
       _getLatestFunction = getLatestFunction;
       _transactionRunner = transactionRunner;
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> long saveLatest(FooUrn urn, Class<ASPECT> aspectClass, ASPECT oldEntry,
+    protected <ASPECT extends RecordTemplate> long saveLatest(Urn urn, Class<ASPECT> aspectClass, ASPECT oldEntry,
         AuditStamp oldAuditStamp, ASPECT newEntry, AuditStamp newAuditStamp, boolean isSoftDeleted,
         @Nullable IngestionTrackingContext trackingContext) {
       return 0;
     }
 
     @Override
-    public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull FooUrn urn, @Nonnull Class<ASPECT> aspectClass) {
+    public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass) {
 
     }
 
@@ -101,23 +102,23 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> AspectEntry<ASPECT> getLatest(FooUrn urn, Class<ASPECT> aspectClass) {
+    protected <ASPECT extends RecordTemplate> AspectEntry<ASPECT> getLatest(Urn urn, Class<ASPECT> aspectClass) {
       return _getLatestFunction.apply(urn, aspectClass);
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> long getNextVersion(FooUrn urn, Class<ASPECT> aspectClass) {
+    protected <ASPECT extends RecordTemplate> long getNextVersion(Urn urn, Class<ASPECT> aspectClass) {
       return 0;
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> void insert(FooUrn urn, RecordTemplate value, Class<ASPECT> aspectClass,
+    protected <ASPECT extends RecordTemplate> void insert(Urn urn, RecordTemplate value, Class<ASPECT> aspectClass,
         AuditStamp auditStamp, long version, @Nullable IngestionTrackingContext trackingContext) {
 
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull FooUrn urn,
+    protected <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull Urn urn,
         @Nullable RecordTemplate value, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp newAuditStamp,
         long version, @Nonnull Timestamp oldTimestamp, @Nullable IngestionTrackingContext trackingContext) {
 
@@ -129,13 +130,13 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> void applyVersionBasedRetention(Class<ASPECT> aspectClass, FooUrn urn,
+    protected <ASPECT extends RecordTemplate> void applyVersionBasedRetention(Class<ASPECT> aspectClass, Urn urn,
         VersionBasedRetention retention, long largestVersion) {
 
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> void applyTimeBasedRetention(Class<ASPECT> aspectClass, FooUrn urn,
+    protected <ASPECT extends RecordTemplate> void applyTimeBasedRetention(Class<ASPECT> aspectClass, Urn urn,
         TimeBasedRetention retention, long currentTime) {
 
     }
@@ -153,8 +154,8 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    public List<FooUrn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-        @Nullable FooUrn lastUrn, int pageSize) {
+    public List<Urn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+        @Nullable Urn lastUrn, int pageSize) {
       return null;
     }
 
@@ -193,15 +194,15 @@ public class BaseLocalDAOTest {
 
     @Override
     @Nonnull
-    public Map<AspectKey<FooUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
-        Set<AspectKey<FooUrn, ? extends RecordTemplate>> aspectKeys) {
+    public Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
+        Set<AspectKey<? extends RecordTemplate>> aspectKeys) {
       return Collections.emptyMap();
     }
 
     @Override
     @Nonnull
-    public Map<AspectKey<FooUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
-        @Nonnull Set<AspectKey<FooUrn, ? extends RecordTemplate>> keys) {
+    public Map<AspectKey<? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
+        @Nonnull Set<AspectKey<? extends RecordTemplate>> keys) {
       return Collections.emptyMap();
     }
   }
@@ -211,7 +212,7 @@ public class BaseLocalDAOTest {
   private BaseMetadataEventProducer _mockEventProducer;
   private BaseTrackingMetadataEventProducer _mockTrackingEventProducer;
   private BaseTrackingManager _mockTrackingManager;
-  private BiFunction<FooUrn, Class<? extends RecordTemplate>, BaseLocalDAO.AspectEntry> _mockGetLatestFunction;
+  private BiFunction<Urn, Class<? extends RecordTemplate>, BaseLocalDAO.AspectEntry> _mockGetLatestFunction;
   private DummyTransactionRunner _mockTransactionRunner;
 
   @BeforeMethod

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -262,7 +262,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+      @Nonnull UrnPathExtractor urnPathExtractor) {
     this(producer, createServer(serverConfig), storageConfig, urnClass, urnPathExtractor);
   }
 
@@ -278,7 +278,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public EbeanLocalDAO(@Nonnull BaseTrackingMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull UrnPathExtractor<URN> urnPathExtractor, @Nonnull BaseTrackingManager trackingManager) {
+      @Nonnull UrnPathExtractor urnPathExtractor, @Nonnull BaseTrackingManager trackingManager) {
     this(producer, createServer(serverConfig), storageConfig, urnClass, urnPathExtractor, trackingManager);
   }
 
@@ -294,7 +294,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull UrnPathExtractor<URN> urnPathExtractor, @Nonnull SchemaConfig schemaConfig) {
+      @Nonnull UrnPathExtractor urnPathExtractor, @Nonnull SchemaConfig schemaConfig) {
     this(producer, createServer(serverConfig), serverConfig, storageConfig, urnClass, urnPathExtractor, schemaConfig);
   }
 
@@ -311,7 +311,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public EbeanLocalDAO(@Nonnull BaseTrackingMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull UrnPathExtractor<URN> urnPathExtractor, @Nonnull SchemaConfig schemaConfig, @Nonnull BaseTrackingManager trackingManager) {
+      @Nonnull UrnPathExtractor urnPathExtractor, @Nonnull SchemaConfig schemaConfig, @Nonnull BaseTrackingManager trackingManager) {
     this(producer, createServer(serverConfig), serverConfig, storageConfig, urnClass, urnPathExtractor, schemaConfig, trackingManager);
   }
 
@@ -325,7 +325,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass) {
-    this(producer, createServer(serverConfig), storageConfig, urnClass, new EmptyPathExtractor<>());
+    this(producer, createServer(serverConfig), storageConfig, urnClass, new EmptyPathExtractor());
   }
 
   /**
@@ -339,7 +339,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public EbeanLocalDAO(@Nonnull BaseTrackingMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass, @Nonnull BaseTrackingManager trackingManager) {
-    this(producer, createServer(serverConfig), storageConfig, urnClass, new EmptyPathExtractor<>(), trackingManager);
+    this(producer, createServer(serverConfig), storageConfig, urnClass, new EmptyPathExtractor(), trackingManager);
   }
 
   /**
@@ -353,7 +353,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass, @Nonnull SchemaConfig schemaConfig) {
-    this(producer, createServer(serverConfig), serverConfig, storageConfig, urnClass, new EmptyPathExtractor<>(), schemaConfig);
+    this(producer, createServer(serverConfig), serverConfig, storageConfig, urnClass, new EmptyPathExtractor(), schemaConfig);
   }
 
   /**
@@ -369,7 +369,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   public EbeanLocalDAO(@Nonnull BaseTrackingMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass, @Nonnull SchemaConfig schemaConfig,
       @Nonnull BaseTrackingManager trackingManager) {
-    this(producer, createServer(serverConfig), serverConfig, storageConfig, urnClass, new EmptyPathExtractor<>(), schemaConfig, trackingManager);
+    this(producer, createServer(serverConfig), serverConfig, storageConfig, urnClass, new EmptyPathExtractor(), schemaConfig, trackingManager);
   }
 
   public EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseTrackingMetadataEventProducer producer,
@@ -379,14 +379,14 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   private EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
       @Nonnull EbeanServer server, @Nonnull Class<URN> urnClass) {
-    super(aspectUnionClass, producer, urnClass, new EmptyPathExtractor<>());
+    super(aspectUnionClass, producer, urnClass, new EmptyPathExtractor());
     _server = server;
     _urnClass = urnClass;
   }
 
   private EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseTrackingMetadataEventProducer producer,
       @Nonnull EbeanServer server, @Nonnull Class<URN> urnClass, @Nonnull BaseTrackingManager trackingManager) {
-    super(aspectUnionClass, producer, trackingManager, urnClass, new EmptyPathExtractor<>());
+    super(aspectUnionClass, producer, trackingManager, urnClass, new EmptyPathExtractor());
     _server = server;
     _urnClass = urnClass;
   }
@@ -449,7 +449,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @VisibleForTesting
   EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull EbeanServer server,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+      @Nonnull UrnPathExtractor urnPathExtractor) {
     super(producer, storageConfig, urnClass, urnPathExtractor);
     _server = server;
     _urnClass = urnClass;
@@ -457,7 +457,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   private EbeanLocalDAO(@Nonnull BaseTrackingMetadataEventProducer producer, @Nonnull EbeanServer server,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull UrnPathExtractor<URN> urnPathExtractor, @Nonnull BaseTrackingManager trackingManager) {
+      @Nonnull UrnPathExtractor urnPathExtractor, @Nonnull BaseTrackingManager trackingManager) {
     super(producer, storageConfig, trackingManager, urnClass, urnPathExtractor);
     _server = server;
     _urnClass = urnClass;
@@ -465,7 +465,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   private EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull EbeanServer server,
       @Nonnull ServerConfig serverConfig, @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass,
-      @Nonnull UrnPathExtractor<URN> urnPathExtractor, @Nonnull SchemaConfig schemaConfig) {
+      @Nonnull UrnPathExtractor urnPathExtractor, @Nonnull SchemaConfig schemaConfig) {
     this(producer, server, storageConfig, urnClass, urnPathExtractor);
     _schemaConfig = schemaConfig;
     if (schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
@@ -474,7 +474,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   private EbeanLocalDAO(@Nonnull BaseTrackingMetadataEventProducer producer, @Nonnull EbeanServer server, @Nonnull ServerConfig serverConfig,
-      @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor<URN> urnPathExtractor,
+      @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass, @Nonnull UrnPathExtractor urnPathExtractor,
       @Nonnull SchemaConfig schemaConfig, @Nonnull BaseTrackingManager trackingManager) {
     this(producer, server, storageConfig, urnClass, urnPathExtractor, trackingManager);
     _schemaConfig = schemaConfig;
@@ -486,16 +486,16 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @VisibleForTesting
   EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull EbeanServer server,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass) {
-    this(producer, server, storageConfig, urnClass, new EmptyPathExtractor<>());
+    this(producer, server, storageConfig, urnClass, new EmptyPathExtractor());
   }
 
   @VisibleForTesting
   EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull EbeanServer server, @Nonnull ServerConfig serverConfig,
       @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass, @Nonnull SchemaConfig schemaConfig) {
-    this(producer, server, serverConfig, storageConfig, urnClass, new EmptyPathExtractor<>(), schemaConfig);
+    this(producer, server, serverConfig, storageConfig, urnClass, new EmptyPathExtractor(), schemaConfig);
   }
 
-  public void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+  public void setUrnPathExtractor(@Nonnull UrnPathExtractor urnPathExtractor) {
     if (_schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
       _localAccess.setUrnPathExtractor(urnPathExtractor);
     }
@@ -503,7 +503,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  public UrnPathExtractor<URN> getUrnPathExtractor() {
+  public UrnPathExtractor getUrnPathExtractor() {
     return _urnPathExtractor;
   }
 
@@ -567,7 +567,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  protected <ASPECT extends RecordTemplate> long saveLatest(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  protected <ASPECT extends RecordTemplate> long saveLatest(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nullable ASPECT oldValue, @Nullable AuditStamp oldAuditStamp, @Nullable ASPECT newValue,
       @Nonnull AuditStamp newAuditStamp, boolean isSoftDeleted, @Nullable IngestionTrackingContext trackingContext) {
     // Save oldValue as the largest version + 1
@@ -612,7 +612,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass) {
+  public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass) {
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("Entity tables cannot be used in OLD_SCHEMA_ONLY mode, so they cannot be backfilled.");
     }
@@ -634,7 +634,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("Local relationship tables cannot be used in OLD_SCHEMA_ONLY mode, so they cannot be backfilled.");
     }
-    AspectKey<URN, ASPECT> key = new AspectKey<>(aspectClass, urn, LATEST_VERSION);
+    AspectKey<ASPECT> key = new AspectKey<>(aspectClass, urn, LATEST_VERSION);
     return runInTransactionWithRetry(() -> {
           List<EbeanMetadataAspect> results = _localAccess.batchGetUnion(Collections.singletonList(key), 1, 0, false);
       if (results.size() == 0) {
@@ -652,7 +652,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param <ASPECT> aspect type
    * @return metadata aspect ebean model {@link EbeanMetadataAspect}
    */
-  private @Nullable <ASPECT extends RecordTemplate> EbeanMetadataAspect queryLatest(@Nonnull URN urn,
+  private @Nullable <ASPECT extends RecordTemplate> EbeanMetadataAspect queryLatest(@Nonnull Urn urn,
       @Nonnull Class<ASPECT> aspectClass) {
 
     EbeanMetadataAspect result;
@@ -682,7 +682,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   @Nonnull
-  protected <ASPECT extends RecordTemplate> AspectEntry<ASPECT> getLatest(@Nonnull URN urn,
+  protected <ASPECT extends RecordTemplate> AspectEntry<ASPECT> getLatest(@Nonnull Urn urn,
       @Nonnull Class<ASPECT> aspectClass) {
     EbeanMetadataAspect latest = queryLatest(urn, aspectClass);
     if (latest == null) {
@@ -698,7 +698,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  private <ASPECT extends RecordTemplate> EbeanMetadataAspect buildMetadataAspectBean(@Nonnull URN urn,
+  private <ASPECT extends RecordTemplate> EbeanMetadataAspect buildMetadataAspectBean(@Nonnull Urn urn,
       @Nullable RecordTemplate value, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp, long version) {
 
     final String aspectName = ModelUtils.getAspectName(aspectClass);
@@ -760,7 +760,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @VisibleForTesting
   @Override
-  protected <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull URN urn,
+  protected <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull Urn urn,
       @Nullable RecordTemplate value, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp newAuditStamp,
       long version, @Nonnull Timestamp oldTimestamp, @Nullable IngestionTrackingContext trackingContext) {
 
@@ -801,7 +801,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  protected <ASPECT extends RecordTemplate> void insert(@Nonnull URN urn, @Nullable RecordTemplate value,
+  protected <ASPECT extends RecordTemplate> void insert(@Nonnull Urn urn, @Nullable RecordTemplate value,
       @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp, long version, @Nullable IngestionTrackingContext trackingContext) {
 
     final EbeanMetadataAspect aspect = buildMetadataAspectBean(urn, value, aspectClass, auditStamp, version);
@@ -823,7 +823,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  protected <ASPECT extends RecordTemplate> long getNextVersion(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass) {
+  protected <ASPECT extends RecordTemplate> long getNextVersion(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass) {
     if (!_changeLogEnabled) {
       throw new UnsupportedOperationException("getNextVersion shouldn't be called when changeLog is disabled");
     } else {
@@ -842,7 +842,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   protected <ASPECT extends RecordTemplate> void applyVersionBasedRetention(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull URN urn, @Nonnull VersionBasedRetention retention, long largestVersion) {
+      @Nonnull Urn urn, @Nonnull VersionBasedRetention retention, long largestVersion) {
     if (_changeLogEnabled) {
       // only apply version based retention when changeLog is enabled
       _server.find(EbeanMetadataAspect.class)
@@ -857,7 +857,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   protected <ASPECT extends RecordTemplate> void applyTimeBasedRetention(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull URN urn, @Nonnull TimeBasedRetention retention, long currentTime) {
+      @Nonnull Urn urn, @Nonnull TimeBasedRetention retention, long currentTime) {
     if (_changeLogEnabled) {
       // only apply time based retention when changeLog is enabled
       _server.find(EbeanMetadataAspect.class)
@@ -871,8 +871,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   @Nonnull
-  public Map<AspectKey<URN, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
-      @Nonnull Set<AspectKey<URN, ? extends RecordTemplate>> keys) {
+  public Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
+      @Nonnull Set<AspectKey<? extends RecordTemplate>> keys) {
     if (keys.isEmpty()) {
       return Collections.emptyMap();
     }
@@ -896,8 +896,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   @Nonnull
-  public Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
-      @Nonnull Set<AspectKey<URN, ? extends RecordTemplate>> keys) {
+  public Map<AspectKey<? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
+      @Nonnull Set<AspectKey<? extends RecordTemplate>> keys) {
     if (keys.isEmpty()) {
       return Collections.emptyMap();
     }
@@ -907,7 +907,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     } else {
       records = batchGet(keys, _queryKeysCount);
     }
-    final Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> result =
+    final Map<AspectKey<? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> result =
         new HashMap<>();
     keys.forEach(key -> records.stream()
         .filter(record -> matchKeys(key, record.getKey()))
@@ -975,7 +975,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param keysCount the max number of keys for each sub query
    */
   @Nonnull
-  private List<EbeanMetadataAspect> batchGet(@Nonnull Set<AspectKey<URN, ? extends RecordTemplate>> keys,
+  private List<EbeanMetadataAspect> batchGet(@Nonnull Set<AspectKey<? extends RecordTemplate>> keys,
       int keysCount) {
 
     int position = 0;
@@ -1006,7 +1006,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  private List<EbeanMetadataAspect> batchGetUnion(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
+  private List<EbeanMetadataAspect> batchGetUnion(@Nonnull List<AspectKey<? extends RecordTemplate>> keys,
       int keysCount, int position) {
 
     // Build one SELECT per key and then UNION ALL the results. This can be much more performant than OR'ing the
@@ -1041,7 +1041,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Nonnull
   @SuppressWarnings({"checkstyle:FallThrough", "checkstyle:DefaultComesLast"})
-  List<EbeanMetadataAspect> batchGetHelper(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
+  List<EbeanMetadataAspect> batchGetHelper(@Nonnull List<AspectKey<? extends RecordTemplate>> keys,
       int keysCount, int position) {
 
     boolean nonLatestVersionFlag = keys.stream().anyMatch(key -> key.getVersion() != LATEST_VERSION);
@@ -1071,7 +1071,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    *
    * @param aspectKey Urn needs to do a ignore case match
    */
-  boolean matchKeys(@Nonnull AspectKey<URN, ? extends RecordTemplate> aspectKey, @Nonnull PrimaryKey pk) {
+  boolean matchKeys(@Nonnull AspectKey<? extends RecordTemplate> aspectKey, @Nonnull PrimaryKey pk) {
     return aspectKey.getUrn().toString().equalsIgnoreCase(pk.getUrn()) && aspectKey.getVersion() == pk.getVersion()
         && ModelUtils.getAspectName(aspectKey.getAspectClass()).equals(pk.getAspect());
   }
@@ -1135,7 +1135,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     * This method is old schema mode use only. Seek alternatives in other schemas.
    */
   @Deprecated
-  protected List<URN> listUrnsPaginatedByLastUrn(@Nullable URN lastUrn, int pageSize) {
+  protected List<Urn> listUrnsPaginatedByLastUrn(@Nullable Urn lastUrn, int pageSize) {
     if (_schemaConfig != SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new UnsupportedOperationException("this method is only allowed in OLD_SCHEMA_ONLY mode");
     }
@@ -1145,7 +1145,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     return sqlRows.stream().map(sqlRow -> getUrn(sqlRow.getString(URN_COLUMN))).collect(Collectors.toList());
   }
 
-  private String getDistinctUrnsOfEntitySqlQuery(URN lastUrn, int pageSize) {
+  private String getDistinctUrnsOfEntitySqlQuery(Urn lastUrn, int pageSize) {
     final String entityType = ModelUtils.getEntityTypeFromUrnClass(_urnClass);
     final String entityUrnPrefix = "urn:li:" + entityType + ":%";
 
@@ -1475,8 +1475,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   @Override
   @Nonnull
-  public List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-      @Nullable URN lastUrn, int pageSize) {
+  public List<Urn> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+      @Nullable Urn lastUrn, int pageSize) {
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY && !(indexFilter == null && indexSortCriterion == null)) {
       throw new UnsupportedOperationException("listUrns with nonnull index filter is only supported in new schema.");
     }
@@ -1496,7 +1496,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   @Override
   @Nonnull
-  public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+  public ListResult<Urn> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize) {
 
     if (_schemaConfig == SchemaConfig.OLD_SCHEMA_ONLY) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
  */
 public interface IEbeanLocalAccess<URN extends Urn> {
 
-  void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor);
+  void setUrnPathExtractor(@Nonnull UrnPathExtractor urnPathExtractor);
 
   /**
    * Upsert aspect into entity table.
@@ -34,7 +34,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param ingestionTrackingContext the ingestionTrackingContext of the MCE responsible for this update
    * @return number of rows inserted or updated
    */
-  <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+  <ASPECT extends RecordTemplate> int add(@Nonnull Urn urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext ingestionTrackingContext);
 
   /**
@@ -49,7 +49,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param ingestionTrackingContext the ingestionTrackingContext of the MCE responsible for calling this update
    * @return number of rows inserted or updated
    */
-  <ASPECT extends RecordTemplate> int addWithOptimisticLocking(@Nonnull URN urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+  <ASPECT extends RecordTemplate> int addWithOptimisticLocking(@Nonnull Urn urn, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp, @Nullable Timestamp oldTimestamp, @Nullable IngestionTrackingContext ingestionTrackingContext);
 
   /**
@@ -60,7 +60,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @return relationship updates applied on relationship table
    */
   @Nonnull
-  <ASPECT extends RecordTemplate> List<LocalRelationshipUpdates> addRelationships(@Nonnull URN urn,
+  <ASPECT extends RecordTemplate> List<LocalRelationshipUpdates> addRelationships(@Nonnull Urn urn,
       @Nonnull ASPECT relationship, @Nonnull Class<ASPECT> aspectClass);
 
   /**
@@ -73,7 +73,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @return a list of {@link EbeanMetadataAspect} as get response
    */
   @Nonnull
-  <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> batchGetUnion(@Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys,
+  <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> batchGetUnion(@Nonnull List<AspectKey<? extends RecordTemplate>> keys,
       int keysCount, int position, boolean includeSoftDeleted);
 
   /**
@@ -88,8 +88,8 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param pageSize maximum number of distinct urns to return
    * @return List of urns from local secondary index that satisfy the given filter conditions
    */
-  List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-      @Nullable URN lastUrn, int pageSize);
+  List<Urn> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+      @Nullable Urn lastUrn, int pageSize);
 
   /**
    * Similar to {@link #listUrns(IndexFilter, IndexSortCriterion, Urn, int)} but returns a list result with pagination
@@ -98,7 +98,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param start the starting offset of the page
    * @return a {@link ListResult} containing a list of urns and other pagination information
    */
-  ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+  ListResult<Urn> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize);
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/ImmutableLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/ImmutableLocalDAO.java
@@ -97,7 +97,7 @@ public class ImmutableLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends U
 
   @Override
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Function<Optional<ASPECT>, ASPECT> updateLambda, @Nonnull AuditStamp auditStamp,
       int maxTransactionRetry) {
     throw new UnsupportedOperationException("Not supported by immutable DAO");
@@ -105,7 +105,7 @@ public class ImmutableLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends U
 
   @Override
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Function<Optional<ASPECT>, ASPECT> updateLambda, @Nonnull AuditStamp auditStamp,
       int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext) {
     throw new UnsupportedOperationException("Not supported by immutable DAO");
@@ -113,7 +113,7 @@ public class ImmutableLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends U
 
   @Override
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Function<Optional<ASPECT>, ASPECT> updateLambda, @Nonnull AuditStamp auditStamp,
       int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionParams ingestionParams) {
     throw new UnsupportedOperationException("Not supported by immutable DAO");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.dao;
 
 import com.google.common.io.Resources;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.dao.localrelationship.SampleLocalRelationshipRegistryImpl;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.utils.BarUrnPathExtractor;
@@ -83,7 +84,7 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessBar = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
         BarUrn.class, new BarUrnPathExtractor(), _ebeanConfig.isNonDollarVirtualColumnsEnabled());
     _ebeanLocalAccessBurger = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BurgerUrn.class, new EmptyPathExtractor<>(), _ebeanConfig.isNonDollarVirtualColumnsEnabled());
+        BurgerUrn.class, new EmptyPathExtractor(), _ebeanConfig.isNonDollarVirtualColumnsEnabled());
     _ebeanLocalAccessFoo.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
     _now = System.currentTimeMillis();
   }
@@ -115,7 +116,7 @@ public class EbeanLocalAccessTest {
     // Given: metadata_entity_foo table with fooUrns from 0 ~ 99
 
     FooUrn fooUrn = makeFooUrn(0);
-    AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey(AspectFoo.class, fooUrn, 0L);
+    AspectKey<AspectFoo> aspectKey = new AspectKey(AspectFoo.class, fooUrn, 0L);
 
     // When get AspectFoo from urn:li:foo:0
     List<EbeanMetadataAspect> ebeanMetadataAspectList =
@@ -135,7 +136,7 @@ public class EbeanLocalAccessTest {
 
     // When get AspectFoo from urn:li:foo:9999 (does not exist)
     FooUrn nonExistFooUrn = makeFooUrn(9999);
-    AspectKey<FooUrn, AspectFoo> nonExistKey = new AspectKey(AspectFoo.class, nonExistFooUrn, 0L);
+    AspectKey<AspectFoo> nonExistKey = new AspectKey(AspectFoo.class, nonExistFooUrn, 0L);
     ebeanMetadataAspectList = _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(nonExistKey), 1000, 0, false);
 
     // Expect: get AspectFoo from urn:li:foo:9999 returns empty result
@@ -166,7 +167,7 @@ public class EbeanLocalAccessTest {
 
     // When: list out results with start = 5 and pageSize = 5
 
-    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 5, 5);
+    ListResult<Urn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 5, 5);
 
     assertEquals(5, listUrns.getValues().size());
     assertEquals(5, listUrns.getPageSize());
@@ -197,10 +198,10 @@ public class EbeanLocalAccessTest {
     IndexSortCriterion indexSortCriterion =
         SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
 
-    FooUrn lastUrn = new FooUrn(29);
+    Urn lastUrn = new FooUrn(29);
 
     // When: list out results with lastUrn = 'urn:li:foo:29' and pageSize = 5
-    List<FooUrn> result1 = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5);
+    List<Urn> result1 = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, lastUrn, 5);
 
     // Expect: 5 rows are returns (30~34) and the first element is 'urn:li:foo:30'
     assertEquals(5, result1.size());
@@ -212,14 +213,14 @@ public class EbeanLocalAccessTest {
     IndexCriterion indexCriterion3 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
     indexCriterionArray = new IndexCriterionArray(Collections.singleton(indexCriterion3));
     IndexFilter filter = new IndexFilter().setCriteria(indexCriterionArray);
-    List<FooUrn> result2 = _ebeanLocalAccessFoo.listUrns(filter, indexSortCriterion, lastUrn, 5);
+    List<Urn> result2 = _ebeanLocalAccessFoo.listUrns(filter, indexSortCriterion, lastUrn, 5);
 
     // Expect: 5 rows are returns (35~39) and the first element is 'urn:li:foo:35'
     assertEquals(5, result2.size());
     assertEquals("35", result2.get(0).getId());
 
     // When: list urns with no filter, no sorting criterion, no last urn.
-    List<FooUrn> result3 = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
+    List<Urn> result3 = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
 
     // 0, 1, 10, 11, 12, 13, 14, 15, 16, 17
     assertEquals(result3.size(), 10);
@@ -227,7 +228,7 @@ public class EbeanLocalAccessTest {
     assertEquals(result3.get(9).getId(), "17");
 
     // When: list urns with no filter, no sorting criterion
-    List<FooUrn> result4 = _ebeanLocalAccessFoo.listUrns(null, null, new FooUrn(17), 10);
+    List<Urn> result4 = _ebeanLocalAccessFoo.listUrns(null, null, new FooUrn(17), 10);
 
     // 18, 19, 2, 20, 21, 22, 23, 24, 25, 26
     assertEquals(result4.size(), 10);
@@ -365,7 +366,7 @@ public class EbeanLocalAccessTest {
     List<BelongsTo> relationships = ebeanLocalRelationshipQueryDAO.findRelationships(
         BarSnapshot.class, EMPTY_FILTER, FooSnapshot.class, EMPTY_FILTER, BelongsTo.class, EMPTY_FILTER, 0, 10);
 
-    AspectKey<FooUrn, AspectFooBar> key = new AspectKey<>(AspectFooBar.class, fooUrn, 0L);
+    AspectKey<AspectFooBar> key = new AspectKey<>(AspectFooBar.class, fooUrn, 0L);
     List<EbeanMetadataAspect> aspects = _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(key), 10, 0, false);
 
     assertEquals(3, relationships.size());
@@ -486,7 +487,7 @@ public class EbeanLocalAccessTest {
   public void testGetAspectNoSoftDeleteCheck() {
     FooUrn fooUrn = makeFooUrn(0);
     _ebeanLocalAccessFoo.add(fooUrn, null, AspectFoo.class, makeAuditStamp("foo", System.currentTimeMillis()), null);
-    AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey(AspectFoo.class, fooUrn, 0L);
+    AspectKey<AspectFoo> aspectKey = new AspectKey(AspectFoo.class, fooUrn, 0L);
     List<EbeanMetadataAspect> ebeanMetadataAspectList =
         _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(aspectKey), 1000, 0, false);
     assertEquals(0, ebeanMetadataAspectList.size());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -217,10 +217,10 @@ public class EbeanLocalDAOTest {
     // Since we added a_urn columns to both metadata_entity_foo and metadata_entity_bar tables in the SQL initialization scripts,
     // it is required that we set non-default UrnPathExtractors for the corresponding DAOs when initialized.
     if (urnClass == FooUrn.class) {
-      dao.setUrnPathExtractor((UrnPathExtractor<URN>) new FooUrnPathExtractor());
+      dao.setUrnPathExtractor((UrnPathExtractor) new FooUrnPathExtractor());
     }
     if (urnClass == BarUrn.class) {
-      dao.setUrnPathExtractor((UrnPathExtractor<URN>) new BarUrnPathExtractor());
+      dao.setUrnPathExtractor((UrnPathExtractor) new BarUrnPathExtractor());
     }
     dao.setEmitAuditEvent(true);
     dao.setChangeLogEnabled(_enableChangeLog);
@@ -372,7 +372,7 @@ public class EbeanLocalDAOTest {
 
     // make sure that the update still went through by checking the aspect's lastmodifiedon
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
-      AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, urn, 0L);
+      AspectKey<AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, urn, 0L);
       long aspectFooLastModifiedOn = dao.getWithExtraInfo(aspectKey).get().getExtraInfo().getAudit().getTime();
       assertEquals(aspectFooLastModifiedOn, t2);
     } else {
@@ -398,7 +398,7 @@ public class EbeanLocalDAOTest {
 
     // Even though the aspect is annotated with FORCE_UPDATE annotation, the filter does not match so the update is not persisted.
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
-      AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, urn, 0L);
+      AspectKey<AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, urn, 0L);
       long aspectFooLastModifiedOn = dao.getWithExtraInfo(aspectKey).get().getExtraInfo().getAudit().getTime();
       assertEquals(aspectFooLastModifiedOn, t1);
     } else {
@@ -425,7 +425,7 @@ public class EbeanLocalDAOTest {
 
     // One filter (two filters in total) matched, we should persist into db.
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
-      AspectKey<FooUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, 0L);
+      AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, 0L);
       long aspectFooLastModifiedOn = dao.getWithExtraInfo(aspectKey).get().getExtraInfo().getAudit().getTime();
       assertEquals(aspectFooLastModifiedOn, t2);
     } else {
@@ -454,7 +454,7 @@ public class EbeanLocalDAOTest {
 
     // No filter, we should not persist into db.
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
-      AspectKey<FooUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, 0L);
+      AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, 0L);
       long aspectFooLastModifiedOn = dao.getWithExtraInfo(aspectKey).get().getExtraInfo().getAudit().getTime();
       assertEquals(aspectFooLastModifiedOn, t1);
     } else {
@@ -489,7 +489,7 @@ public class EbeanLocalDAOTest {
 
     // however, make sure that the update still went through by checking the aspect's lastmodifiedon
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
-      AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, urn, 0L);
+      AspectKey<AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, urn, 0L);
       long aspectFooLastModifiedOn = dao.getWithExtraInfo(aspectKey).get().getExtraInfo().getAudit().getTime();
       assertEquals(aspectFooLastModifiedOn, t2);
     } else {
@@ -827,7 +827,7 @@ public class EbeanLocalDAOTest {
     // urn3 has nothing
     FooUrn urn3 = makeFooUrn(3);
 
-    Map<FooUrn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> result =
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> result =
         dao.get(ImmutableSet.of(AspectFoo.class, AspectBar.class), ImmutableSet.of(urn1, urn2, urn3));
 
     assertEquals(result.size(), 3);
@@ -898,7 +898,7 @@ public class EbeanLocalDAOTest {
     });
 
     // when
-    Map<FooUrn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
         dao.backfill(Collections.singleton(AspectFoo.class), new HashSet<>(urns));
 
     // then
@@ -925,7 +925,7 @@ public class EbeanLocalDAOTest {
     });
 
     // when
-    Map<FooUrn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
         dao.backfill(ImmutableSet.of(AspectFoo.class, AspectBar.class), Collections.singleton(urns.get(0)));
 
     // then
@@ -955,7 +955,7 @@ public class EbeanLocalDAOTest {
     });
 
     // when
-    Map<FooUrn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
         dao.backfill(ImmutableSet.of(AspectFoo.class, AspectBar.class), new HashSet<>(urns));
 
     // then
@@ -1230,40 +1230,40 @@ public class EbeanLocalDAOTest {
     // 1. with two filter conditions
     IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray(Arrays.asList(criterion1, criterion2));
     final IndexFilter indexFilter1 = new IndexFilter().setCriteria(indexCriterionArray1);
-    List<FooUrn> urns1 = dao.listUrns(indexFilter1, null, 3);
+    List<Urn> urns1 = dao.listUrns(indexFilter1, null, 3);
 
     assertEquals(urns1, Arrays.asList(urn1, urn2, urn3));
 
     // 2. with two filter conditions, check if LIMIT is working as desired i.e. totalCount is more than the page size
-    List<FooUrn> urns2 = dao.listUrns(indexFilter1, null, 2);
+    List<Urn> urns2 = dao.listUrns(indexFilter1, null, 2);
     assertEquals(urns2, Arrays.asList(urn1, urn2));
 
     // 3. with six filter conditions covering all different data types that value can take
     IndexCriterionArray indexCriterionArray3 =
         new IndexCriterionArray(Arrays.asList(criterion1, criterion2, criterion3, criterion4, criterion5, criterion6));
     final IndexFilter indexFilter3 = new IndexFilter().setCriteria(indexCriterionArray3);
-    List<FooUrn> urns3 = dao.listUrns(indexFilter3, urn1, 5);
+    List<Urn> urns3 = dao.listUrns(indexFilter3, urn1, 5);
     assertEquals(urns3, Collections.singletonList(urn3));
 
     // 4. GREATER_THAN criterion
     IndexCriterionArray indexCriterionArray4 = new IndexCriterionArray(
         Arrays.asList(criterion1, criterion2, criterion3, criterion4, criterion5, criterion6, criterion7));
     final IndexFilter indexFilter4 = new IndexFilter().setCriteria(indexCriterionArray4);
-    List<FooUrn> urns4 = dao.listUrns(indexFilter4, null, 5);
+    List<Urn> urns4 = dao.listUrns(indexFilter4, null, 5);
     assertEquals(urns4, Arrays.asList(urn1, urn3));
 
     // 5. GREATER_THAN_EQUAL_TO criterion
     IndexCriterionArray indexCriterionArray5 = new IndexCriterionArray(
         Arrays.asList(criterion1, criterion2, criterion3, criterion4, criterion5, criterion6, criterion7, criterion8));
     final IndexFilter indexFilter5 = new IndexFilter().setCriteria(indexCriterionArray5);
-    List<FooUrn> urns5 = dao.listUrns(indexFilter5, null, 10);
+    List<Urn> urns5 = dao.listUrns(indexFilter5, null, 10);
     assertEquals(urns5, Arrays.asList(urn1, urn3));
 
     // 6. LESS_THAN criterion
     IndexCriterionArray indexCriterionArray6 = new IndexCriterionArray(
         Arrays.asList(criterion1, criterion3, criterion4, criterion5, criterion6, criterion7, criterion8, criterion9));
     final IndexFilter indexFilter6 = new IndexFilter().setCriteria(indexCriterionArray6);
-    List<FooUrn> urns6 = dao.listUrns(indexFilter6, urn1, 8);
+    List<Urn> urns6 = dao.listUrns(indexFilter6, urn1, 8);
     assertEquals(urns6, Collections.singletonList(urn3));
 
     // 7. LESS_THAN_EQUAL_TO
@@ -1271,7 +1271,7 @@ public class EbeanLocalDAOTest {
         Arrays.asList(criterion1, criterion3, criterion4, criterion5, criterion6, criterion7, criterion8, criterion9,
             criterion10));
     final IndexFilter indexFilter7 = new IndexFilter().setCriteria(indexCriterionArray7);
-    List<FooUrn> urns7 = dao.listUrns(indexFilter7, null, 4);
+    List<Urn> urns7 = dao.listUrns(indexFilter7, null, 4);
     assertEquals(urns7, Collections.emptyList());
   }
 
@@ -1300,7 +1300,7 @@ public class EbeanLocalDAOTest {
 
     IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray(Collections.singletonList(criterion1));
     final IndexFilter indexFilter1 = new IndexFilter().setCriteria(indexCriterionArray1);
-    List<FooUrn> urns1 = dao.listUrns(indexFilter1, null, 5);
+    List<Urn> urns1 = dao.listUrns(indexFilter1, null, 5);
     assertEquals(urns1, Arrays.asList(urn1, urn2));
 
     // full string
@@ -1311,7 +1311,7 @@ public class EbeanLocalDAOTest {
 
     IndexCriterionArray indexCriterionArray2 = new IndexCriterionArray(Collections.singletonList(criterion2));
     final IndexFilter indexFilter2 = new IndexFilter().setCriteria(indexCriterionArray2);
-    List<FooUrn> urns2 = dao.listUrns(indexFilter2, null, 5);
+    List<Urn> urns2 = dao.listUrns(indexFilter2, null, 5);
     assertEquals(urns2, Collections.singletonList(urn1));
   }
 
@@ -1419,21 +1419,21 @@ public class EbeanLocalDAOTest {
     IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray(Collections.singletonList(criterion1));
     final IndexFilter indexFilter1 = new IndexFilter().setCriteria(indexCriterionArray1);
 
-    List<FooUrn> urns1 = dao.listUrns(indexFilter1, null, null, 5);
+    List<Urn> urns1 = dao.listUrns(indexFilter1, null, null, 5);
     assertEquals(urns1, Arrays.asList(urn1, urn2, urn3));
 
     // filter and sort on same aspect and path
     IndexSortCriterion indexSortCriterion1 =
         new IndexSortCriterion().setAspect(aspect1).setPath("/value").setOrder(SortOrder.DESCENDING);
 
-    List<FooUrn> urns2 = dao.listUrns(indexFilter1, indexSortCriterion1, null, 5);
+    List<Urn> urns2 = dao.listUrns(indexFilter1, indexSortCriterion1, null, 5);
     assertEquals(urns2, Arrays.asList(urn2, urn1, urn3));
 
     // filter and sort on different aspect and path
     IndexSortCriterion indexSortCriterion2 =
         new IndexSortCriterion().setAspect(aspect2).setPath("/stringField").setOrder(SortOrder.ASCENDING);
 
-    List<FooUrn> urns3 = dao.listUrns(indexFilter1, indexSortCriterion2, null, 5);
+    List<Urn> urns3 = dao.listUrns(indexFilter1, indexSortCriterion2, null, 5);
     assertEquals(urns3, Arrays.asList(urn3, urn1, urn2));
 
     // sorting on long column
@@ -1449,14 +1449,14 @@ public class EbeanLocalDAOTest {
     IndexSortCriterion indexSortCriterion3 =
         new IndexSortCriterion().setAspect(aspect2).setPath("/longField").setOrder(SortOrder.DESCENDING);
 
-    List<FooUrn> urns4 = dao.listUrns(indexFilter2, indexSortCriterion3, null, 5);
+    List<Urn> urns4 = dao.listUrns(indexFilter2, indexSortCriterion3, null, 5);
     assertEquals(urns4, Arrays.asList(urn3, urn1));
 
     // sorting on nested field
     IndexSortCriterion indexSortCriterion4 =
         new IndexSortCriterion().setAspect(aspect2).setPath("/recordField/value").setOrder(SortOrder.ASCENDING);
 
-    List<FooUrn> urns5 = dao.listUrns(indexFilter1, indexSortCriterion4, null, 5);
+    List<Urn> urns5 = dao.listUrns(indexFilter1, indexSortCriterion4, null, 5);
     assertEquals(urns5, Arrays.asList(urn3, urn2, urn1));
   }
 
@@ -1488,7 +1488,7 @@ public class EbeanLocalDAOTest {
 
     IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray(Collections.singletonList(criterion1));
     final IndexFilter indexFilter1 = new IndexFilter().setCriteria(indexCriterionArray1);
-    List<FooUrn> urns1 = dao.listUrns(indexFilter1, null, 5);
+    List<Urn> urns1 = dao.listUrns(indexFilter1, null, 5);
     assertEquals(urns1, Arrays.asList(urn1, urn2));
 
     IndexValue indexValue2 = new IndexValue();
@@ -1498,7 +1498,7 @@ public class EbeanLocalDAOTest {
 
     IndexCriterionArray indexCriterionArray2 = new IndexCriterionArray(Collections.singletonList(criterion2));
     final IndexFilter indexFilter2 = new IndexFilter().setCriteria(indexCriterionArray2);
-    List<FooUrn> urns2 = dao.listUrns(indexFilter2, null, 5);
+    List<Urn> urns2 = dao.listUrns(indexFilter2, null, 5);
     assertEquals(urns2, Arrays.asList());
 
     IndexValue indexValue3 = new IndexValue();
@@ -1557,7 +1557,7 @@ public class EbeanLocalDAOTest {
         new IndexSortCriterion().setAspect(aspect1).setPath("/value").setOrder(SortOrder.DESCENDING);
 
     // first page
-    ListResult<FooUrn> results1 = dao.listUrns(indexFilter, indexSortCriterion, 0, 2);
+    ListResult<Urn> results1 = dao.listUrns(indexFilter, indexSortCriterion, 0, 2);
     assertEquals(results1.getValues(), Arrays.asList(urn2, urn1));
     assertTrue(results1.isHavingMore());
     assertEquals(results1.getNextStart(), 2);
@@ -1566,7 +1566,7 @@ public class EbeanLocalDAOTest {
     assertEquals(results1.getTotalPageCount(), 2);
 
     // last page
-    ListResult<FooUrn> results2 = dao.listUrns(indexFilter, indexSortCriterion, 2, 2);
+    ListResult<Urn> results2 = dao.listUrns(indexFilter, indexSortCriterion, 2, 2);
     assertEquals(results2.getValues(), Arrays.asList(urn3));
     assertFalse(results2.isHavingMore());
     assertEquals(results2.getNextStart(), ListResult.INVALID_NEXT_START);
@@ -1575,7 +1575,7 @@ public class EbeanLocalDAOTest {
     assertEquals(results2.getTotalPageCount(), 2);
 
     // beyond last page
-    ListResult<FooUrn> results3 = dao.listUrns(indexFilter, indexSortCriterion, 4, 2);
+    ListResult<Urn> results3 = dao.listUrns(indexFilter, indexSortCriterion, 4, 2);
     assertEquals(results3.getValues(), new ArrayList<>());
     assertFalse(results3.isHavingMore());
     assertEquals(results3.getNextStart(), ListResult.INVALID_NEXT_START);
@@ -1644,7 +1644,7 @@ public class EbeanLocalDAOTest {
     }
 
     // initial pagination
-    List<FooUrn> results = dao.listUrnsPaginatedByLastUrn(null, 1);
+    List<Urn> results = dao.listUrnsPaginatedByLastUrn(null, 1);
     assertEquals(results, urns.subList(0, 1));
 
     // next pagination
@@ -1965,7 +1965,7 @@ public class EbeanLocalDAOTest {
     // 1. only aspect and not path or value is provided in Index Filter
     indexCriterion = new IndexCriterion().setAspect(aspect);
     final IndexFilter indexFilter4 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
-    List<FooUrn> urns = dao.listUrns(indexFilter4, null, 2);
+    List<Urn> urns = dao.listUrns(indexFilter4, null, 2);
     assertEquals(urns, Arrays.asList(urn1, urn2));
 
     // 2. aspect with path and value is provided in index filter
@@ -2006,7 +2006,7 @@ public class EbeanLocalDAOTest {
     IndexCriterion indexCriterion = new IndexCriterion().setAspect(aspect);
     final IndexFilter indexFilter = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
 
-    List<FooUrn> urns = dao.listUrns(indexFilter, null, 0);
+    List<Urn> urns = dao.listUrns(indexFilter, null, 0);
 
     assertEquals(urns, Collections.emptyList());
   }
@@ -2034,11 +2034,11 @@ public class EbeanLocalDAOTest {
     addIndex(urn4, BarUrn.class.getCanonicalName(), "/path4", "0");
 
     // List foo urns
-    List<FooUrn> urns1 = dao1.listUrns(FooUrn.class, null, 2);
+    List<Urn> urns1 = dao1.listUrns(FooUrn.class, null, 2);
     assertEquals(urns1, Arrays.asList(urn1, urn2));
 
     // List bar urns
-    List<BarUrn> urns2 = dao2.listUrns(BarUrn.class, null, 1);
+    List<Urn> urns2 = dao2.listUrns(BarUrn.class, null, 1);
     assertEquals(urns2, Collections.singletonList(urn4));
   }
 
@@ -2417,8 +2417,8 @@ public class EbeanLocalDAOTest {
     FooUrn fooUrn = makeFooUrn(1);
 
     // both aspect keys exist
-    AspectKey<FooUrn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, fooUrn, 1L);
-    AspectKey<FooUrn, AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, fooUrn, 0L);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, fooUrn, 1L);
+    AspectKey<AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, fooUrn, 0L);
 
     // add metadata
     addMetadata(fooUrn, AspectFoo.class, 1, null);
@@ -2426,7 +2426,7 @@ public class EbeanLocalDAOTest {
     addMetadata(fooUrn, AspectBar.class, 0, barV0);
 
     // when
-    Map<AspectKey<FooUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> records =
+    Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> records =
         dao.get(new HashSet<>(Arrays.asList(aspectKey1, aspectKey2)));
 
     // then
@@ -2508,10 +2508,10 @@ public class EbeanLocalDAOTest {
         impersonator3.toString());
 
     // both aspect keys exist
-    AspectKey<FooUrn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn, 1L);
-    AspectKey<FooUrn, AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, urn, 0L);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn, 1L);
+    AspectKey<AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, urn, 0L);
 
-    Map<AspectKey<FooUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> result =
+    Map<AspectKey<? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> result =
         dao.getWithExtraInfo(new HashSet<>(Arrays.asList(aspectKey1, aspectKey2)));
 
     assertEquals(result.keySet().size(), 2);
@@ -2521,7 +2521,7 @@ public class EbeanLocalDAOTest {
         new ExtraInfo().setAudit(makeAuditStamp(creator3, impersonator3, _now)).setVersion(0).setUrn(urn)));
 
     // one of the aspect keys does not exist
-    AspectKey<FooUrn, AspectBar> aspectKey3 = new AspectKey<>(AspectBar.class, urn, 1L);
+    AspectKey<AspectBar> aspectKey3 = new AspectKey<>(AspectBar.class, urn, 1L);
 
     result = dao.getWithExtraInfo(new HashSet<>(Arrays.asList(aspectKey1, aspectKey3)));
 
@@ -2538,8 +2538,8 @@ public class EbeanLocalDAOTest {
     FooUrn fooUrn = makeFooUrn(1);
 
     // both aspect keys exist
-    AspectKey<FooUrn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, fooUrn, 1L);
-    AspectKey<FooUrn, AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, fooUrn, 0L);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, fooUrn, 1L);
+    AspectKey<AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, fooUrn, 0L);
 
     // add metadata
     AspectFoo fooV1 = new AspectFoo().setValue("foo");
@@ -2549,7 +2549,7 @@ public class EbeanLocalDAOTest {
 
     // batch get without query keys count set
     // when
-    Map<AspectKey<FooUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> records =
+    Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> records =
         dao.get(new HashSet<>(Arrays.asList(aspectKey1, aspectKey2)));
 
     // then
@@ -2682,7 +2682,7 @@ public class EbeanLocalDAOTest {
     final IndexFilter indexFilter4 = new IndexFilter().setCriteria(indexCriterionArray4);
 
     result = dao.countAggregate(indexFilter4, indexGroupByCriterion1);
-    List<FooUrn> test = dao.listUrns(indexFilter4, null, null, 10);
+    List<Urn> test = dao.listUrns(indexFilter4, null, null, 10);
     assertEquals(test.size(), 3);
     assertEquals(result.size(), 2);
     assertEquals(result.get("valB").longValue(), 2);
@@ -2704,8 +2704,8 @@ public class EbeanLocalDAOTest {
     FooUrn fooUrn = makeFooUrn(1);
 
     // both aspect keys exist
-    AspectKey<FooUrn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, fooUrn, 1L);
-    AspectKey<FooUrn, AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, fooUrn, 0L);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, fooUrn, 1L);
+    AspectKey<AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, fooUrn, 0L);
 
     // add metadata
     AspectFoo fooV1 = new AspectFoo().setValue("foo");
@@ -2714,9 +2714,9 @@ public class EbeanLocalDAOTest {
     addMetadata(fooUrn, AspectBar.class, 0, barV0);
 
     FooUrn fooUrn2 = makeFooUrn(2);
-    AspectKey<FooUrn, AspectFoo> aspectKey3 = new AspectKey<>(AspectFoo.class, fooUrn2, 0L);
-    AspectKey<FooUrn, AspectFoo> aspectKey4 = new AspectKey<>(AspectFoo.class, fooUrn2, 1L);
-    AspectKey<FooUrn, AspectBar> aspectKey5 = new AspectKey<>(AspectBar.class, fooUrn2, 0L);
+    AspectKey<AspectFoo> aspectKey3 = new AspectKey<>(AspectFoo.class, fooUrn2, 0L);
+    AspectKey<AspectFoo> aspectKey4 = new AspectKey<>(AspectFoo.class, fooUrn2, 1L);
+    AspectKey<AspectBar> aspectKey5 = new AspectKey<>(AspectBar.class, fooUrn2, 0L);
 
     // add metadata
     AspectFoo fooV3 = new AspectFoo().setValue("foo3");
@@ -2729,7 +2729,7 @@ public class EbeanLocalDAOTest {
     dao.setQueryKeysCount(querySize);
 
     // when
-    Map<AspectKey<FooUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> fiveRecords =
+    Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> fiveRecords =
         dao.get(new HashSet<>(Arrays.asList(aspectKey1, aspectKey2, aspectKey3, aspectKey4, aspectKey5)));
 
     // then
@@ -2960,7 +2960,7 @@ public class EbeanLocalDAOTest {
       IndexCriterion criterion = new IndexCriterion().setAspect(AspectAttributes.class.getCanonicalName()).setPathParams(indexPathParams);
       IndexFilter indexFilter = new IndexFilter().setCriteria(new IndexCriterionArray(criterion));
       dao.add(fooUrn, attributes, _dummyAuditStamp);
-      List<FooUrn> urns = dao.listUrns(indexFilter, null, 5);
+      List<Urn> urns = dao.listUrns(indexFilter, null, 5);
 
       // Verify find one
       assertEquals(urns, Collections.singletonList(fooUrn));
@@ -2970,7 +2970,7 @@ public class EbeanLocalDAOTest {
       IndexCriterion criterion2 = new IndexCriterion().setAspect(AspectAttributes.class.getCanonicalName()).setPathParams(indexPathParams2);
       IndexFilter indexFilter2 = new IndexFilter().setCriteria(new IndexCriterionArray(criterion2));
       dao.add(fooUrn, attributes, _dummyAuditStamp);
-      List<FooUrn> empty = dao.listUrns(indexFilter2, null, 5);
+      List<Urn> empty = dao.listUrns(indexFilter2, null, 5);
 
       // Verify nothing found
       assertTrue(empty.isEmpty());
@@ -2993,7 +2993,7 @@ public class EbeanLocalDAOTest {
       IndexCriterion criterion = new IndexCriterion().setAspect(AspectAttributes.class.getCanonicalName()).setPathParams(indexPathParams);
       IndexFilter indexFilter = new IndexFilter().setCriteria(new IndexCriterionArray(criterion));
 
-      List<FooUrn> urns = dao.listUrns(indexFilter, null, 5);
+      List<Urn> urns = dao.listUrns(indexFilter, null, 5);
 
       // Verify find one
       assertEquals(urns, Collections.singletonList(fooUrn));
@@ -3003,7 +3003,7 @@ public class EbeanLocalDAOTest {
       IndexPathParams indexPathParams2 = new IndexPathParams().setPath("/attributes").setValue(arrayValue2).setCondition(Condition.EQUAL);
       IndexCriterion criterion2 = new IndexCriterion().setAspect(AspectAttributes.class.getCanonicalName()).setPathParams(indexPathParams2);
       IndexFilter indexFilter2 = new IndexFilter().setCriteria(new IndexCriterionArray(criterion2));
-      List<FooUrn> empty1 = dao.listUrns(indexFilter2, null, 5);
+      List<Urn> empty1 = dao.listUrns(indexFilter2, null, 5);
 
       // Verify nothing found
       assertTrue(empty1.isEmpty());
@@ -3013,7 +3013,7 @@ public class EbeanLocalDAOTest {
       IndexPathParams indexPathParams3 = new IndexPathParams().setPath("/attributes").setValue(arrayValue3).setCondition(Condition.EQUAL);
       IndexCriterion criterion3 = new IndexCriterion().setAspect(AspectAttributes.class.getCanonicalName()).setPathParams(indexPathParams3);
       IndexFilter indexFilter3 = new IndexFilter().setCriteria(new IndexCriterionArray(criterion3));
-      List<FooUrn> empty2 = dao.listUrns(indexFilter3, null, 5);
+      List<Urn> empty2 = dao.listUrns(indexFilter3, null, 5);
 
       // Verify nothing found
       assertTrue(empty2.isEmpty());
@@ -3037,7 +3037,7 @@ public class EbeanLocalDAOTest {
           new IndexCriterion().setAspect(AspectAttributes.class.getCanonicalName()).setPathParams(indexPathParams);
       IndexFilter indexFilter = new IndexFilter().setCriteria(new IndexCriterionArray(criterion));
 
-      List<FooUrn> urns = dao.listUrns(indexFilter, null, 5);
+      List<Urn> urns = dao.listUrns(indexFilter, null, 5);
 
       // Verify find one
       assertEquals(urns, Collections.singletonList(fooUrn));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -84,9 +84,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipWriterDAO = new EbeanLocalRelationshipWriterDAO(_server);
     _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
     _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        FooUrn.class, new EmptyPathExtractor<>(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
+        FooUrn.class, new EmptyPathExtractor(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
-        BarUrn.class, new EmptyPathExtractor<>(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
+        BarUrn.class, new EmptyPathExtractor(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
   }
 
   @BeforeMethod

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/BarUrnPathExtractor.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/BarUrnPathExtractor.java
@@ -1,20 +1,28 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.testing.urn.BarUrn;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
 
-public class BarUrnPathExtractor implements UrnPathExtractor<BarUrn> {
+public class BarUrnPathExtractor implements UrnPathExtractor {
   @Override
-  public Map<String, Object> extractPaths(@Nonnull BarUrn urn) {
-    return Collections.unmodifiableMap(new HashMap<String, Integer>() {
-      {
-        put("/barId", urn.getBarIdEntity());
-      }
-    });
+  public Map<String, Object> extractPaths(@Nonnull Urn urn) {
+
+    try {
+      BarUrn barUrn = BarUrn.createFromString(urn.toString());
+      return Collections.unmodifiableMap(new HashMap<String, Integer>() {
+        {
+          put("/barId", barUrn.getBarIdEntity());
+        }
+      });
+    } catch (URISyntaxException ignored) {
+      return Collections.emptyMap();
+    }
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/BazUrnPathExtractor.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/BazUrnPathExtractor.java
@@ -1,20 +1,30 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.testing.urn.BazUrn;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
 
-public class BazUrnPathExtractor implements UrnPathExtractor<BazUrn> {
+public class BazUrnPathExtractor implements UrnPathExtractor {
   @Override
-  public Map<String, Object> extractPaths(@Nonnull BazUrn urn) {
-    return Collections.unmodifiableMap(new HashMap<String, Integer>() {
-      {
-        put("/bazId", urn.getBazIdEntity());
-      }
-    });
+  public Map<String, Object> extractPaths(@Nonnull Urn urn) {
+
+    try {
+      BazUrn bazUrn = BazUrn.createFromString(urn.toString());
+
+      return Collections.unmodifiableMap(new HashMap<String, Integer>() {
+        {
+          put("/bazId", bazUrn.getBazIdEntity());
+        }
+      });
+    } catch (URISyntaxException e) {
+      return Collections.emptyMap();
+    }
+
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,6 +72,10 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
+          configurationBuilder.setBaseDir("/opt/homebrew");
+          configurationBuilder.setUnpackingFromClasspath(false);
+          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -72,10 +72,6 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
-          configurationBuilder.setBaseDir("/opt/homebrew");
-          configurationBuilder.setUnpackingFromClasspath(false);
-          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
-
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/FooUrnPathExtractor.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/FooUrnPathExtractor.java
@@ -1,14 +1,16 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.testing.urn.FooUrn;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
 
-public class FooUrnPathExtractor implements UrnPathExtractor<FooUrn> {
+public class FooUrnPathExtractor implements UrnPathExtractor {
   private Map<String, Integer> urnPaths = new HashMap<String, Integer>() {
     {
       put("/dummyId", 10); // Hard-code the value to test ingestion multiple filters with @gma.aspect.ingestion
@@ -16,8 +18,14 @@ public class FooUrnPathExtractor implements UrnPathExtractor<FooUrn> {
   };
 
   @Override
-  public Map<String, Object> extractPaths(@Nonnull FooUrn urn) {
-    urnPaths.put("/fooId", urn.getFooIdEntity());
+  public Map<String, Object> extractPaths(@Nonnull Urn urn) {
+    try {
+      FooUrn fooUrn = FooUrn.createFromString(urn.toString());
+      urnPaths.put("/fooId", fooUrn.getFooIdEntity());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
     return Collections.unmodifiableMap(urnPaths);
   }
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -154,7 +154,7 @@ public abstract class BaseAspectRoutingResource<
       @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
 
     return RestliUtils.toTask(() -> {
-      final Set<URN> urnSet = Arrays.stream(urns).map(this::parseUrnParam).collect(Collectors.toSet());
+      final Set<Urn> urnSet = Arrays.stream(urns).map(this::parseUrnParam).collect(Collectors.toSet());
       final Set<Class<? extends RecordTemplate>> aspectClasses = parseAspectsParam(aspectNames);
       Map<URN, Map<Class<? extends RecordTemplate>, java.util.Optional<? extends RecordTemplate>>> urnToAspect =
           new HashMap<>();
@@ -191,7 +191,7 @@ public abstract class BaseAspectRoutingResource<
       @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
 
     return RestliUtils.toTask(() -> {
-      final Set<URN> urnSet = Arrays.stream(urns).map(this::parseUrnParam).collect(Collectors.toSet());
+      final Set<Urn> urnSet = Arrays.stream(urns).map(this::parseUrnParam).collect(Collectors.toSet());
       final Set<Class<? extends RecordTemplate>> aspectClasses = parseAspectsParam(aspectNames);
       return RestliUtils.buildBackfillResult(getLocalDAO().backfillWithNewValue(getNonRoutingAspects(aspectClasses), urnSet));
     });
@@ -292,7 +292,7 @@ public abstract class BaseAspectRoutingResource<
       return Collections.emptyList();
     }
 
-    final Set<AspectKey<URN, ? extends RecordTemplate>> keys = aspectClasses.stream()
+    final Set<AspectKey<? extends RecordTemplate>> keys = aspectClasses.stream()
         .map(aspectClass -> new AspectKey<>(aspectClass, urn, LATEST_VERSION))
         .collect(Collectors.toSet());
 
@@ -379,7 +379,7 @@ public abstract class BaseAspectRoutingResource<
   }
 
   @Nonnull
-  private BackfillResult backfillWithDefault(@Nonnull final Set<URN> urns) {
+  private BackfillResult backfillWithDefault(@Nonnull final Set<Urn> urns) {
     try {
       List<BackfillResult> backfillResults = getAspectRoutingGmsClientManager().getRegisteredRoutingGmsClients()
           .stream()

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
@@ -155,7 +155,7 @@ public abstract class BaseAspectV2Resource<
    */
   @Action(name = ACTION_BACKFILL_WITH_URNS)
   @Nonnull
-  public Task<BackfillResult> backfillWithUrns(@Nonnull Set<URN> urns) {
+  public Task<BackfillResult> backfillWithUrns(@Nonnull Set<Urn> urns) {
     return RestliUtils.toTask(() ->
         RestliUtils.buildBackfillResult(getLocalDAO().backfill(ImmutableSet.of(_aspectClass), urns)));
   }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV3Resource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV3Resource.java
@@ -1,0 +1,150 @@
+package com.linkedin.metadata.restli;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.dao.AspectKey;
+import com.linkedin.metadata.dao.BaseLocalDAO;
+import com.linkedin.metadata.events.IngestionTrackingContext;
+import com.linkedin.metadata.internal.IngestionParams;
+import com.linkedin.metadata.restli.dao.LocalDaoRegistry;
+import com.linkedin.parseq.Task;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.CreateResponse;
+import com.linkedin.restli.server.RestLiServiceException;
+import com.linkedin.restli.server.annotations.Action;
+import com.linkedin.restli.server.annotations.Optional;
+import com.linkedin.restli.server.annotations.RestMethod;
+import com.linkedin.restli.server.resources.CollectionResourceTaskTemplate;
+import java.net.URISyntaxException;
+import java.time.Clock;
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+import static com.linkedin.metadata.dao.BaseReadDAO.*;
+import static com.linkedin.metadata.restli.RestliConstants.*;
+
+
+/**
+ * This resource is intended to be used as top level resource, instead of a sub resource.
+ * For sub-resource please use {@link BaseVersionedAspectResource}
+ *
+ * @param <ASPECT> must be a valid aspect type inside ASPECT_UNION
+ */
+public abstract class BaseAspectV3Resource<ASPECT extends RecordTemplate> extends CollectionResourceTaskTemplate<String, ASPECT> {
+
+  private static final BaseRestliAuditor DUMMY_AUDITOR = new DummyRestliAuditor(Clock.systemUTC());
+
+  private final Class<ASPECT> _aspectClass;
+
+  public BaseAspectV3Resource(Class<ASPECT> aspectClass) {
+    _aspectClass = aspectClass;
+  }
+
+  /**
+   * Returns the {@link LocalDaoRegistry} that contains the mapping from entity type to {@link BaseLocalDAO}.
+   * @return {@link LocalDaoRegistry}
+   */
+  @Nonnull
+  protected abstract LocalDaoRegistry getLocalDaoRegistry();
+
+  /**
+   * Returns a {@link BaseRestliAuditor} for this resource.
+   */
+  @Nonnull
+  protected BaseRestliAuditor getAuditor() {
+    return DUMMY_AUDITOR;
+  }
+
+  /**
+   * Get the ASPECT associated with URN.
+   */
+  @RestMethod.Get
+  @Nonnull
+  public Task<ASPECT> get(@Nonnull String urnStr) {
+
+    try {
+      final Urn urn = Urn.createFromString(urnStr);
+      final String entityType = urn.getEntityType();
+      final AspectKey<ASPECT> key = new AspectKey<>(_aspectClass, urn, LATEST_VERSION);
+      return RestliUtils.toTask(() -> getLocalDao(entityType).get(key).orElseThrow(RestliUtils::resourceNotFoundException));
+
+    } catch (URISyntaxException e) {
+      throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST,
+          String.format("Failed to cast %s to Urn. Please check if urn if correctly formatted.", urnStr));
+    }
+  }
+
+  @RestMethod.Create
+  @Nonnull
+  public Task<CreateResponse> create(@Nonnull String urnStr, @Nonnull ASPECT aspect) {
+    return RestliUtils.toTask(() -> {
+      try {
+        final Urn urn = Urn.createFromString(urnStr);
+        final String entityType = urn.getEntityType();
+        final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
+        getLocalDao(entityType).add(urn, aspect, auditStamp);
+        return new CreateResponse(HttpStatus.S_201_CREATED);
+      } catch (URISyntaxException e) {
+        throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST,
+            String.format("Failed to cast %s to Urn. Please check if urn if correctly formatted.", urnStr));
+      }
+    });
+  }
+
+  @RestMethod.Create
+  @Nonnull
+  public Task<CreateResponse> createWithTracking(@Nonnull String urnStr, @Nonnull ASPECT aspect,
+      @Nonnull IngestionTrackingContext trackingContext, @Optional IngestionParams ingestionParams) {
+    return RestliUtils.toTask(() -> {
+      try {
+        final Urn urn = Urn.createFromString(urnStr);
+        final String entityType = urn.getEntityType();
+        final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
+        getLocalDao(entityType).add(urn, aspect, auditStamp, trackingContext, ingestionParams);
+        return new CreateResponse(HttpStatus.S_201_CREATED);
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /**
+   * Backfill ASPECT for each entity identified by its URN.
+   * @param urns Identifies a set of entities for which its ASPECT will be backfilled.
+   * @return BackfillResult for each entity identified by URN.
+   */
+  @Action(name = ACTION_BACKFILL_WITH_URNS)
+  @Nonnull
+  public Task<BackfillResult> backfillWithUrns(@Nonnull Set<String> urns) {
+
+    for (String urnStr : urns) {
+      final Urn urn;
+      try {
+        urn = Urn.createFromString(urnStr);
+        final String entityType = urn.getEntityType();
+
+        return RestliUtils.toTask(() ->
+            RestliUtils.buildBackfillResult(getLocalDao(entityType).backfill(ImmutableSet.of(_aspectClass), Collections.singleton(urn))));
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return null;
+  }
+
+  private BaseLocalDAO<? extends UnionTemplate, ? extends Urn> getLocalDao(String entityType) {
+    final java.util.Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> dao =
+        getLocalDaoRegistry().getLocalDaoByEntityType(entityType);
+    if (!dao.isPresent()) {
+      throw new RestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
+          String.format("LocalDAO not found for entity type: %s", entityType));
+    }
+
+    return dao.get();
+  }
+}

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticResource.java
@@ -84,7 +84,7 @@ public abstract class BaseEntityAgnosticResource {
 
       // for each entity type, backfill MAE for each urn in parallel
       for (String entityType : entityTypeToRequestsMap.keySet()) {
-        final Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> dao = getLocalDaoByEntity(entityType);
+        final Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> dao = getLocalDaoRegistry().getLocalDaoByEntityType(entityType);
         if (!dao.isPresent()) {
           log.warn("LocalDAO not found for entity type: " + entityType);
           continue;
@@ -119,7 +119,8 @@ public abstract class BaseEntityAgnosticResource {
       @ActionParam(PARAM_ENTITY_TYPE) @Nonnull String entityType,
       @ActionParam(PARAM_LIMIT) int limit) {
 
-    final Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> dao = getLocalDaoByEntity(entityType);
+    final Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> dao =
+        getLocalDaoRegistry().getLocalDaoByEntityType(entityType);
     if (!dao.isPresent()) {
       throw new RestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
           String.format("LocalDAO not found for entity type: %s", entityType));
@@ -154,13 +155,5 @@ public abstract class BaseEntityAgnosticResource {
       log.warn(String.format("Backfill failed for illegal state, urn: %s, aspectSet: %s", urn, aspectSet), e);
     }
     return Optional.empty();
-  }
-
-  /**
-   * Helper method to get the {@link BaseLocalDAO} from class {@link LocalDaoRegistry} for the given entity type.
-   */
-  protected Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> getLocalDaoByEntity(String entityType) {
-    LocalDaoRegistry localDaoRegistry = getLocalDaoRegistry();
-    return Optional.ofNullable(localDaoRegistry.getLocalDaoByEntityType(entityType));
   }
 }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableAspectResource.java
@@ -77,14 +77,14 @@ public abstract class BaseSearchableAspectResource<
   @Nonnull
   public CollectionResult<ASPECT, SearchResultMetadata> getSearchQueryCollectionResult(@Nonnull SearchResult<DOCUMENT> searchResult) {
 
-    final Set<URN> matchedUrns = searchResult.getDocumentList()
+    final Set<Urn> matchedUrns = searchResult.getDocumentList()
         .stream()
         .map(d -> (URN) ModelUtils.getUrnFromDocument(d))
         .collect(Collectors.toSet());
 
-    final Map<URN, java.util.Optional<ASPECT>> urnAspectMap = getLocalDAO().get(_aspectClass, matchedUrns);
+    final Map<Urn, java.util.Optional<ASPECT>> urnAspectMap = getLocalDAO().get(_aspectClass, matchedUrns);
 
-    final List<URN> existingUrns = matchedUrns.stream().filter(urnAspectMap::containsKey).collect(Collectors.toList());
+    final List<Urn> existingUrns = matchedUrns.stream().filter(urnAspectMap::containsKey).collect(Collectors.toList());
 
     final List<ASPECT> aspects = urnAspectMap.values().stream().filter(java.util.Optional::isPresent).map(
         java.util.Optional::get).collect(Collectors.toList());

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
@@ -159,12 +159,12 @@ public abstract class BaseSearchableEntityResource<
   public CollectionResult<VALUE, SearchResultMetadata> getSearchQueryCollectionResult(@Nonnull SearchResult<DOCUMENT> searchResult,
       @Nullable String[] aspectNames) {
 
-    final List<URN> matchedUrns = searchResult.getDocumentList()
+    final List<Urn> matchedUrns = searchResult.getDocumentList()
         .stream()
         .map(d -> (URN) ModelUtils.getUrnFromDocument(d))
         .collect(Collectors.toList());
-    final Map<URN, VALUE> urnValueMap = getInternalNonEmpty(matchedUrns, parseAspectsParam(aspectNames));
-    final List<URN> existingUrns = matchedUrns.stream().filter(urn -> urnValueMap.containsKey(urn)).collect(Collectors.toList());
+    final Map<Urn, VALUE> urnValueMap = getInternalNonEmpty(matchedUrns, parseAspectsParam(aspectNames));
+    final List<Urn> existingUrns = matchedUrns.stream().filter(urn -> urnValueMap.containsKey(urn)).collect(Collectors.toList());
     return new CollectionResult<>(
         existingUrns.stream().map(urn -> urnValueMap.get(urn)).collect(Collectors.toList()),
         searchResult.getTotalCount(),

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntityResource.java
@@ -72,7 +72,7 @@ public abstract class BaseSingleAspectEntityResource<
    * @return the complete entity.
    */
   @Nonnull
-  protected abstract VALUE createEntity(@Nonnull VALUE partialEntity, @Nonnull URN urn);
+  protected abstract VALUE createEntity(@Nonnull VALUE partialEntity, @Nonnull Urn urn);
 
   /**
    * Override {@link BaseEntityResource}'s method to override the default logic of returning entity values
@@ -81,7 +81,7 @@ public abstract class BaseSingleAspectEntityResource<
    */
   @Override
   @Nonnull
-  protected Map<URN, VALUE> getInternal(@Nonnull Collection<URN> urns,
+  protected Map<Urn, VALUE> getInternal(@Nonnull Collection<Urn> urns,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses) {
     return getUrnEntityMapInternal(urns);
   }
@@ -93,24 +93,24 @@ public abstract class BaseSingleAspectEntityResource<
    */
   @Override
   @Nonnull
-  protected Map<URN, VALUE> getInternalNonEmpty(@Nonnull Collection<URN> urns,
+  protected Map<Urn, VALUE> getInternalNonEmpty(@Nonnull Collection<Urn> urns,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses) {
     return getUrnEntityMapInternal(urns);
   }
 
   @Nonnull
-  private Map<URN, VALUE> getUrnEntityMapInternal(@Nonnull Collection<URN> urns) {
-    final Set<AspectKey<URN, ? extends RecordTemplate>> aspectKeys =
+  private Map<Urn, VALUE> getUrnEntityMapInternal(@Nonnull Collection<Urn> urns) {
+    final Set<AspectKey<? extends RecordTemplate>> aspectKeys =
         urns.stream().map(urn -> new AspectKey<>(_aspectClass, urn, LATEST_VERSION)).collect(Collectors.toSet());
 
-    final Map<AspectKey<URN, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspectKeyOptionalAspects =
+    final Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspectKeyOptionalAspects =
         getLocalDAO().get(aspectKeys);
 
     return aspectKeyOptionalAspects.entrySet()
         .stream()
         .filter(entry -> entry.getValue().isPresent())
         .collect(Collectors.toMap(entry -> entry.getKey().getUrn(), entry -> {
-          final URN urn = entry.getKey().getUrn();
+          final Urn urn = entry.getKey().getUrn();
           @SuppressWarnings("unchecked")
           ASPECT aspect = (ASPECT) entry.getValue().get();
           return createEntity(createPartialEntityFromAspect(aspect), urn);

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntityResource.java
@@ -66,7 +66,7 @@ public abstract class BaseSingleAspectSearchableEntityResource<
    * @return the complete entity.
    * */
   @Nonnull
-  protected abstract VALUE createEntity(@Nonnull VALUE partialEntity, @Nonnull URN urn);
+  protected abstract VALUE createEntity(@Nonnull VALUE partialEntity, @Nonnull Urn urn);
 
   /**
    * Override {@link BaseEntityResource}'s method to override the default logic of returning entity values
@@ -75,8 +75,8 @@ public abstract class BaseSingleAspectSearchableEntityResource<
    * */
   @Override
   @Nonnull
-  protected Map<URN, VALUE> getInternal(
-      @Nonnull Collection<URN> urns,
+  protected Map<Urn, VALUE> getInternal(
+      @Nonnull Collection<Urn> urns,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses) {
     // ignore the second parameter as it is not required for single aspect entities
     return getUrnEntityMapInternal(urns);
@@ -89,27 +89,27 @@ public abstract class BaseSingleAspectSearchableEntityResource<
    * */
   @Override
   @Nonnull
-  protected Map<URN, VALUE> getInternalNonEmpty(
-      @Nonnull Collection<URN> urns,
+  protected Map<Urn, VALUE> getInternalNonEmpty(
+      @Nonnull Collection<Urn> urns,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses) {
     // ignore the second parameter as it is not required for single aspect entities
     return getUrnEntityMapInternal(urns);
   }
 
   @Nonnull
-  private Map<URN, VALUE> getUrnEntityMapInternal(@Nonnull Collection<URN> urns) {
-    final Set<AspectKey<URN, ? extends RecordTemplate>> aspectKeys = urns.stream()
+  private Map<Urn, VALUE> getUrnEntityMapInternal(@Nonnull Collection<Urn> urns) {
+    final Set<AspectKey<? extends RecordTemplate>> aspectKeys = urns.stream()
         .map(urn -> new AspectKey<>(_aspectClass, urn, LATEST_VERSION))
         .collect(Collectors.toSet());
 
-    final Map<AspectKey<URN, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspectKeyOptionalAspects =
+    final Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspectKeyOptionalAspects =
         getLocalDAO().get(aspectKeys);
 
     return aspectKeyOptionalAspects.entrySet()
         .stream()
         .filter(entry -> entry.getValue().isPresent())
         .collect(Collectors.toMap(entry -> entry.getKey().getUrn(), entry -> {
-          final URN urn = entry.getKey().getUrn();
+          final Urn urn = entry.getKey().getUrn();
           @SuppressWarnings("unchecked") ASPECT aspect = (ASPECT) entry.getValue().get();
           return createEntity(createPartialEntityFromAspect(aspect), urn);
         }));

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/dao/DefaultLocalDaoRegistryImpl.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/dao/DefaultLocalDaoRegistryImpl.java
@@ -5,8 +5,8 @@ import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.BaseLocalDAO;
 import com.linkedin.metadata.dao.utils.ModelUtils;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 
 /**
@@ -57,13 +57,10 @@ public class DefaultLocalDaoRegistryImpl implements LocalDaoRegistry {
   }
 
   /**
-   * Returns the {@link BaseLocalDAO} registered on the given entity type.
-   *
-   * @param entityType the entity type string
-   * @return the {@link BaseLocalDAO} registered on the given entity type, or null if no such registration.
+   * Helper method to get the {@link BaseLocalDAO} from class {@link LocalDaoRegistry} for the given entity type.
    */
-  @Nullable
-  public BaseLocalDAO<? extends UnionTemplate, ? extends Urn> getLocalDaoByEntityType(@Nonnull String entityType) {
-    return entityTypeToLocalDaoMap.get(entityType);
+  @Override
+  public Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> getLocalDaoByEntityType(@Nonnull String entityType) {
+    return Optional.ofNullable(entityTypeToLocalDaoMap.get(entityType));
   }
 }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/dao/LocalDaoRegistry.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/dao/LocalDaoRegistry.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.restli.dao;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.BaseLocalDAO;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 
 
@@ -17,6 +18,6 @@ public interface LocalDaoRegistry {
    * @param entityType the entity type string
    * @return the {@link BaseLocalDAO} registered on the given entity type, or null if no such registration.
    */
-  BaseLocalDAO<? extends UnionTemplate, ? extends Urn> getLocalDaoByEntityType(@Nonnull String entityType);
+  Optional<BaseLocalDAO<? extends UnionTemplate, ? extends Urn>> getLocalDaoByEntityType(@Nonnull String entityType);
 }
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -163,7 +163,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     AspectBar bar = new AspectBar().setValue("bar");
     AspectAttributes attributes = new AspectAttributes();
 
-    AspectKey<FooUrn, AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspectBarKey)))).thenReturn(
@@ -190,7 +190,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     FooUrn urn = makeFooUrn(1234);
     AspectBar bar = new AspectBar().setValue("bar");
 
-    AspectKey<FooUrn, AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspectBarKey)))).thenReturn(
@@ -238,7 +238,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     FooUrn urn = makeFooUrn(1234);
     AspectFoo foo = new AspectFoo().setValue("foo");
 
-    AspectKey<FooUrn, AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspectBarKey)))).thenReturn(
@@ -258,7 +258,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     FooUrn urn = makeFooUrn(1234);
     AspectBar bar = new AspectBar().setValue("bar");
 
-    AspectKey<FooUrn, AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspectBarKey)))).thenReturn(
@@ -346,7 +346,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
   public void testGetSnapshotWithoutRoutingAspect() {
     FooUrn urn = makeFooUrn(1);
     AspectFoo bar = new AspectFoo().setValue("bar");
-    AspectKey<FooUrn, ? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
     when(_mockLocalDAO.get(ImmutableSet.of(barKey))).thenReturn(ImmutableMap.of(barKey, Optional.of(bar)));
 
     EntitySnapshot snapshot = runAndWait(_resource.getSnapshot(urn.toString(), new String[]{AspectBar.class.getCanonicalName()}));
@@ -364,8 +364,8 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectFoo bar = new AspectFoo().setValue("bar");
     AspectAttributes attributes = new AspectAttributes();
-    AspectKey<FooUrn, ? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
-    Set<AspectKey<FooUrn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(barKey);
+    AspectKey<? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    Set<AspectKey<? extends RecordTemplate>> aspectKeys = ImmutableSet.of(barKey);
     when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(barKey, Optional.of(bar)));
     when(_mockAspectFooGmsClient.get(urn)).thenReturn(foo);
     when(_mockAspectAttributeGmsClient.get(urn)).thenReturn(attributes);

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectV2ResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectV2ResourceTest.java
@@ -82,7 +82,7 @@ public class BaseAspectV2ResourceTest extends BaseEngineTest {
   @Test
   public void testGet() {
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, ENTITY_URN, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, ENTITY_URN, LATEST_VERSION);
     when(_mockLocalDAO.get(aspectKey)).thenReturn(Optional.of(foo));
     AspectFoo result = runAndWait(_resource.get(ENTITY_URN));
     assertEquals(result, foo);

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectV3ResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectV3ResourceTest.java
@@ -11,8 +11,11 @@ import com.linkedin.metadata.events.IngestionTrackingContext;
 import com.linkedin.metadata.restli.dao.DefaultLocalDaoRegistryImpl;
 import com.linkedin.metadata.restli.dao.LocalDaoRegistry;
 import com.linkedin.parseq.BaseEngineTest;
+import com.linkedin.restli.server.ResourceContext;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.EntityAspectUnion;
+import com.linkedin.testing.urn.FooUrn;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,12 +32,20 @@ import static org.testng.Assert.*;
 
 
 public class BaseAspectV3ResourceTest extends BaseEngineTest {
-  private BaseLocalDAO<EntityAspectUnion, Urn> _mockLocalDAO;
+  private BaseLocalDAO<EntityAspectUnion, FooUrn> _mockLocalDAO;
 
   private final BaseAspectV3ResourceTest.TestResource _resource =
       new com.linkedin.metadata.restli.BaseAspectV3ResourceTest.TestResource();
 
-  private static final Urn ENTITY_URN = makeUrn(1234);
+  private static final FooUrn ENTITY_URN;
+
+  static {
+    try {
+      ENTITY_URN = FooUrn.createFromString("urn:li:foo:1");
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   class TestResource extends BaseAspectV3Resource<AspectFoo> {
 
@@ -45,13 +56,19 @@ public class BaseAspectV3ResourceTest extends BaseEngineTest {
     @Nonnull
     @Override
     protected LocalDaoRegistry getLocalDaoRegistry() {
-      return DefaultLocalDaoRegistryImpl.init(Collections.singletonMap("testing", _mockLocalDAO));
+      return DefaultLocalDaoRegistryImpl.init(Collections.singletonMap("foo", _mockLocalDAO));
+    }
+
+    @Override
+    public ResourceContext getContext() {
+      return mock(ResourceContext.class);
     }
   }
 
   @BeforeMethod
   public void setup() {
     _mockLocalDAO = mock(BaseLocalDAO.class);
+    when(_mockLocalDAO.getUrnClass()).thenReturn(FooUrn.class);
   }
 
   @Test
@@ -68,6 +85,7 @@ public class BaseAspectV3ResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     runAndWait(_resource.create(ENTITY_URN.toString(), foo));
     verify(_mockLocalDAO, times(1)).add(eq(ENTITY_URN), eq(foo), any(AuditStamp.class));
+    verify(_mockLocalDAO, times(1)).getUrnClass();
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 
@@ -77,22 +95,22 @@ public class BaseAspectV3ResourceTest extends BaseEngineTest {
     IngestionTrackingContext trackingContext = new IngestionTrackingContext();
     runAndWait(_resource.createWithTracking(ENTITY_URN.toString(), foo, trackingContext, null));
     verify(_mockLocalDAO, times(1)).add(eq(ENTITY_URN), eq(foo), any(AuditStamp.class), eq(trackingContext), eq(null));
+    verify(_mockLocalDAO, times(1)).getUrnClass();
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 
   @Test
   public void testBackfill() {
     AspectFoo aspectFoo = new AspectFoo().setValue("value1");
-    Set<String> urnStrs = ImmutableSet.of(makeUrn(111).toString(), makeUrn(222).toString());
-    Set<Urn> urns = ImmutableSet.of(makeUrn(111), makeUrn(222));
+    Set<String> urnStrs = ImmutableSet.of(makeFooUrn(111).toString(), makeFooUrn(222).toString());
     Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillResult1 = new HashMap<>();
-    backfillResult1.put(makeUrn(111), ImmutableMap.of(AspectFoo.class, Optional.of(aspectFoo)));
+    backfillResult1.put(makeFooUrn(111), ImmutableMap.of(AspectFoo.class, Optional.of(aspectFoo)));
 
     Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillResult2 = new HashMap<>();
-    backfillResult2.put(makeUrn(222), ImmutableMap.of(AspectFoo.class, Optional.empty()));
+    backfillResult2.put(makeFooUrn(222), ImmutableMap.of(AspectFoo.class, Optional.empty()));
 
-    when(_mockLocalDAO.backfill(ImmutableSet.of(AspectFoo.class), Collections.singleton(makeUrn(111)))).thenReturn(backfillResult1);
-    when(_mockLocalDAO.backfill(ImmutableSet.of(AspectFoo.class), Collections.singleton(makeUrn(222)))).thenReturn(backfillResult2);
+    when(_mockLocalDAO.backfill(ImmutableSet.of(AspectFoo.class), Collections.singleton(makeFooUrn(111)))).thenReturn(backfillResult1);
+    when(_mockLocalDAO.backfill(ImmutableSet.of(AspectFoo.class), Collections.singleton(makeFooUrn(222)))).thenReturn(backfillResult2);
 
     BackfillResult result = runAndWait(_resource.backfillWithUrns(urnStrs));
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectV3ResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectV3ResourceTest.java
@@ -1,0 +1,101 @@
+package com.linkedin.metadata.restli;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.dao.AspectKey;
+import com.linkedin.metadata.dao.BaseLocalDAO;
+import com.linkedin.metadata.events.IngestionTrackingContext;
+import com.linkedin.metadata.restli.dao.DefaultLocalDaoRegistryImpl;
+import com.linkedin.metadata.restli.dao.LocalDaoRegistry;
+import com.linkedin.parseq.BaseEngineTest;
+import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.EntityAspectUnion;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.linkedin.metadata.dao.BaseReadDAO.*;
+import static com.linkedin.testing.TestUtils.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class BaseAspectV3ResourceTest extends BaseEngineTest {
+  private BaseLocalDAO<EntityAspectUnion, Urn> _mockLocalDAO;
+
+  private final BaseAspectV3ResourceTest.TestResource _resource =
+      new com.linkedin.metadata.restli.BaseAspectV3ResourceTest.TestResource();
+
+  private static final Urn ENTITY_URN = makeUrn(1234);
+
+  class TestResource extends BaseAspectV3Resource<AspectFoo> {
+
+    public TestResource() {
+      super(AspectFoo.class);
+    }
+
+    @Nonnull
+    @Override
+    protected LocalDaoRegistry getLocalDaoRegistry() {
+      return DefaultLocalDaoRegistryImpl.init(Collections.singletonMap("testing", _mockLocalDAO));
+    }
+  }
+
+  @BeforeMethod
+  public void setup() {
+    _mockLocalDAO = mock(BaseLocalDAO.class);
+  }
+
+  @Test
+  public void testGet() {
+    AspectFoo foo = new AspectFoo().setValue("foo");
+    AspectKey<AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, ENTITY_URN, LATEST_VERSION);
+    when(_mockLocalDAO.get(aspectKey)).thenReturn(Optional.of(foo));
+    AspectFoo result = runAndWait(_resource.get(ENTITY_URN.toString()));
+    assertEquals(result, foo);
+  }
+
+  @Test
+  public void testCreate() {
+    AspectFoo foo = new AspectFoo().setValue("foo");
+    runAndWait(_resource.create(ENTITY_URN.toString(), foo));
+    verify(_mockLocalDAO, times(1)).add(eq(ENTITY_URN), eq(foo), any(AuditStamp.class));
+    verifyNoMoreInteractions(_mockLocalDAO);
+  }
+
+  @Test
+  public void testCreateWithTracking() {
+    AspectFoo foo = new AspectFoo().setValue("foo");
+    IngestionTrackingContext trackingContext = new IngestionTrackingContext();
+    runAndWait(_resource.createWithTracking(ENTITY_URN.toString(), foo, trackingContext, null));
+    verify(_mockLocalDAO, times(1)).add(eq(ENTITY_URN), eq(foo), any(AuditStamp.class), eq(trackingContext), eq(null));
+    verifyNoMoreInteractions(_mockLocalDAO);
+  }
+
+  @Test
+  public void testBackfill() {
+    AspectFoo aspectFoo = new AspectFoo().setValue("value1");
+    Set<String> urnStrs = ImmutableSet.of(makeUrn(111).toString(), makeUrn(222).toString());
+    Set<Urn> urns = ImmutableSet.of(makeUrn(111), makeUrn(222));
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillResult1 = new HashMap<>();
+    backfillResult1.put(makeUrn(111), ImmutableMap.of(AspectFoo.class, Optional.of(aspectFoo)));
+
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillResult2 = new HashMap<>();
+    backfillResult2.put(makeUrn(222), ImmutableMap.of(AspectFoo.class, Optional.empty()));
+
+    when(_mockLocalDAO.backfill(ImmutableSet.of(AspectFoo.class), Collections.singleton(makeUrn(111)))).thenReturn(backfillResult1);
+    when(_mockLocalDAO.backfill(ImmutableSet.of(AspectFoo.class), Collections.singleton(makeUrn(222)))).thenReturn(backfillResult2);
+
+    BackfillResult result = runAndWait(_resource.backfillWithUrns(urnStrs));
+
+    assertEquals(result.getEntities().size(), 2);
+  }
+}

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityAgnosticResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityAgnosticResourceTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.restli;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.backfill.BackfillItem;
 import com.linkedin.metadata.backfill.BackfillMode;
@@ -212,7 +213,7 @@ public class BaseEntityAgnosticResourceTest extends BaseEngineTest {
   @Test
   public void testListUrns() {
     TestResource testResource = new TestResource();
-    List<FooUrn> urns = ImmutableList.of(makeFooUrn(2), makeFooUrn(3));
+    List<Urn> urns = ImmutableList.of(makeFooUrn(2), makeFooUrn(3));
 
     when(_fooLocalDAO.listUrns("urn:li:foo:1", 2, null, null))
         .thenReturn(urns);

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.restli;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.LongMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
@@ -155,10 +156,10 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   public void testGet() {
     FooUrn urn = makeFooUrn(1234);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<FooUrn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFooBar> aspect3Key = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, AspectAttributes> aspect4Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
+    AspectKey<AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspect3Key = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspect4Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key, aspect4Key)))).thenReturn(
         Collections.singletonMap(aspect1Key, Optional.of(foo)));
@@ -173,8 +174,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   public void testGetUrnNotFound() {
     FooUrn urn = makeFooUrn(1234);
 
-    AspectKey<FooUrn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(false);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key)))).thenReturn(Collections.emptyMap());
@@ -206,7 +207,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   public void testGetSpecificAspect() {
     FooUrn urn = makeFooUrn(1234);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<FooUrn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     String[] aspectNames = {AspectFoo.class.getCanonicalName()};
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
@@ -241,14 +242,14 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
 
-    AspectKey<FooUrn, AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
 
     when(_mockLocalDAO.get(ImmutableSet.of(aspectFooBarKey1, aspectFooBarKey2, aspectFooKey1, aspectBarKey1, aspectFooKey2,
         aspectBarKey2, aspectAttKey1, aspectAttKey2)))
@@ -270,8 +271,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   public void testBatchGetSpecificAspect() {
     FooUrn urn1 = makeFooUrn(1);
     FooUrn urn2 = makeFooUrn(2);
-    AspectKey<FooUrn, AspectFoo> fooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFoo> fooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFoo> fooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> fooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
     String[] aspectNames = {ModelUtils.getAspectName(AspectFoo.class)};
 
     runAndWait(_resource.batchGet(ImmutableSet.of(makeResourceKey(urn1), makeResourceKey(urn2)), aspectNames));
@@ -286,8 +287,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     FooUrn urn2 = makeFooUrn(2);
     String[] aspectNames = {ModelUtils.getAspectName(AspectFoo.class)};
 
-    AspectKey<FooUrn, AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
 
     when(_mockLocalDAO.get(ImmutableSet.of(aspectFooKey1, aspectFooKey2)))
         .thenReturn(Collections.emptyMap());
@@ -319,14 +320,14 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     FooUrn urn1 = makeFooUrn(1);
     FooUrn urn2 = makeFooUrn(2);
 
-    AspectKey<FooUrn, AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
 
     when(_mockLocalDAO.get(ImmutableSet.of(aspectFooBarKey1, aspectFooBarKey2, aspectFooKey1, aspectBarKey1, aspectFooKey2,
         aspectBarKey2, aspectAttKey1, aspectAttKey2)))
@@ -362,10 +363,10 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectBar bar = new AspectBar().setValue("bar");
     String[] aspectNames = {AspectFoo.class.getCanonicalName(), AspectBar.class.getCanonicalName()};
 
-    AspectKey<FooUrn, AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
 
     when(_mockLocalDAO.get(ImmutableSet.of(aspectFooKey1, aspectBarKey1, aspectFooKey2, aspectBarKey2)))
         .thenReturn(ImmutableMap.of(aspectFooKey1, Optional.of(foo), aspectBarKey2, Optional.of(bar)));
@@ -401,10 +402,10 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     String[] aspectNames = {AspectFoo.class.getCanonicalName(), AspectBar.class.getCanonicalName()};
 
-    AspectKey<FooUrn, AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
-    AspectKey<FooUrn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
-    AspectKey<FooUrn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
 
     when(_mockLocalDAO.get(ImmutableSet.of(aspectFooKey1, aspectBarKey1, aspectFooKey2, aspectBarKey2)))
         .thenReturn(ImmutableMap.of(aspectFooKey1, Optional.of(foo), aspectBarKey2, Optional.empty()));
@@ -501,8 +502,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   public void testGetSnapshotWithOneAspect() {
     FooUrn urn = makeFooUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<FooUrn, ? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    Set<AspectKey<FooUrn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey);
+    AspectKey<? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    Set<AspectKey<? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey);
     when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo)));
     String[] aspectNames = new String[]{ModelUtils.getAspectName(AspectFoo.class)};
 
@@ -521,12 +522,12 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectFooBar fooBar = new AspectFooBar().setBars(new BarUrnArray(new BarUrn(1)));
     AspectAttributes attributes = new AspectAttributes().setAttributes(new StringArray("a"));
 
-    AspectKey<FooUrn, ? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, ? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, ? extends RecordTemplate> fooBarKey = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, ? extends RecordTemplate> attKey = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> fooBarKey = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> attKey = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
 
-    Set<AspectKey<FooUrn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, attKey);
+    Set<AspectKey<? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, attKey);
     when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo), barKey, Optional.of(bar),
         fooBarKey, Optional.of(fooBar), attKey, Optional.of(attributes)));
 
@@ -806,7 +807,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     FooUrn urn1 = makeFooUrn(1);
     FooUrn urn2 = makeFooUrn(2);
     FooUrn urn3 = makeFooUrn(3);
-    List<FooUrn> urns1 = Arrays.asList(urn2, urn3);
+    List<Urn> urns1 = Arrays.asList(urn2, urn3);
 
     when(_mockLocalDAO.listUrns(indexFilter1, urn1, 2)).thenReturn(urns1);
     String[] actual = runAndWait(_resource.listUrnsFromIndex(indexFilter1, urn1.toString(), 2));
@@ -820,7 +821,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual, new String[]{urn2.toString(), urn3.toString()});
 
     // case 3: lastUrn is null
-    List<FooUrn> urns3 = Arrays.asList(urn1, urn2);
+    List<Urn> urns3 = Arrays.asList(urn1, urn2);
     when(_mockLocalDAO.listUrns(indexFilter2, null, 2)).thenReturn(urns3);
     actual = runAndWait(_resource.listUrnsFromIndex(indexFilter2, null, 2));
     assertEquals(actual, new String[]{urn1.toString(), urn2.toString()});
@@ -835,7 +836,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     FooUrn urn2 = makeFooUrn(2);
     FooUrn urn3 = makeFooUrn(3);
 
-    List<FooUrn> urns1 = Arrays.asList(urn2, urn3);
+    List<Urn> urns1 = Arrays.asList(urn2, urn3);
 
     when(_mockLocalDAO.listUrns(indexFilter1, null, urn1, 2)).thenReturn(urns1);
     List<EntityValue> actual =
@@ -846,7 +847,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual.get(1), new EntityValue());
 
     // case 2: lastUrn is null
-    List<FooUrn> urns2 = Arrays.asList(urn1, urn2);
+    List<Urn> urns2 = Arrays.asList(urn1, urn2);
     IndexCriterion indexCriterion2 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
     IndexFilter indexFilter2 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion2));
     when(_mockLocalDAO.listUrns(null, null, null, 2)).thenReturn(urns2);
@@ -856,7 +857,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual.get(1), new EntityValue());
 
     // case 3: sortCriterion is not null
-    List<FooUrn> urns3 = Arrays.asList(urn3, urn2);
+    List<Urn> urns3 = Arrays.asList(urn3, urn2);
     IndexSortCriterion indexSortCriterion = new IndexSortCriterion().setAspect("aspect1").setPath("/id")
         .setOrder(SortOrder.DESCENDING);
     when(_mockLocalDAO.listUrns(null, indexSortCriterion, null, 2)).thenReturn(urns3);
@@ -866,7 +867,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual.get(1), new EntityValue());
 
     // case 4: offset pagination
-    ListResult<FooUrn> urnsListResult = ListResult.<FooUrn>builder()
+    ListResult<Urn> urnsListResult = ListResult.<Urn>builder()
         .values(urns3)
         .metadata(null)
         .nextStart(ListResult.INVALID_NEXT_START)
@@ -898,8 +899,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectBar bar1 = new AspectBar().setValue("val1");
     AspectBar bar2 = new AspectBar().setValue("val2");
 
-    UrnAspectEntry<FooUrn> entry1 = new UrnAspectEntry<>(urn1, Arrays.asList(foo1, bar1));
-    UrnAspectEntry<FooUrn> entry2 = new UrnAspectEntry<>(urn2, Arrays.asList(foo2, bar2));
+    UrnAspectEntry entry1 = new UrnAspectEntry(urn1, Arrays.asList(foo1, bar1));
+    UrnAspectEntry entry2 = new UrnAspectEntry(urn2, Arrays.asList(foo2, bar2));
 
     IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName());
     IndexCriterionArray criterionArray = new IndexCriterionArray(criterion);
@@ -909,7 +910,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     String[] aspectNames = {ModelUtils.getAspectName(AspectFoo.class), ModelUtils.getAspectName(AspectBar.class)};
 
     // case 1: aspect list is provided, null last urn
-    List<UrnAspectEntry<FooUrn>> listResult1 = Arrays.asList(entry1, entry2);
+    List<UrnAspectEntry> listResult1 = Arrays.asList(entry1, entry2);
 
     when(_mockLocalDAO.getAspects(ImmutableSet.of(AspectFoo.class, AspectBar.class), indexFilter, null, null, 2))
         .thenReturn(listResult1);
@@ -922,7 +923,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual1.get(1), new EntityValue().setFoo(foo2).setBar(bar2));
 
     // case 2: null aspects is provided i.e. all aspects in the aspect union will be returned, non-null last urn
-    List<UrnAspectEntry<FooUrn>> listResult2 = Collections.singletonList(entry2);
+    List<UrnAspectEntry> listResult2 = Collections.singletonList(entry2);
 
     when(_mockLocalDAO.getAspects(ImmutableSet.of(AspectFoo.class, AspectBar.class, AspectFooBar.class, AspectAttributes.class), indexFilter, null, urn1, 2))
         .thenReturn(listResult2);
@@ -933,7 +934,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual2.get(0), new EntityValue().setFoo(foo2).setBar(bar2));
 
     // case 3: non-null sort criterion is provided
-    List<UrnAspectEntry<FooUrn>> listResult3 = Arrays.asList(entry2, entry1);
+    List<UrnAspectEntry> listResult3 = Arrays.asList(entry2, entry1);
 
     when(_mockLocalDAO.getAspects(ImmutableSet.of(AspectFoo.class, AspectBar.class), indexFilter, indexSortCriterion, null, 2))
         .thenReturn(listResult3);
@@ -946,7 +947,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(actual3.get(1), new EntityValue().setFoo(foo1).setBar(bar1));
 
     // case 4: offset pagination
-    ListResult<UrnAspectEntry<FooUrn>> urnsListResult = ListResult.<UrnAspectEntry<FooUrn>>builder()
+    ListResult<UrnAspectEntry> urnsListResult = ListResult.<UrnAspectEntry>builder()
         .values(Arrays.asList(entry2, entry1))
         .metadata(null)
         .nextStart(ListResult.INVALID_NEXT_START)
@@ -1003,8 +1004,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectBar bar1 = new AspectBar().setValue("val1");
     AspectBar bar2 = new AspectBar().setValue("val2");
 
-    UrnAspectEntry<FooUrn> entry1 = new UrnAspectEntry<>(urn1, Arrays.asList(foo1, bar1));
-    UrnAspectEntry<FooUrn> entry2 = new UrnAspectEntry<>(urn2, Arrays.asList(foo2, bar2));
+    UrnAspectEntry entry1 = new UrnAspectEntry(urn1, Arrays.asList(foo1, bar1));
+    UrnAspectEntry entry2 = new UrnAspectEntry(urn2, Arrays.asList(foo2, bar2));
 
     IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName());
     IndexCriterionArray criterionArray = new IndexCriterionArray(criterion);
@@ -1031,8 +1032,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectBar bar1 = new AspectBar().setValue("val1");
     AspectBar bar2 = new AspectBar().setValue("val2");
 
-    UrnAspectEntry<FooUrn> entry1 = new UrnAspectEntry<>(urn1, Arrays.asList(foo1, bar1));
-    UrnAspectEntry<FooUrn> entry2 = new UrnAspectEntry<>(urn2, Arrays.asList(foo2, bar2));
+    UrnAspectEntry entry1 = new UrnAspectEntry(urn1, Arrays.asList(foo1, bar1));
+    UrnAspectEntry entry2 = new UrnAspectEntry(urn2, Arrays.asList(foo2, bar2));
 
     IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName());
     IndexCriterionArray criterionArray = new IndexCriterionArray(criterion);

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
@@ -58,10 +58,10 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     long id = 1234;
     Urn urn = makeUrn(id);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    AspectKey<Urn, AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
-    AspectKey<Urn, AspectFooBar> aspect3Key = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
-    AspectKey<Urn, AspectAttributes> aspect4Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
+    AspectKey<AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspect3Key = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspect4Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key, aspect4Key))))
@@ -93,8 +93,8 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     long id = 1234;
     Urn urn = makeUrn(id);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    AspectKey<Urn, AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
     when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key))))
@@ -114,7 +114,7 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     long id = 1234;
     Urn urn = makeUrn(id);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     String[] aspectNames = {AspectFoo.class.getCanonicalName()};
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
@@ -152,14 +152,14 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
 
-    AspectKey<Urn, AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<Urn, AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
-    AspectKey<Urn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
-    AspectKey<Urn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
-    AspectKey<Urn, AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
-    AspectKey<Urn, AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
-    AspectKey<Urn, AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
-    AspectKey<Urn, AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
+    AspectKey<AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
+    AspectKey<AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
 
     when(_mockLocalDAO.get(ImmutableSet.of(aspectFooKey1, aspectBarKey1, aspectAttKey1, aspectFooKey2, aspectBarKey2,
         aspectAttKey2, aspectFooBarKey1, aspectFooBarKey2))).thenReturn(
@@ -183,8 +183,8 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     Urn urn1 = makeUrn(id1);
     long id2 = 2;
     Urn urn2 = makeUrn(id2);
-    AspectKey<Urn, AspectFoo> fooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
-    AspectKey<Urn, AspectFoo> fooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
+    AspectKey<AspectFoo> fooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
+    AspectKey<AspectFoo> fooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
     String[] aspectNames = {ModelUtils.getAspectName(AspectFoo.class)};
 
     runAndWait(_resource.batchGet(ImmutableSet.of(id1, id2), aspectNames));
@@ -213,8 +213,8 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
   public void testGetSnapshotWithOneAspect() {
     Urn urn = makeUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, ? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    Set<AspectKey<Urn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey);
+    AspectKey<? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    Set<AspectKey<? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey);
     when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo)));
     String[] aspectNames = new String[]{ModelUtils.getAspectName(AspectFoo.class)};
 
@@ -232,11 +232,11 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     AspectBar bar = new AspectBar().setValue("bar");
     AspectFooBar fooBar = new AspectFooBar().setBars(new BarUrnArray(new BarUrn(1)));
     AspectAttributes att = new AspectAttributes().setAttributes(new StringArray("a"));
-    AspectKey<Urn, ? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
-    AspectKey<Urn, ? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
-    AspectKey<Urn, ? extends RecordTemplate> fooBarKey = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
-    AspectKey<Urn, ? extends RecordTemplate> attKey = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
-    Set<AspectKey<Urn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, attKey);
+    AspectKey<? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> fooBarKey = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
+    AspectKey<? extends RecordTemplate> attKey = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
+    Set<AspectKey<? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, attKey);
     when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo), barKey, Optional.of(bar),
         fooBarKey, Optional.of(fooBar), attKey, Optional.of(att)));
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSearchableEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSearchableEntityResourceTest.java
@@ -140,8 +140,8 @@ public class BaseSearchableEntityResourceTest extends BaseEngineTest {
     Urn urn1 = makeUrn(1);
     Urn urn2 = makeUrn(2);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
-    AspectKey<Urn, AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
     SearchResultMetadata searchResultMetadata = makeSearchResultMetadata(new AggregationMetadata().setName("agg")
         .setAggregations(new LongMap(ImmutableMap.of("bucket1", 1L, "bucket2", 2L))));
 
@@ -169,8 +169,8 @@ public class BaseSearchableEntityResourceTest extends BaseEngineTest {
     Urn urn1 = makeUrn(1);
     Urn urn2 = makeUrn(2);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
-    AspectKey<Urn, AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
 
     // Test with two filter criteria and validate it returns the right search result metadata
     Filter filterWithTwoCriteria = newFilter(ImmutableMap.of("removed1", "true", "removed2", "false"));
@@ -227,8 +227,8 @@ public class BaseSearchableEntityResourceTest extends BaseEngineTest {
     Urn urn1 = makeUrn(1);
     Urn urn2 = makeUrn(2);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
-    AspectKey<Urn, AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
 
     SortCriterion sortCriterion1 = new SortCriterion().setField("urn").setOrder(SortOrder.ASCENDING);
 
@@ -263,7 +263,7 @@ public class BaseSearchableEntityResourceTest extends BaseEngineTest {
 
     // test the case when there is more results in the search index
     Urn urn3 = makeUrn(3);
-    AspectKey<Urn, AspectFoo> aspectKey3 = new AspectKey<>(AspectFoo.class, urn3, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey3 = new AspectKey<>(AspectFoo.class, urn3, BaseLocalDAO.LATEST_VERSION);
     when(_mockSearchDAO.filter(EMPTY_FILTER, sortCriterion1, 1, 3)).thenReturn(
         makeSearchResult(ImmutableList.of(makeDocument(urn1), makeDocument(urn2), makeDocument(urn3)), 3, new SearchResultMetadata()));
     when(_mockLocalDAO.get(ImmutableSet.of(aspectKey1, aspectKey2, aspectKey3))).thenReturn(

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSearchableEntitySimpleKeyResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSearchableEntitySimpleKeyResourceTest.java
@@ -62,8 +62,8 @@ public class BaseSearchableEntitySimpleKeyResourceTest extends BaseEngineTest {
     Urn urn1 = makeUrn(1);
     Urn urn2 = makeUrn(2);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
-    AspectKey<Urn, AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
     Filter filter = new Filter().setCriteria(new CriterionArray());
     SearchResultMetadata searchResultMetadata = makeSearchResultMetadata(new AggregationMetadata().setName("agg")
         .setAggregations(new LongMap(ImmutableMap.of("bucket1", 1L, "bucket2", 2L))));
@@ -121,8 +121,8 @@ public class BaseSearchableEntitySimpleKeyResourceTest extends BaseEngineTest {
     Urn urn1 = makeUrn(1);
     Urn urn2 = makeUrn(2);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
-    AspectKey<Urn, AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey1 = new AspectKey<>(AspectFoo.class, urn1, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey2 = new AspectKey<>(AspectFoo.class, urn2, BaseLocalDAO.LATEST_VERSION);
 
     Filter filter1 = new Filter().setCriteria(new CriterionArray());
     SortCriterion sortCriterion1 = new SortCriterion().setField("urn").setOrder(SortOrder.ASCENDING);
@@ -159,7 +159,7 @@ public class BaseSearchableEntitySimpleKeyResourceTest extends BaseEngineTest {
 
     // test the case when there is more results in the search index
     Urn urn3 = makeUrn(3);
-    AspectKey<Urn, AspectFoo> aspectKey3 = new AspectKey<>(AspectFoo.class, urn3, BaseLocalDAO.LATEST_VERSION);
+    AspectKey<AspectFoo> aspectKey3 = new AspectKey<>(AspectFoo.class, urn3, BaseLocalDAO.LATEST_VERSION);
     when(_mockSearchDAO.filter(filter1, sortCriterion1, 1, 3)).thenReturn(
         makeSearchResult(ImmutableList.of(makeDocument(urn1), makeDocument(urn2), makeDocument(urn3)), 3, new SearchResultMetadata()));
     when(_mockLocalDAO.get(ImmutableSet.of(aspectKey1, aspectKey2, aspectKey3))).thenReturn(

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyResourceTest.java
@@ -60,7 +60,7 @@ public class BaseSingleAspectEntitySimpleKeyResourceTest extends BaseEngineTest 
 
     SingleAspectEntityUrn urn = new SingleAspectEntityUrn(id1);
     AspectBar aspect = new AspectBar().setValue(field1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
     when(_mockLocalDao.exists(urn)).thenReturn(true);
     when(_mockLocalDao.get(Collections.singleton(aspectKey))).thenReturn(
         Collections.singletonMap(aspectKey, Optional.of(aspect)));
@@ -82,15 +82,15 @@ public class BaseSingleAspectEntitySimpleKeyResourceTest extends BaseEngineTest 
 
     SingleAspectEntityUrn urn1 = new SingleAspectEntityUrn(id1);
     AspectBar aspect1 = new AspectBar().setValue(field1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> aspectKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
 
     SingleAspectEntityUrn urn2 = new SingleAspectEntityUrn(id2);
     AspectBar aspect2 = new AspectBar().setValue(field11);
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
+    AspectKey<AspectBar> aspectKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
 
-    Set<AspectKey<SingleAspectEntityUrn, ? extends RecordTemplate>> keys =
+    Set<AspectKey<? extends RecordTemplate>> keys =
         new HashSet<>(Arrays.asList(aspectKey1, aspectKey2));
-    Map<AspectKey<SingleAspectEntityUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> keyAspectMap =
+    Map<AspectKey<? extends RecordTemplate>, Optional<? extends RecordTemplate>> keyAspectMap =
         new HashMap<>();
     keyAspectMap.put(aspectKey1, Optional.of(aspect1));
     keyAspectMap.put(aspectKey2, Optional.of(aspect2));
@@ -111,7 +111,7 @@ public class BaseSingleAspectEntitySimpleKeyResourceTest extends BaseEngineTest 
     long id1 = 100L;
 
     SingleAspectEntityUrn urn = new SingleAspectEntityUrn(id1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
     when(_mockLocalDao.get(Collections.singleton(aspectKey))).thenReturn(Collections.emptyMap());
 
     try {
@@ -149,7 +149,7 @@ public class BaseSingleAspectEntitySimpleKeyResourceTest extends BaseEngineTest 
     AspectBar aspect = new AspectBar().setValue(field1);
     List<EntityAspectUnion> aspectUnions =
         Collections.singletonList(ModelUtils.newAspectUnion(EntityAspectUnion.class, aspect));
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDao.get(Collections.singleton(aspectKey))).thenReturn(
         Collections.singletonMap(aspectKey, Optional.of(aspect)));
@@ -162,7 +162,7 @@ public class BaseSingleAspectEntitySimpleKeyResourceTest extends BaseEngineTest 
   public void testGetSnapshotWithInvalidUrn() throws URISyntaxException {
     long id1 = 100L;
     SingleAspectEntityUrn urn = new SingleAspectEntityUrn(id1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
+    AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
 
     when(_mockLocalDao.get(aspectKey)).thenReturn(Optional.empty());
     try {
@@ -254,7 +254,7 @@ public class BaseSingleAspectEntitySimpleKeyResourceTest extends BaseEngineTest 
 
     @Override
     @Nonnull
-    protected EntityValue createEntity(@Nonnull EntityValue partialEntity, @Nonnull SingleAspectEntityUrn urn) {
+    protected EntityValue createEntity(@Nonnull EntityValue partialEntity, @Nonnull Urn urn) {
       return partialEntity.setId(urn.getIdAsLong());
     }
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyVersionedSubResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyVersionedSubResourceTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.restli;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.dao.AspectKey;
 import com.linkedin.metadata.dao.BaseLocalDAO;
 import com.linkedin.metadata.dao.ListResult;
@@ -48,7 +49,7 @@ public class BaseSingleAspectEntitySimpleKeyVersionedSubResourceTest extends Bas
 
     SingleAspectEntityUrn urn = new SingleAspectEntityUrn(id1);
     AspectBar aspect = new AspectBar().setValue(field1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, version);
+    AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, version);
 
     when(_mockLocalDao.get(aspectKey)).thenReturn(Optional.of(aspect));
 
@@ -64,7 +65,7 @@ public class BaseSingleAspectEntitySimpleKeyVersionedSubResourceTest extends Bas
     long version = 10_000L;
 
     SingleAspectEntityUrn urn = new SingleAspectEntityUrn(id1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, version);
+    AspectKey<AspectBar> aspectKey = new AspectKey<>(AspectBar.class, urn, version);
 
     when(_mockLocalDao.get(aspectKey)).thenReturn(Optional.empty());
 
@@ -188,7 +189,7 @@ public class BaseSingleAspectEntitySimpleKeyVersionedSubResourceTest extends Bas
 
     @Override
     @Nonnull
-    protected EntityValue createEntity(@Nonnull EntityValue partialEntity, @Nonnull SingleAspectEntityUrn urn) {
+    protected EntityValue createEntity(@Nonnull EntityValue partialEntity, @Nonnull Urn urn) {
       return partialEntity.setId(urn.getIdAsLong());
     }
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntitySimpleKeyResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntitySimpleKeyResourceTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.restli;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.dao.AspectKey;
 import com.linkedin.metadata.dao.BaseLocalDAO;
@@ -55,7 +56,7 @@ public class BaseSingleAspectSearchableEntitySimpleKeyResourceTest extends BaseE
     SingleAspectEntityUrn urn1 = new SingleAspectEntityUrn(id1);
     AspectBar aspect1 = new AspectBar().setValue(field1);
     EntityValue value1 = new EntityValue().setValue(field1).setId(id1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> key1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> key1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
 
     String searchInput = "foo";
 
@@ -113,7 +114,7 @@ public class BaseSingleAspectSearchableEntitySimpleKeyResourceTest extends BaseE
     AspectBar aspect1 = new AspectBar().setValue(field1);
     EntityValue value1 = new EntityValue().setValue(field1).setId(id1);
     EntityDocument document1 = new EntityDocument().setF1(field1).setUrn(urn1);
-    AspectKey<SingleAspectEntityUrn, AspectBar> key1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
+    AspectKey<AspectBar> key1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
 
     long id11 = 200L;
     SingleAspectEntityUrn urn11 = new SingleAspectEntityUrn(id11);
@@ -121,7 +122,7 @@ public class BaseSingleAspectSearchableEntitySimpleKeyResourceTest extends BaseE
     AspectBar aspect11 = new AspectBar().setValue(field11);
     EntityValue value11 = new EntityValue().setValue(field11).setId(id11);
     EntityDocument document11 = new EntityDocument().setF1(field11).setUrn(urn11);
-    AspectKey<SingleAspectEntityUrn, AspectBar> key11 = new AspectKey<>(AspectBar.class, urn11, LATEST_VERSION);
+    AspectKey<AspectBar> key11 = new AspectKey<>(AspectBar.class, urn11, LATEST_VERSION);
 
     PagingContext pagingContext1 = new PagingContext(0, 2);
 
@@ -186,7 +187,7 @@ public class BaseSingleAspectSearchableEntitySimpleKeyResourceTest extends BaseE
 
     @Override
     @Nonnull
-    protected EntityValue createEntity(@Nonnull EntityValue partialEntity, @Nonnull SingleAspectEntityUrn urn) {
+    protected EntityValue createEntity(@Nonnull EntityValue partialEntity, @Nonnull Urn urn) {
       return partialEntity.setId(urn.getIdAsLong());
     }
   }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseVersionedAspectResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseVersionedAspectResourceTest.java
@@ -70,7 +70,7 @@ public class BaseVersionedAspectResourceTest extends BaseEngineTest {
   @Test
   public void testGet() {
     AspectFoo foo = new AspectFoo().setValue("foo");
-    AspectKey<Urn, AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, ENTITY_URN, 123L);
+    AspectKey<AspectFoo> aspectKey = new AspectKey<>(AspectFoo.class, ENTITY_URN, 123L);
 
     when(_mockLocalDAO.get(aspectKey)).thenReturn(Optional.of(foo));
 


### PR DESCRIPTION
## Context
Aspect-routing is an essential feature provided by Metadata Graph. As part of the simplify metadata onboarding initiative, we will need to make this feature easy to enable. Current process (_go/mg/aspectrouting, a 7-page doc on how to enable aspect-routing_) for enabling aspect-routing has many moving pieces and requires code changes as different places.

## Solution
Inspired by existing `BaseEntityAgnosticResource`, we introduce `BaseAspectV3Resource` in this PR. The new BaseAspectV3Resource has mostly same set of methods as its previous version BaseAspectV2Resource. The major difference is that BaseAspectV3Resource is **entity agnostic**. User only needs to specify the routing aspect when implementing it. 

Using `AccoutableOwnership` aspect as an example, the class signature will be

from 
`public class GrpcMethodAccountableOwnershipResource extends BaseAspectV2Resource<GrpcMethodUrn, GrpcMethodAspect, AccountableOwnership>`
to 
`public class AccountableOwnershipResource extends BaseAspectV3Resource<AccountableOwnership>`

## Why this solution
The major benefit of this solution is when a new entity is onboarded, user will _not_ need to go to aspect GMS e.g. ownership-gms to implement new clients and new resources etc. The AccountableOwnershipResource hosted in ownership-gms should be able read / write AccountableOwnership not no matter which entity the aspect is attached to.

## Testing Done
Unit test

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
