### PR TITLE
Fix return type for generic ingest API

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
@@ -88,7 +88,6 @@ public abstract class BaseEntityAgnosticAspectResource extends ResourceContextHo
    * @param aspectClass The canonical class name of the aspect.
    * @param trackingContext Nullable tracking context contains information passed from metadata events.
    * @param ingestionParams Different options for ingestion.
-   * @return CreateResponse if metadata is ingested successfully.
    */
   @Action(name = ACTION_INGEST)
   @Nonnull

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
@@ -11,7 +11,6 @@ import com.linkedin.metadata.events.IngestionTrackingContext;
 import com.linkedin.metadata.internal.IngestionParams;
 import com.linkedin.parseq.Task;
 import com.linkedin.restli.common.HttpStatus;
-import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.annotations.Action;
 import com.linkedin.restli.server.annotations.ActionParam;

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
@@ -92,7 +92,7 @@ public abstract class BaseEntityAgnosticAspectResource extends ResourceContextHo
    */
   @Action(name = ACTION_INGEST)
   @Nonnull
-  public Task<CreateResponse> ingest(
+  public Task<Void> ingest(
       @ActionParam(PARAM_URN) @Nonnull String urn,
       @ActionParam(PARAM_ASPECT) @Nonnull String aspect,
       @ActionParam(PARAM_ASPECT_CLASS) @Nonnull String aspectClass,
@@ -104,7 +104,7 @@ public abstract class BaseEntityAgnosticAspectResource extends ResourceContextHo
       Class clazz = this.getClass().getClassLoader().loadClass(aspectClass);
       IngestionMode ingestionMode = ingestionParams == null ? null : ingestionParams.getIngestionMode();
       genericLocalDAO().save(Urn.createFromCharSequence(urn), clazz, aspect, auditStamp, trackingContext, ingestionMode);
-      return RestliUtils.toTask(() -> new CreateResponse(HttpStatus.S_201_CREATED));
+      return Task.value(null);
     } catch (ClassNotFoundException e) {
       throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, String.format("No such class %s.", aspectClass));
     } catch (URISyntaxException e) {

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
@@ -113,12 +113,12 @@ public abstract class BaseEntityAgnosticAspectResource extends ResourceContextHo
   /**
    * Backfill secondary storage by triggering MAEs.
    * @param urn The urn identified the entity for which the metadata is associated with.
-   * @param aspectNames The metadata aspect serialized as string in JSON format.
+   * @param aspectNames A list of aspect's canonical names.
    */
-  @Action(name = ACTION_BACKFILL_WITH_URNS)
+  @Action(name = ACTION_BACKFILL_WITH_URN)
   @Nonnull
   public Task<BackfillResult> backfill(
-      @ActionParam(PARAM_URNS) @Nonnull String urn,
+      @ActionParam(PARAM_URN) @Nonnull String urn,
       @ActionParam(PARAM_ASPECTS) @Nonnull String[] aspectNames) {
     Set<Class<? extends RecordTemplate>> aspects = Arrays.stream(aspectNames).map(ModelUtils::getAspectClass).collect(Collectors.toSet());
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -14,6 +14,7 @@ public final class RestliConstants {
   public static final String ACTION_BACKFILL_ENTITY_TABLES = "backfillEntityTables";
   public static final String ACTION_BACKFILL_RELATIONSHIP_TABLES = "backfillRelationshipTables";
   public static final String ACTION_BACKFILL_WITH_URNS = "backfillWithUrns";
+  public static final String ACTION_BACKFILL_WITH_URN = "backfillWithUrn";
   public static final String ACTION_BACKFILL_WITH_NEW_VALUE = "backfillWithNewValue";
   public static final String ACTION_BACKFILL_LEGACY = "backfillLegacy";
   public static final String ACTION_BROWSE = "browse";


### PR DESCRIPTION
## Summary
Restli Action has this constraint that return type cannot be CreateResponse. Change the return type `Task<Void>` to be same as other ingest method.

## Testing Done

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
