### PR TITLE
bug fix - consider entity type when using aspect routing client in backfill

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,11 @@ coverage:
         # this allows a 0% drop from the previous base commit coverage
         threshold: 0%
         only_pulls: true # no status will be posted for commits not on a pull request
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        only_pulls: true
 
 github_checks:
   annotations: false

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingGmsClient.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingGmsClient.java
@@ -8,12 +8,20 @@ import com.linkedin.restli.server.RestLiServiceException;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.Getter;
 
 
 /**
  * A client interacts with standard GMS APIs.
  */
 public abstract class BaseAspectRoutingGmsClient {
+
+  @Getter
+  private final String entityType;
+
+  public BaseAspectRoutingGmsClient(String entityType) {
+    this.entityType = entityType;
+  }
 
   /**
    * Retrieves the latest version of the routing aspect for an entity.

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingGmsClient.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingGmsClient.java
@@ -16,6 +16,9 @@ import lombok.Getter;
  */
 public abstract class BaseAspectRoutingGmsClient {
 
+  /**
+   * The entity type associated with the aspect / client.
+   */
   @Getter
   private final String entityType;
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -82,7 +82,7 @@ public abstract class BaseEntityResource<
   private final Class<SNAPSHOT> _snapshotClass;
   private final Class<ASPECT_UNION> _aspectUnionClass;
   private final Set<Class<? extends RecordTemplate>> _supportedAspectClasses;
-  private final Class<URN> _urnClass;
+  protected final Class<URN> _urnClass;
 
   protected BaseTrackingManager _trackingManager = null;
 


### PR DESCRIPTION
## Summary
currently, every client registered in the aspect routing manager will be used regardless of the entity. It will cause problems in backfill since we want a GMS to share the same routing manager.

With this pr, only clients that have same entity type as the aspectroutingresource will be used in the backfill.

## Testing Done
./gradlew build

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
