### PR TITLE
change getSearchQueryCollectionResult to be public method

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
@@ -210,7 +210,7 @@ public abstract class BaseSearchableEntityResource<
    * @return CollectionResult which contains: 1. aspect values fetched from MySQL DB, 2. Total count 3. Search result metadata.
    */
   @Nonnull
-  private CollectionResult<VALUE, SearchResultMetadata> getSearchQueryCollectionResult(@Nonnull SearchResult<DOCUMENT> searchResult,
+  public CollectionResult<VALUE, SearchResultMetadata> getSearchQueryCollectionResult(@Nonnull SearchResult<DOCUMENT> searchResult,
       @Nullable String[] aspectNames, boolean isInternalModelsEnabled) {
 
     final List<URN> matchedUrns = searchResult.getDocumentList()


### PR DESCRIPTION
## Summary

change getSearchQueryCollectionResult to be public method as there are dependencies from corp-gms, ai-metadata-gms ..etc 

## Testing Done



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
