### PR TITLE
feat: add new findRelationships API and unit tests

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.dao;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.utils.ClassUtils;
@@ -24,13 +25,20 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.javatuples.Pair;
+
+import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
+
 
 /**
  * An Ebean implementation of {@link BaseQueryDAO} backed by local relationship tables.
  */
 @Slf4j
 public class EbeanLocalRelationshipQueryDAO {
+  public static final String URN_CREW_PATTERN = "urn:li:crew:?[a-zA-Z0-9]*";
+  public static final String URN_ENTITY_PATTERN =
+      "urn:li:[a-zA-Z0-9]+:?\\(?[a-zA-Z0-9]*\\)?";
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -151,13 +159,8 @@ public class EbeanLocalRelationshipQueryDAO {
 
     final String relationshipTableName = SQLSchemaUtils.getRelationshipTableName(relationshipType);
 
-    final String sql = buildFindRelationshipSQL(
-        destTableName,
-        sourceTableName,
-        relationshipTableName,
-        sourceEntityFilter,
-        destinationEntityFilter,
-        relationshipFilter);
+    final String sql = buildFindRelationshipSQL(relationshipTableName, relationshipFilter, sourceTableName,
+        sourceEntityFilter, destTableName, destinationEntityFilter);
 
     return _server.createSqlQuery(sql).findList().stream()
         .map(row -> RecordUtils.toRecordTemplate(relationshipType, row.getString("metadata")))
@@ -174,7 +177,8 @@ public class EbeanLocalRelationshipQueryDAO {
    * @param relationshipType the type of relationship to query
    * @param relationshipFilter the filter to apply to relationship when querying
    * @param offset the offset query should start at. Ignored if set to a negative value.
-   * @param count the maximum number of entities to return. Ignored if set to a non-positive value.   * @return A list of relationship records.
+   * @param count the maximum number of entities to return. Ignored if set to a non-positive value.
+   * @return A list of relationship records.
    */
   @Nonnull
   public <RELATIONSHIP extends RecordTemplate> List<RELATIONSHIP> findRelationships(
@@ -184,7 +188,135 @@ public class EbeanLocalRelationshipQueryDAO {
       int offset, int count) {
     // NOTE: additional validation for sourceEntityUrn and sourceEntityUrn first.
     // for non-MG entities, filters need to be null or ignored.
-    throw new RuntimeException("findRelationships is not implemented.");
+    EntityType sourceEntityType = validateAndCategorizeEntityUrn(sourceEntityFilter, sourceEntityUrn);
+    EntityType destEntityType = validateAndCategorizeEntityUrn(destinationEntityFilter, destinationEntityUrn);
+    validateEntityFilter(relationshipFilter, relationshipType);
+
+    // if source entity is not MG entity, then we cannot filter on source
+    if (sourceEntityType != EntityType.MG_ENTITY) {
+      sourceEntityUrn = null;
+      sourceEntityFilter = null;
+    }
+
+    String sql;
+
+    // the assumption is we have the table for every MG entity. For non-MG entities, sourceTableName will be null.
+    String sourceTableName = extractTableNameFromUrnForMgEntity(sourceEntityUrn);
+    final String relationshipTableName = SQLSchemaUtils.getRelationshipTableName(relationshipType);
+
+    switch (destEntityType) {
+      case CREW:
+        // since crew in not an MG entity, we don't have a table for it.
+        // we still need to filter on the name of the crew, the name will be in the ownedby table's destination col.
+        sql = buildFindRelationshipSQL(
+            relationshipTableName, relationshipFilter,
+            sourceTableName, sourceEntityFilter,
+            null, null,
+            destinationEntityFilter);
+        break;
+      case NULL:
+      case MG_ENTITY:
+      default:
+        String destTableName = extractTableNameFromUrnForMgEntity(destinationEntityUrn);
+
+        sql = buildFindRelationshipSQL(
+            relationshipTableName, relationshipFilter,
+            sourceTableName, sourceEntityFilter,
+            destTableName, destinationEntityFilter);
+        break;
+    }
+
+    List<RELATIONSHIP> relationships = _server.createSqlQuery(sql).findList().stream()
+        .map(row -> RecordUtils.toRecordTemplate(relationshipType, row.getString("metadata")))
+        .collect(Collectors.toList());
+
+    // return sublist based on offset and count
+    // if offset < 0, start from 0. if count < 0, return all.
+    return relationships.subList(Math.max(0, offset), count < 0 ? relationships.size() : Math.min(count, relationships.size()));
+  }
+
+
+  /**
+   * Validate:
+   * 1. The entity filter only contains supported condition.
+   * 2. if entity urn is null or empty, then filter should be emtpy.
+   * If any of above is violated, throw IllegalArgumentException.
+   * Categorize:
+   * 1. If entityUrn is null or empty, return NULL.
+   * 2. If entityUrn is a crew entity urn, return CREW.
+   * 3. If entityUrn is an MG entity urn, return MG_ENTITY.
+   *
+   * @return EntityType of the entityUrn
+   */
+  private EntityType validateAndCategorizeEntityUrn(@Nullable LocalRelationshipFilter filter, @Nullable String entityUrn) {
+    if (StringUtils.isBlank(entityUrn) && filter != null && filter.hasCriteria() && filter.getCriteria().size() > 0) {
+      throw new IllegalArgumentException("Entity urn is null or empty but filter is not empty.");
+    }
+
+    if (StringUtils.isBlank(entityUrn)) {
+      return EntityType.NULL;
+    }
+
+    EntityType entityType;
+
+    if (isCrewEntityUrn(entityUrn)) {
+      entityType = EntityType.CREW;
+    } else if (isMgEntityUrn(entityUrn)) {
+      entityType = EntityType.MG_ENTITY;
+    } else {
+      throw new IllegalArgumentException(String.format("Entity urn is not valid: %s", entityUrn));
+    }
+
+    if (filter != null) {
+      validateFilterCriteria(
+          filter.getCriteria().stream().map(LocalRelationshipCriterion::getCondition).collect(Collectors.toList()));
+    }
+
+    return entityType;
+  }
+
+  /**
+   * Pattern matches with "urn:li:crew:?[a-zA-Z0-9]*".
+   */
+  private static boolean isCrewEntityUrn(@Nonnull String entityUrn) {
+    return entityUrn.matches(URN_CREW_PATTERN);
+  }
+
+  /**
+   * Checks if entity type name can be extracted from urn, and that entity type has a table in db.
+   */
+  @VisibleForTesting
+  protected boolean isMgEntityUrn(@Nonnull String entityUrn) {
+    if (!entityUrn.matches(URN_ENTITY_PATTERN)) {
+      return false;
+    }
+
+    String possibleTableName = extractTableNameFromUrnForMgEntity(entityUrn);
+    SqlRow row = _server.createSqlQuery("SELECT 1 FROM " + possibleTableName + " LIMIT 1").findOne();
+    return row != null;
+  }
+
+  /**
+   * Extracts the entity type name from an entity urn.
+   * @param entityUrn should match pattern "urn:li:[a-zA-Z0-9]+:?\(?[a-zA-Z0-9]*\)?"
+   * @return the 3rd segment of urn
+   */
+  @Nonnull
+  private static String getEntityTypeName(@Nonnull String entityUrn) {
+    return entityUrn.split(":")[2];
+  }
+
+  /**
+   * Extracts the table name from an entity urn for MG entities.
+   * @param entityUrn should match pattern "urn:li:[a-zA-Z0-9]+:?\(?[a-zA-Z0-9]*\)?"
+   * @return metadata_entity_entity_type_name
+   */
+  @Nullable
+  private String extractTableNameFromUrnForMgEntity(@Nullable String entityUrn) {
+    if (entityUrn == null) {
+      return null;
+    }
+    return ENTITY_TABLE_PREFIX + getEntityTypeName(entityUrn);
   }
 
   /**
@@ -256,39 +388,70 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Construct SQL similar to following:
+   * Constructs SQL similar to following.
    *
    * <p>SELECT rt.* FROM relationship_table rt
    * INNER JOIN destination_entity_table dt ON dt.urn = rt.destinationEntityUrn
    * INNER JOIN source_entity_table st ON st.urn = rt.sourceEntityUrn
-   * WHERE destination entity filters AND source entity filters AND relationship filters
+   * WHERE destination entity filters AND source entity filters AND relationship filters</p>
+   *
+   * @param relationshipTableName   relationship table name
+   * @param relationshipFilter      filter on relationship
+   * @param sourceTableName         source entity table name
+   * @param sourceEntityFilter      filter on source entity.
+   * @param destTableName           destination entity table name. Always null if building relationship with crew
+   *                                entity.
+   * @param destinationEntityFilter filter on destination entity.
+   * @param crewEntityFilter        filter on crew entity. The condition is applied to the relationship table.
    */
   @Nonnull
-  private String buildFindRelationshipSQL(@Nullable final String destTableName, @Nullable final String sourceTableName,
-      @Nonnull final String relationshipTableName, @Nonnull final LocalRelationshipFilter sourceEntityFilter,
-      @Nonnull final LocalRelationshipFilter destinationEntityFilter, @Nonnull final LocalRelationshipFilter relationshipFilter) {
+  private String buildFindRelationshipSQL(
+      @Nonnull final String relationshipTableName, @Nonnull final LocalRelationshipFilter relationshipFilter,
+      @Nullable final String sourceTableName, @Nullable final LocalRelationshipFilter sourceEntityFilter,
+      @Nullable final String destTableName, @Nullable final LocalRelationshipFilter destinationEntityFilter,
+      @Nullable final LocalRelationshipFilter crewEntityFilter) {
 
     StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("SELECT rt.* FROM ").append(relationshipTableName).append(" rt ");
 
-    if (destTableName != null) {
+    List<Pair<LocalRelationshipFilter, String>> filters = new ArrayList<>();
+
+    // destTableName and destinationEntityFilter should always come in pair. Since we are joining and filtering on the same table.
+    if (destTableName != null && destinationEntityFilter != null) {
       sqlBuilder.append("INNER JOIN ").append(destTableName).append(" dt ON dt.urn=rt.destination ");
+      filters.add(new Pair<>(destinationEntityFilter, "dt"));
     }
 
-    if (sourceTableName != null) {
+    // sourceTableName and sourceEntityFilter should always come in pair. Since we are joining and filtering on the same table.
+    if (sourceTableName != null && sourceEntityFilter != null) {
       sqlBuilder.append("INNER JOIN ").append(sourceTableName).append(" st ON st.urn=rt.source ");
+      filters.add(new Pair<>(sourceEntityFilter, "st"));
     }
 
     sqlBuilder.append("WHERE deleted_ts is NULL");
+
+    if (crewEntityFilter != null) {
+      filters.add(new Pair<>(crewEntityFilter, "rt"));
+    }
+
+    filters.add(new Pair<>(relationshipFilter, "rt"));
+
     String whereClause = SQLStatementUtils.whereClause(SUPPORTED_CONDITIONS,
         _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled(),
-        new Pair<>(sourceEntityFilter, "st"),
-        new Pair<>(destinationEntityFilter, "dt"),
-        new Pair<>(relationshipFilter, "rt"));
+        filters.toArray(new Pair[filters.size()]));
 
     if (whereClause != null) {
       sqlBuilder.append(" AND ").append(whereClause);
     }
     return sqlBuilder.toString();
+  }
+
+  @Nonnull
+  private String buildFindRelationshipSQL(
+      @Nonnull final String relationshipTableName, @Nonnull final LocalRelationshipFilter relationshipFilter,
+      @Nullable final String sourceTableName, @Nullable final LocalRelationshipFilter sourceEntityFilter,
+      @Nullable final String destTableName, @Nullable final LocalRelationshipFilter destinationEntityFilter) {
+    return buildFindRelationshipSQL(relationshipTableName, relationshipFilter, sourceTableName, sourceEntityFilter,
+        destTableName, destinationEntityFilter, null);
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -146,7 +146,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter, int offset, int count) {
     validateEntityFilter(sourceEntityFilter, sourceEntityClass);
     validateEntityFilter(destinationEntityFilter, destinationEntityClass);
-    validateEntityFilter(relationshipFilter, relationshipType);
+    validateRelationshipFilter(relationshipFilter);
 
     String destTableName = null;
     if (destinationEntityClass != null) {
@@ -192,13 +192,9 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable String destinationEntityUrn, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
       int offset, int count) {
-
-    // there is some race condition, the local relationship db might not be ready when EbeanLocalRelationshipQueryDAO inits.
-    initMgEntityTypeNameSetOnce();
-
     validateEntityUrnAndFilter(sourceEntityFilter, sourceEntityUrn);
     validateEntityUrnAndFilter(destinationEntityFilter, destinationEntityUrn);
-    validateEntityFilter(relationshipFilter, relationshipType);
+    validateRelationshipFilter(relationshipFilter);
 
     // the assumption is we have the table for every MG entity. For non-MG entities, sourceTableName will be null.
     final String sourceTableName = extractTableNameFromUrnForMgEntityIfPossible(sourceEntityUrn);
@@ -228,6 +224,10 @@ public class EbeanLocalRelationshipQueryDAO {
    */
   @VisibleForTesting
   protected boolean isMgEntityUrn(@Nonnull String entityUrn) {
+    // there is some race condition, the local relationship db might not be ready when EbeanLocalRelationshipQueryDAO inits.
+    // so we can't init the _mgEntityTypeNameSet in constructor.
+    initMgEntityTypeNameSetOnce();
+
     return _mgEntityTypeNameSet.contains(getEntityTypeName(entityUrn));
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -228,8 +228,7 @@ public class EbeanLocalRelationshipQueryDAO {
       initMgEntityTypeNameSet();
     }
 
-    assert _mgEntityTypeNameSet != null;
-    return _mgEntityTypeNameSet.contains(entityUrn.getEntityType());
+    return _mgEntityTypeNameSet.contains(StringUtils.lowerCase(entityUrn.getEntityType()));
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EntityType.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EntityType.java
@@ -1,0 +1,7 @@
+package com.linkedin.metadata.dao;
+
+public enum EntityType {
+  CREW,
+  MG_ENTITY,
+  NULL
+}

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EntityType.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EntityType.java
@@ -1,7 +1,0 @@
-package com.linkedin.metadata.dao;
-
-public enum EntityType {
-  CREW,
-  MG_ENTITY,
-  NULL
-}

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.metadata.query.IndexValue;
 import com.linkedin.metadata.query.LocalRelationshipCriterionArray;
 import com.linkedin.metadata.query.LocalRelationshipFilter;
+import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.SortOrder;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.BarSnapshot;
@@ -59,7 +60,8 @@ public class EbeanLocalAccessTest {
   private static IEbeanLocalAccess<BurgerUrn> _ebeanLocalAccessBurger;
   private static long _now;
   private final EBeanDAOConfig _ebeanConfig = new EBeanDAOConfig();
-  private static final LocalRelationshipFilter EMPTY_FILTER = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray());
+  private static final LocalRelationshipFilter EMPTY_FILTER = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray())
+      .setDirection(RelationshipDirection.UNDIRECTED);
 
   @Factory(dataProvider = "inputList")
   public EbeanLocalAccessTest(boolean nonDollarVirtualColumnsEnabled) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -524,6 +524,29 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
+  public void testFindOneRelationshipWithNonUrnFilterOnSourceEntityForCrewUsage() throws Exception {
+    // Find all owned-by relationship for crew.
+    LocalRelationshipCriterion filterUrnCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("urn:li:foo:4"), // 4 is crew as defined at very beginning.
+        Condition.EQUAL,
+        new AspectField());
+    LocalRelationshipFilter filterUrn = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion));
+
+    LocalRelationshipCriterion filterUrnCriterion1 = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("urn:li:foo:1"), // 1 is kafka as defined at very beginning.
+        Condition.EQUAL,
+        new UrnField());
+    LocalRelationshipFilter filterUrn1 = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion1));
+
+    // non-mg entity cannot be filtered by non-urn filter. This will throw an exception.
+    assertThrows(IllegalArgumentException.class, () -> {
+      _localRelationshipQueryDAO.findRelationships(fooEntityUrn, filterUrn1, crewEntityUrn, filterUrn,
+          OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+          -1, -1);
+    });
+  }
+
+  @Test
   void testFindRelationshipsWithEntityUrnOffsetAndCount() throws Exception {
     FooUrn alice = new FooUrn(1);
     FooUrn bob = new FooUrn(2);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -177,7 +177,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filter = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterCriterion));
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationships(FooSnapshot.class,
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()), FooSnapshot.class, filter,
-        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()), 0, 10);
+        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray())
+            .setDirection(RelationshipDirection.UNDIRECTED), 0, 10);
 
     // Asserts
     assertEquals(reportsToAlice.size(), 2);
@@ -194,7 +195,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     reportsToAlice = _localRelationshipQueryDAO.findRelationships(FooSnapshot.class,
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()), FooSnapshot.class, filter,
-        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()), 0, 10);
+        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray())
+            .setDirection(RelationshipDirection.UNDIRECTED), 0, 10);
 
     // Expect: only bob reports to Alice
     assertEquals(reportsToAlice.size(), 1);
@@ -249,7 +251,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         FooSnapshot.class,
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
         ConsumeFrom.class,
-        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         0, 10);
 
     // Assert
@@ -261,7 +263,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         new RelationshipField().setPath("/environment"));
 
     LocalRelationshipFilter filterRelationship = new LocalRelationshipFilter().setCriteria(
-        new LocalRelationshipCriterionArray(filterRelationshipCriterion));
+        new LocalRelationshipCriterionArray(filterRelationshipCriterion)).setDirection(RelationshipDirection.UNDIRECTED);
 
     List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationships(
         BarSnapshot.class,
@@ -304,7 +306,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationships(
         null, null,
         FOO_ENTITY_URN, destFilter,
-        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
     // Asserts
@@ -323,7 +325,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     reportsToAlice = _localRelationshipQueryDAO.findRelationships(
         null, null,
         FOO_ENTITY_URN, destFilter,
-        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
     // Expect: only bob reports to Alice
@@ -377,7 +379,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         BAR_ENTITY_URN, filterUrn,
         FOO_ENTITY_URN, null,
         ConsumeFrom.class,
-        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
     assertEquals(consumeFromSamza.size(), 2); // Because Samza consumes from 1. kafka and 2. restli
@@ -388,7 +390,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         new RelationshipField().setPath("/environment"));
 
     LocalRelationshipFilter filterRelationship = new LocalRelationshipFilter().setCriteria(
-        new LocalRelationshipCriterionArray(filterRelationshipCriterion));
+        new LocalRelationshipCriterionArray(filterRelationshipCriterion)).setDirection(RelationshipDirection.UNDIRECTED);
 
     List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationships(
         BAR_ENTITY_URN, filterUrn,
@@ -454,7 +456,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew1 can be found
     List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationships(null, null,
         CREW_ENTITY_URN, filterUrn,
-        OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
     assertEquals(ownedByCrew1.size(), 3);
@@ -469,7 +471,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew2 can be found
     List<OwnedBy> ownedByCrew2 = _localRelationshipQueryDAO.findRelationships(null, null,
         CREW_ENTITY_URN, filterUrn2,
-        OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
     assertEquals(ownedByCrew2.size(), 2);
@@ -515,12 +517,11 @@ public class EbeanLocalRelationshipQueryDAOTest {
         new UrnField());
     LocalRelationshipFilter filterUrn1 = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion1));
 
-
     // test owned by of crew can be filtered by source entity, e.g. only include kafka
     List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationships(
         FOO_ENTITY_URN, filterUrn1,
         CREW_ENTITY_URN, filterUrn,
-        OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
     assertEquals(ownedByCrew1.size(), 1);
@@ -571,7 +572,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationships(
         null, null, FOO_ENTITY_URN, filter,
-        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, 3);
 
     // Asserts only 3 reports-to relationships are returned
@@ -579,7 +580,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     reportsToAlice = _localRelationshipQueryDAO.findRelationships(
         null, null, FOO_ENTITY_URN, filter,
-        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()),
+        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         2, -1);
 
     // Asserts 3 returns, and the content starts from the 3rd report (Lisa)

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao.localrelationship;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.dao.EBeanDAOConfig;
@@ -60,9 +61,10 @@ import static org.testng.Assert.*;
 
 
 public class EbeanLocalRelationshipQueryDAOTest {
-  public static final String FOO_ENTITY_URN = "urn:li:foo";
-  public static final String BAR_ENTITY_URN = "urn:li:bar";
-  public static final String CREW_ENTITY_URN = "urn:li:crew";
+  public Urn fooEntityUrn;
+  public Urn barEntityUrn;
+  public Urn crewEntityUrn;
+
   private EbeanServer _server;
   private EbeanLocalRelationshipWriterDAO _localRelationshipWriterDAO;
   private EbeanLocalRelationshipQueryDAO _localRelationshipQueryDAO;
@@ -84,7 +86,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @BeforeClass
-  public void init() {
+  public void init() throws URISyntaxException {
     _server = EmbeddedMariaInstance.getServer(EbeanLocalRelationshipQueryDAOTest.class.getSimpleName());
     _localRelationshipWriterDAO = new EbeanLocalRelationshipWriterDAO(_server);
     _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
@@ -92,6 +94,10 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
         BarUrn.class, new EmptyPathExtractor<>(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
+
+    fooEntityUrn = new Urn("urn:li:foo");
+    barEntityUrn = new Urn("urn:li:bar");
+    crewEntityUrn = new Urn("urn:li:crew");
   }
 
   @BeforeMethod
@@ -304,8 +310,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter destFilter = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterCriterion));
 
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationships(
-        null, null,
-        FOO_ENTITY_URN, destFilter,
+        null, null, fooEntityUrn, destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -323,8 +328,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     deletionSQL.execute();
 
     reportsToAlice = _localRelationshipQueryDAO.findRelationships(
-        null, null,
-        FOO_ENTITY_URN, destFilter,
+        null, null, fooEntityUrn, destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -375,9 +379,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         new UrnField());
     LocalRelationshipFilter filterUrn = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion));
 
-    List<ConsumeFrom> consumeFromSamza = _localRelationshipQueryDAO.findRelationships(
-        BAR_ENTITY_URN, filterUrn,
-        FOO_ENTITY_URN, null,
+    List<ConsumeFrom> consumeFromSamza = _localRelationshipQueryDAO.findRelationships(barEntityUrn, filterUrn, fooEntityUrn, null,
         ConsumeFrom.class,
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
@@ -392,9 +394,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filterRelationship = new LocalRelationshipFilter().setCriteria(
         new LocalRelationshipCriterionArray(filterRelationshipCriterion)).setDirection(RelationshipDirection.UNDIRECTED);
 
-    List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationships(
-        BAR_ENTITY_URN, filterUrn,
-        FOO_ENTITY_URN, null,
+    List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationships(barEntityUrn, filterUrn, fooEntityUrn, null,
         ConsumeFrom.class,
         filterRelationship,
         -1, -1);
@@ -454,8 +454,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filterUrn = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion));
 
     // test owned by of crew1 can be found
-    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationships(null, null,
-        CREW_ENTITY_URN, filterUrn,
+    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationships(null, null, crewEntityUrn, filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -469,8 +468,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filterUrn2 = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion2));
 
     // test owned by of crew2 can be found
-    List<OwnedBy> ownedByCrew2 = _localRelationshipQueryDAO.findRelationships(null, null,
-        CREW_ENTITY_URN, filterUrn2,
+    List<OwnedBy> ownedByCrew2 = _localRelationshipQueryDAO.findRelationships(null, null, crewEntityUrn, filterUrn2,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -518,9 +516,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filterUrn1 = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion1));
 
     // test owned by of crew can be filtered by source entity, e.g. only include kafka
-    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationships(
-        FOO_ENTITY_URN, filterUrn1,
-        CREW_ENTITY_URN, filterUrn,
+    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationships(fooEntityUrn, filterUrn1, crewEntityUrn, filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -571,7 +567,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filter = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterCriterion));
 
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationships(
-        null, null, FOO_ENTITY_URN, filter,
+        null, null, fooEntityUrn, filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, 3);
 
@@ -579,14 +575,25 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertEquals(reportsToAlice.size(), 3);
 
     reportsToAlice = _localRelationshipQueryDAO.findRelationships(
-        null, null, FOO_ENTITY_URN, filter,
+        null, null, fooEntityUrn, filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        2, -1);
+        2, 10);
 
     // Asserts 3 returns, and the content starts from the 3rd report (Lisa)
     assertEquals(reportsToAlice.size(), 3);
     Set<FooUrn> actual = reportsToAlice.stream().map(reportsTo -> makeFooUrn(reportsTo.getSource().toString())).collect(Collectors.toSet());
     Set<FooUrn> expected = ImmutableSet.of(lisa, rose, jenny);
+    assertEquals(actual, expected);
+
+    reportsToAlice = _localRelationshipQueryDAO.findRelationships(
+        null, null, fooEntityUrn, filter,
+        ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+        2, -1);
+
+    // Asserts 5 returns, because offset cannot be applied when count isn't specified.
+    assertEquals(reportsToAlice.size(), 5);
+    actual = reportsToAlice.stream().map(reportsTo -> makeFooUrn(reportsTo.getSource().toString())).collect(Collectors.toSet());
+    expected = ImmutableSet.of(bob, jack, lisa, rose, jenny);
     assertEquals(actual, expected);
   }
 
@@ -597,14 +604,14 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _fooUrnEBeanLocalAccess.add(fooUrn, new AspectFoo().setValue("Alice"), AspectFoo.class, new AuditStamp(), null);
 
     // EbeanLocalRelationshipQueryDAOTest does not have the same package as EbeanLocalRelationshipQueryDAO (cant access protected method directly).
-    Method isMgEntityUrnMethod = EbeanLocalRelationshipQueryDAO.class.getDeclaredMethod("isMgEntityUrn", String.class);
+    Method isMgEntityUrnMethod = EbeanLocalRelationshipQueryDAO.class.getDeclaredMethod("isMgEntityUrn", Urn.class);
     isMgEntityUrnMethod.setAccessible(true);
 
     // assert foo is an MG entity (has metadata_entity_foo table in db)
-    assertTrue((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, FOO_ENTITY_URN));
+    assertTrue((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, fooEntityUrn));
 
     // assert crew is not an MG entity (does not have metadata_entity_crew table in db)
-    assertFalse((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, CREW_ENTITY_URN));
+    assertFalse((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, crewEntityUrn));
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -87,11 +87,11 @@ public class EbeanLocalRelationshipQueryDAOTest {
   public void init() {
     _server = EmbeddedMariaInstance.getServer(EbeanLocalRelationshipQueryDAOTest.class.getSimpleName());
     _localRelationshipWriterDAO = new EbeanLocalRelationshipWriterDAO(_server);
-    _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
     _fooUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
         FooUrn.class, new EmptyPathExtractor<>(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
     _barUrnEBeanLocalAccess = new EbeanLocalAccess<>(_server, EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName()),
         BarUrn.class, new EmptyPathExtractor<>(), _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled());
+    _localRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
   }
 
   @BeforeMethod
@@ -602,8 +602,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // assert foo is an MG entity (has metadata_entity_foo table in db)
     assertTrue((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, FOO_ENTITY_URN));
 
-    // assert bar is not an MG entity (does not have metadata_entity_bar table in db)
-    assertFalse((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, BAR_ENTITY_URN));
+    // assert crew is not an MG entity (does not have metadata_entity_crew table in db)
+    assertFalse((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, CREW_ENTITY_URN));
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS metadata_relationship_belongsto;
 DROP TABLE IF EXISTS metadata_relationship_reportsto;
+DROP TABLE IF EXISTS metadata_relationship_ownedby;
 DROP TABLE IF EXISTS metadata_relationship_pairswith;
 DROP TABLE IF EXISTS metadata_relationship_versionof;
 DROP TABLE IF EXISTS metadata_relationship_consumefrom;
@@ -20,6 +21,19 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata JSON NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_ownedby (
                                                                id BIGINT NOT NULL AUTO_INCREMENT,
                                                                metadata JSON NOT NULL,
                                                                source VARCHAR(1000) NOT NULL,

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS metadata_relationship_belongsto;
 DROP TABLE IF EXISTS metadata_relationship_reportsto;
+DROP TABLE IF EXISTS metadata_relationship_ownedby;
 DROP TABLE IF EXISTS metadata_relationship_pairswith;
 DROP TABLE IF EXISTS metadata_relationship_versionof;
 DROP TABLE IF EXISTS metadata_relationship_consumefrom;
@@ -20,6 +21,19 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
 );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_ownedby (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata JSON NOT NULL,
     source VARCHAR(1000) NOT NULL,

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/OwnedBy.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/OwnedBy.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.testing.localrelationship
+
+@pairings = [ {
+  "destination": "com.linkedin.testing.urn.FooUrn",
+  "source": "com.linkedin.testing.urn.BarUrn"
+} ]
+record OwnedBy includes BaseRelationship {
+}


### PR DESCRIPTION
## Summary
Implemented new findRelationships API that doesn't require snapshot.class as input AND supports non-MG entity (only crew for now).

Note that now entity as passed in as urn, and we will extract the entity type directly from it, which is not type-safe as snapshot. So extra validation is needed to check if an entity is actually MG. Two options I considered, one is to check if snapshot.class exists, and second is check the table name in db. This PR is following the latter.

Another change is nullability of entity and filter, the old API requires filters to be nonnull, but it still allows empty filter arrays. So I made it nullable, and also, entity and filter should both exists for the sql query to work.

## Details
change of old code:
1. rearranged param order for buildFindRelationshipSQL
2. modified buildFindRelationshipSQL input nullability and refactored logic for handling non-mg entity filter

new code:
1. implemented new findRelationships which takes entity urn instead of snapshot
2. new validation for entity urn and filter
4. logic to check if an entity has table in db by sql query
5. OwnedBy.pdl and table creation logic for local access for unit testing
6. unit tests that covers old MG entity only use case, and new crew entity use case

## Testing Done
./gradlew build
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
