### PR TITLE
Update EbeanLocalAccess batchGetUnion SQL query from "UNION ALL" to "IN"

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -186,11 +186,10 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   /**
    * Construct and execute a SQL statement as follows.
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
-   * UNION ALL
-   * SELECT urn, aspect2, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND JSON_EXTRACT(aspect2, '$.gma_deleted') IS NULL
-   * UNION ALL
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:2' AND JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
+   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby
+   * FROM metadata_entity_foo
+   * WHERE JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
+   * AND urn IN ('urn:1', 'urn:2', 'urn:3')
    * @param aspectKeys a List of keys (urn, aspect pairings) to query for
    * @param keysCount number of keys to query
    * @param position position of the key to start from

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -79,9 +79,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   protected final EbeanServer _server;
   protected final Class<URN> _urnClass;
-
-  private final static int DEFAULT_BATCH_SIZE = 50;
-  private int _queryKeysCount = DEFAULT_BATCH_SIZE;
+  private int _queryKeysCount = 0; // 0 means no pagination on keys
   private IEbeanLocalAccess<URN> _localAccess;
   private SchemaConfig _schemaConfig = SchemaConfig.OLD_SCHEMA_ONLY;
   private final EBeanDAOConfig _eBeanDAOConfig = new EBeanDAOConfig();
@@ -901,12 +899,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (keys.isEmpty()) {
       return Collections.emptyMap();
     }
-    final List<EbeanMetadataAspect> records;
-    if (_queryKeysCount == 0) {
-      records = batchGet(keys, keys.size());
-    } else {
-      records = batchGet(keys, _queryKeysCount);
-    }
+
+    final List<EbeanMetadataAspect> records = batchGet(keys, keys.size());
+
     final Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> result =
         new HashMap<>();
     keys.forEach(key -> records.stream()
@@ -946,18 +941,13 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Sets the max keys allowed for each single query, not allowed more than the default batch size.
+   * Sets the max keys allowed for each single query
    */
   public void setQueryKeysCount(int keysCount) {
     if (keysCount < 0) {
       throw new IllegalArgumentException("Query keys count must be non-negative: " + keysCount);
-    } else if (keysCount > DEFAULT_BATCH_SIZE) {
-      log.warn("Setting query keys count greater than " + DEFAULT_BATCH_SIZE
-          + " may cause performance issues. Defaulting to " + DEFAULT_BATCH_SIZE + ".");
-      _queryKeysCount = DEFAULT_BATCH_SIZE;
-    } else {
-      _queryKeysCount = keysCount;
     }
+    _queryKeysCount = keysCount;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -941,7 +941,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Sets the max keys allowed for each single query
+   * Sets the max keys allowed for each single query.
    */
   public void setQueryKeysCount(int keysCount) {
     if (keysCount < 0) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -55,11 +55,19 @@ public class SQLStatementUtilsTest {
     Set<Urn> set = new HashSet<>();
     set.add(fooUrn1);
     set.add(fooUrn2);
+    // test when includeSoftDeleted is false
     String expectedSql =
-        "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:li:foo:1' "
-            + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL UNION ALL SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
-            + "FROM metadata_entity_foo WHERE urn = 'urn:li:foo:2' AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL";
+        "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
+            + "FROM metadata_entity_foo "
+            + "WHERE JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL "
+            + "AND urn IN ('urn:li:foo:1', 'urn:li:foo:2')";
     assertEquals(SQLStatementUtils.createAspectReadSql(AspectFoo.class, set, false), expectedSql);
+    // test when includeSoftDeleted is true
+    expectedSql =
+        "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
+            + "FROM metadata_entity_foo "
+            + "WHERE urn IN ('urn:li:foo:1', 'urn:li:foo:2')";
+    assertEquals(SQLStatementUtils.createAspectReadSql(AspectFoo.class, set, true), expectedSql);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Based on previous TMS [issues](https://docs.google.com/document/d/1-aCoR9kZRUDMKw_cLNcwtbWMvkUzwiTF1Nry1CgdaRs/edit) and slow query [analysis](https://docs.google.com/spreadsheets/d/1_0Dk88Z_YXKOCNwxAClSzIeJOekhfPZIjqRpK715VvQ/edit#gid=332139990), we identified the UNION ALL type of queries are taking a long time, exhausts DB resources, and can cause slow response times. One sample query is:
```
SELECT urn, a_clusterdatasetsla, lastmodifiedon, lastmodifiedby FROM metadata_entity_dataset WHERE urn = 'urn:li:dataset:(urn:li:dataPlatform:kafka,METRICS.RtfActivityEvent,CORP)' AND JSON_EXTRACT(a_clusterdatasetsla, '$.gma_deleted') IS NULL 
UNION ALL 
SELECT urn, a_clusterdatasetsla, lastmodifiedon, lastmodifiedby FROM metadata_entity_dataset WHERE urn = 'urn:li:dataset:(urn:li:dataPlatform:kafka,METRICS.rtf-store-war-service_call,CORP)' AND JSON_EXTRACT(a_clusterdatasetsla, '$.gma_deleted') IS NULL 
UNION ALL 
SELECT urn, a_clusterdatasetsla, lastmodifiedon, lastmodifiedby FROM metadata_entity_dataset WHERE urn = 'urn:li:dataset:(urn:li:dataPlatform:kafka,METRICS.redliner-log_event,CORP)' AND JSON_EXTRACT(a_clusterdatasetsla, '$.gma_deleted') IS NULL 
UNION ALL …
```
This PR is to:
1. Convert those long `UNION ALL` logic into using `IN`, such as:
```
SELECT urn, a_clusterdatasetsla, lastmodifiedon, lastmodifiedby 
FROM metadata_entity_dataset 
WHERE JSON_EXTRACT(a_clusterdatasetsla, '$.gma_deleted') IS NULL 
AND urn IN (
'urn:li:dataset:(urn:li:dataPlatform:kafka,METRICS.RtfActivityEvent,CORP)',
'urn:li:dataset:(urn:li:dataPlatform:kafka,METRICS.rtf-store-war-service_call,CORP)',
'urn:li:dataset:(urn:li:dataPlatform:kafka,METRICS.redliner-log_event,CORP)',
...
)
```
2. Revert the previous changes in PR https://github.com/linkedin/datahub-gma/pull/367 which was to divide UNION ALL queries into small batches. When the change was released, it caused downtime instead because all smaller queries were executed at the same time and caused memory exhaustion. After the issue, the TMS side code was reverted, but the datahub-gma changes wasn't.

## Testing Done
Details testings are documented into [this document](https://docs.google.com/document/d/1Z9Qqje62SD2I6AN5HqvcxXfLD1rh4CrCGc9fP0qGV3Q/edit#heading=h.n5atghzf9v9q). I'm briefly listing the testing and results here. Please refer to the doc for some analysis and detailed test steps.
1. Directly run UNION ALL and IN queries on MySQL DB (metagalaxy_stg) to compare execution time.
**Result**

| Test                     | Time  |
|--------------------------|-------|
| UNION ALL over 5k urns   | 2.630s|
| IN over 5k urns          | 0.700s|
| UNION ALL over 10k urns  | 6.561s|
| IN over 10k urns         | 0.880s|

2. Local Testing
3. EI Testing
4. DC Testing

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
