### PR TITLE
feat: add new findRelationships interface and unit test placeholder

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -165,23 +165,25 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Finds a list of relationships of a specific type based on the given filters.
-   * Source and destination entities must have tables registered under metadata_entity_sourceEntityType/destinationEntityType in db.
+   * Finds a list of relationships of a specific type based on the given filters if applicable.
    *
-   * @param sourceEntityType type name of the source entity to query
-   * @param sourceEntityFilter the filter to apply to the source entity when querying
-   * @param destinationEntityType type name of the destination entity to query
-   * @param destinationEntityFilter the filter to apply to the destination entity when querying
+   * @param sourceEntityUrn urn of the source entity to query
+   * @param sourceEntityFilter the filter to apply to the source entity when querying (not applicable to non-MG entities)
+   * @param destinationEntityUrn urn of the destination entity to query. If relationship is OwnedBy, this is crew/ldap.
+   * @param destinationEntityFilter the filter to apply to the destination entity when querying (not applicable to non-MG entities)
    * @param relationshipType the type of relationship to query
    * @param relationshipFilter the filter to apply to relationship when querying
-   * @return A list of relationship records.
+   * @param offset the offset query should start at. Ignored if set to a negative value.
+   * @param count the maximum number of entities to return. Ignored if set to a non-positive value.   * @return A list of relationship records.
    */
   @Nonnull
   public <RELATIONSHIP extends RecordTemplate> List<RELATIONSHIP> findRelationships(
-      @Nullable String sourceEntityType, @Nonnull LocalRelationshipFilter sourceEntityFilter,
-      @Nullable String destinationEntityType, @Nonnull LocalRelationshipFilter destinationEntityFilter,
-      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter) {
-    // NOTE: additional validation for  sourceEntityType and destinationEntityType first.
+      @Nullable String sourceEntityUrn, @Nullable LocalRelationshipFilter sourceEntityFilter,
+      @Nullable String destinationEntityUrn, @Nullable LocalRelationshipFilter destinationEntityFilter,
+      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
+      int offset, int count) {
+    // NOTE: additional validation for sourceEntityUrn and sourceEntityUrn first.
+    // for non-MG entities, filters need to be null or ignored.
     throw new RuntimeException("findRelationships is not implemented.");
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -165,6 +165,27 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
+   * Finds a list of relationships of a specific type based on the given filters.
+   * Source and destination entities must have tables registered under metadata_entity_sourceEntityType/destinationEntityType in db.
+   *
+   * @param sourceEntityType type name of the source entity to query
+   * @param sourceEntityFilter the filter to apply to the source entity when querying
+   * @param destinationEntityType type name of the destination entity to query
+   * @param destinationEntityFilter the filter to apply to the destination entity when querying
+   * @param relationshipType the type of relationship to query
+   * @param relationshipFilter the filter to apply to relationship when querying
+   * @return A list of relationship records.
+   */
+  @Nonnull
+  public <RELATIONSHIP extends RecordTemplate> List<RELATIONSHIP> findRelationships(
+      @Nullable String sourceEntityType, @Nonnull LocalRelationshipFilter sourceEntityFilter,
+      @Nullable String destinationEntityType, @Nonnull LocalRelationshipFilter destinationEntityFilter,
+      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter) {
+    // NOTE: additional validation for  sourceEntityType and destinationEntityType first.
+    throw new RuntimeException("findRelationships is not implemented.");
+  }
+
+  /**
    * Validate:
    * 1. The entity filter only contains supported condition.
    * 2. if entity class is null, then filter should be emtpy.

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -272,13 +272,24 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
-  public void testFindOneRelationshipWithEntityTypeName() {
+  public void testFindOneRelationshipWithEntityUrn() {
     // TODO: implement
   }
 
   @Test
-  public void testFindOneRelationshipWithFilterWithEntityTypeName() {
+  public void testFindOneRelationshipWithFilterWithEntityUrn() {
     // TODO: implement
+  }
+
+  @Test
+  public void testFindOneRelationshipWithNonMgEntityUrn() {
+    // TODO: implement
+  }
+
+  @Test
+  public void testFindOneRelationshipWithFilterWithNonMgEntityUrn() {
+    // TODO: implement
+    // non-MG entities should not support filter
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -272,6 +272,16 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
+  public void testFindOneRelationshipWithEntityTypeName() {
+    // TODO: implement
+  }
+
+  @Test
+  public void testFindOneRelationshipWithFilterWithEntityTypeName() {
+    // TODO: implement
+  }
+
+  @Test
   public void testFindEntitiesOneHopAwayIncomingDirection() throws Exception {
     FooUrn alice = new FooUrn(1);
     FooUrn bob = new FooUrn(2);


### PR DESCRIPTION
## Summary
new findRelationships API, which doesn't require entity snapshot, is needed to support non-MG entities. This PR adds API signature and unit test placeholder for review purpose.

The old API only uses snapshot to extract the entity type and find the db table. We can just provide that entity urn in the function call.

## Context
The current findRelationships API in EbeanLocalRelationshipQueryDAO requires that the source, destination, and relationship type parameters are of type RecordTemplate (i.e. Snapshots in this case). Considering that we want to support relationships between both MG entities and non-MG entities (for the crew use case), we need to define a new findRelationships API in EbeanLocalRelationshipQueryDAO which does impose this restriction on the parameters.

## Testing Done
mint build

## JIRA
META-20529

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
