### PR TITLE
fix(schema validation): remove optional 'delta' field requirement from DeltaValidator

### DIFF
--- a/validators/src/main/java/com/linkedin/metadata/validator/DeltaValidator.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/DeltaValidator.java
@@ -52,7 +52,6 @@ public final class DeltaValidator {
   }
 
   private static boolean isValidDeltaField(@Nonnull RecordDataSchema.Field field) {
-    return field.getName().equals("delta") && !field.getOptional()
-        && field.getType().getType() == DataSchema.Type.UNION;
+    return field.getName().equals("delta") && field.getType().getType() == DataSchema.Type.UNION;
   }
 }


### PR DESCRIPTION

## Summary
All other validators have been updated to no longer check for required fields in model schemas. This is a required change as we move from PDL to Proto since all fields in Proto are optional.
## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
