### PR TITLE
fix: move EntityQueryFilter and RelationshipQueryFilter package

### DIFF
--- a/dao-api/src/main/pegasus/pegasus/com/linkedin/metadata/query/EntityQueryFilter.pdl
+++ b/dao-api/src/main/pegasus/pegasus/com/linkedin/metadata/query/EntityQueryFilter.pdl
@@ -1,4 +1,6 @@
-namespace com.linkedin.metadata.query
+namespace pegasus.com.linkedin.metadata.query
+
+import com.linkedin.metadata.query.LocalRelationshipFilter
 
 /**
  * Filter for finding source/destination entity(s)

--- a/dao-api/src/main/pegasus/pegasus/com/linkedin/metadata/query/RelationshipQueryFilter.pdl
+++ b/dao-api/src/main/pegasus/pegasus/com/linkedin/metadata/query/RelationshipQueryFilter.pdl
@@ -1,4 +1,6 @@
-namespace com.linkedin.metadata.query
+namespace pegasus.com.linkedin.metadata.query
+
+import com.linkedin.metadata.query.LocalRelationshipFilter
 
 /**
  * Filter for relationship in query


### PR DESCRIPTION
## Summary
last PR #392 did not resolve the issue when adding proto equivalent in metadata-models. Need to move it to pegasus namespace.

## Testing Done

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
