### PR TITLE
add create asset to remote write DAO

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/internal/BaseRemoteWriterDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/internal/BaseRemoteWriterDAO.java
@@ -35,4 +35,16 @@ public abstract class BaseRemoteWriterDAO {
    */
   abstract public <URN extends Urn> void createWithTracking(@Nonnull URN urn, @Nonnull RecordTemplate snapshot,
       @Nonnull IngestionTrackingContext trackingContext, @Nullable IngestionParams ingestionParams);
+
+
+  /**
+   * Same as {@link #createWithTracking(Urn, RecordTemplate, IngestionTrackingContext, IngestionParams)} but create Assets instead.
+   * @param urn the {@link Urn} for the asset
+   * @param asset the asset containing updated metadata aspects
+   * @param trackingContext {@link IngestionTrackingContext} to use for DAO tracking probes and to pass on to the MAE
+   * @param ingestionParams {@link IngestionParams} which indicates how the aspect should be ingested
+   * @param <URN> must be the entity URN type in {@code ASSET}
+   */
+  abstract public <URN extends Urn> void createAsset(@Nonnull URN urn, @Nonnull RecordTemplate asset,
+      @Nonnull IngestionTrackingContext trackingContext, @Nullable IngestionParams ingestionParams);
 }


### PR DESCRIPTION
## Summary

Add createAsset to remote write DAO. This API will be need by RestliRemoteWriterDAO implementation at metadata-models. 

## Testing Done

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
