### PR TITLE
fix: reflect the internal models to asset models from param and return types

### DIFF
--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -319,8 +319,8 @@ public class ModelUtilsTest {
     EntityAsset asset = new EntityAsset();
     AspectFoo expectedAspectFoo = new AspectFoo().setValue("foo");
     AspectBar expectedAspectBar = new AspectBar().setValue("bar");
-    asset.setAspectFoo(expectedAspectFoo);
-    asset.setAspectBar(expectedAspectBar);
+    asset.setFoo(expectedAspectFoo);
+    asset.setBar(expectedAspectBar);
 
     List<? extends RecordTemplate> aspects = ModelUtils.getAspectsFromAsset(asset);
 
@@ -601,10 +601,10 @@ public class ModelUtilsTest {
         ModelUtils.newAsset(EntityAsset.class, expectedUrn, Lists.newArrayList(aspectUnion1, aspectUnion2));
 
     assertEquals(asset.getUrn(), expectedUrn);
-    assertTrue(asset.hasAspectFoo());
-    assertTrue(asset.hasAspectBar());
-    assertEquals(asset.getAspectFoo(), expectedFoo);
-    assertEquals(asset.getAspectBar(), expectedBar);
+    assertTrue(asset.hasFoo());
+    assertTrue(asset.hasBar());
+    assertEquals(asset.getFoo(), expectedFoo);
+    assertEquals(asset.getBar(), expectedBar);
     assertFalse(asset.hasAspectAttributes());
   }
 
@@ -626,10 +626,10 @@ public class ModelUtilsTest {
     EntityAsset entityAsset = ModelUtils.convertSnapshotToAsset(EntityAsset.class, snapshot);
 
     assertEquals(entityAsset.getUrn(), expectedUrn);
-    assertTrue(entityAsset.hasAspectFoo());
-    assertTrue(entityAsset.hasAspectBar());
-    assertEquals(entityAsset.getAspectFoo(), expectedFoo);
-    assertEquals(entityAsset.getAspectBar(), expectedBar);
+    assertTrue(entityAsset.hasFoo());
+    assertTrue(entityAsset.hasBar());
+    assertEquals(entityAsset.getFoo(), expectedFoo);
+    assertEquals(entityAsset.getBar(), expectedBar);
     assertFalse(entityAsset.hasAspectAttributes());
   }
 
@@ -651,9 +651,9 @@ public class ModelUtilsTest {
     EntityAsset entityAsset = ModelUtils.convertSnapshotToAsset(EntityAsset.class, internalEntitySnapshot);
 
     assertEquals(entityAsset.getUrn(), expectedUrn);
-    assertEquals(entityAsset.getAspectFoo(), expectedFoo);
+    assertEquals(entityAsset.getFoo(), expectedFoo);
     assertEquals(entityAsset.getAspectFooBar(), expectedFooBar);
-    assertFalse(entityAsset.hasAspectBar());
+    assertFalse(entityAsset.hasBar());
     assertFalse(entityAsset.hasAspectAttributes());
   }
 
@@ -665,8 +665,8 @@ public class ModelUtilsTest {
     AspectBar expectedBar = new AspectBar().setValue("bar");
     AspectFooBar expectedFooBar = new AspectFooBar().setBars(new BarUrnArray(new BarUrn(2)));
     asset.setUrn(expectedUrn);
-    asset.setAspectFoo(expectedFoo);
-    asset.setAspectBar(expectedBar);
+    asset.setFoo(expectedFoo);
+    asset.setBar(expectedBar);
     asset.setAspectFooBar(expectedFooBar);
 
     InternalEntitySnapshot internalEntitySnapshot =

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -1458,8 +1458,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
     asset.setUrn(urn);
-    asset.setAspectFoo(foo);
-    asset.setAspectBar(bar);
+    asset.setFoo(foo);
+    asset.setBar(bar);
     IngestionTrackingContext trackingContext = new IngestionTrackingContext();
 
     IngestionParams ingestionParams1 = new IngestionParams().setTestMode(true);
@@ -1503,9 +1503,9 @@ public class BaseEntityResourceTest extends BaseEngineTest {
 
     assertEquals(asset.getUrn(), urn);
 
-    assertEquals(asset.getAspectFoo(), foo);
+    assertEquals(asset.getFoo(), foo);
     assertEquals(asset.getAspectFooEvolved(), fooEvolved);
-    assertEquals(asset.getAspectBar(), bar);
+    assertEquals(asset.getBar(), bar);
     assertEquals(asset.getAspectFooBar(), fooBar);
     assertEquals(asset.getAspectAttributes(), attributes);
   }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAsset.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAsset.pdl
@@ -15,20 +15,23 @@ record EntityAsset {
   /**
    * For unit tests
    */
-  aspectFoo: optional AspectFoo,
+  foo: optional AspectFoo,
+
   /**
    * For unit tests
    */
-  aspectBar: optional AspectBar,
+  bar: optional AspectBar,
 
   /**
    * For unit tests
    */
   aspectFooEvolved: optional AspectFooEvolved,
+
   /**
    * For unit tests
    */
   aspectFooBar: optional AspectFooBar,
+
   /**
    * For unit tests
    */


### PR DESCRIPTION
## Summary
Loose the naming convention on the fields on models, to reflect the internal models to asset models from param and return types
## Testing Done
./gradlew build
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)