### PR TITLE
implement dual write in BaseAspectRoutingResource

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -860,6 +860,21 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
+   * Same as above {@link #add(Urn, RecordTemplate, AuditStamp, IngestionTrackingContext, IngestionParams)} but
+   * skips any pre-update lambdas. DO NOT USE THIS METHOD WITHOUT EXPLICIT PERMISSION FROM THE METADATA GRAPH TEAM.
+   * Please use the regular add method linked above.
+   */
+  @Nonnull
+  public <ASPECT extends RecordTemplate> ASPECT addSimple(@Nonnull URN urn, @Nonnull ASPECT newValue,
+      @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
+      @Nullable IngestionParams ingestionParams) {
+    final IngestionParams nonNullIngestionParams =
+        ingestionParams == null || !ingestionParams.hasTestMode() ? new IngestionParams().setIngestionMode(
+            IngestionMode.LIVE).setTestMode(false) : ingestionParams;
+    return add(urn, (Class<ASPECT>) newValue.getClass(), ignored -> newValue, auditStamp, trackingContext, nonNullIngestionParams);
+  }
+
+  /**
    * Similar to {@link #delete(Urn, Class, AuditStamp, int)} but uses the default maximum transaction retry.
    */
   @Nonnull

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -852,11 +852,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, @Nonnull ASPECT newValue,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
-    final IngestionParams nonNullIngestionParams =
-        ingestionParams == null || !ingestionParams.hasTestMode() ? new IngestionParams().setIngestionMode(
-            IngestionMode.LIVE).setTestMode(false) : ingestionParams;
     ASPECT updatedAspect = preUpdateRouting(urn, newValue);
-    return add(urn, (Class<ASPECT>) newValue.getClass(), ignored -> updatedAspect, auditStamp, trackingContext, nonNullIngestionParams);
+    return addSkipPreIngestionUpdates(urn, updatedAspect, auditStamp, trackingContext, ingestionParams);
   }
 
   /**
@@ -865,7 +862,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Please use the regular add method linked above.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT addSimple(@Nonnull URN urn, @Nonnull ASPECT newValue,
+  public <ASPECT extends RecordTemplate> ASPECT addSkipPreIngestionUpdates(@Nonnull URN urn, @Nonnull ASPECT newValue,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
     final IngestionParams nonNullIngestionParams =

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -323,6 +323,12 @@ public abstract class BaseAspectRoutingResource<
                   return;
                 }
               }
+              // Get the fqcn of the aspect class
+              String aspectFQCN = aspect.getClass().getCanonicalName();
+              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
+              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
+                return;
+              }
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
               } else {
@@ -330,7 +336,7 @@ public abstract class BaseAspectRoutingResource<
               }
               // since we already called any pre-update lambdas earlier, call a simple version of BaseLocalDAO::add
               // which skips pre-update lambdas.
-              getLocalDAO().addSimple(urn, aspect, auditStamp, trackingContext, ingestionParams);
+              getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
             } catch (Exception exception) {
               log.error(
                   String.format("Couldn't ingest routing aspect %s for %s", aspect.getClass().getSimpleName(), urn),
@@ -371,6 +377,12 @@ public abstract class BaseAspectRoutingResource<
                   return;
                 }
               }
+              // Get the fqcn of the aspect class
+              String aspectFQCN = aspect.getClass().getCanonicalName();
+              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
+              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
+                return;
+              }
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass())
                     .ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
@@ -379,7 +391,7 @@ public abstract class BaseAspectRoutingResource<
               }
               // since we already called any pre-update lambdas earlier, call a simple version of BaseLocalDAO::add
               // which skips pre-update lambdas.
-              getLocalDAO().addSimple(urn, aspect, auditStamp, trackingContext, ingestionParams);
+              getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
             } catch (Exception exception) {
               log.error("Couldn't ingest routing aspect {} for {}", aspect.getClass().getSimpleName(), urn, exception);
             }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -315,6 +315,7 @@ public abstract class BaseAspectRoutingResource<
               // get the updated aspect if there is a preupdate routing lambda registered
               RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
               if (registry != null && registry.isRegistered(aspect.getClass())) {
+                log.info(String.format("Executing registered pre-update routing lambda for aspect class %s.", aspect.getClass()));
                 aspect = preUpdateRouting(urn, aspect, registry);
                 // Get the fqcn of the aspect class
                 String aspectFQCN = aspect.getClass().getCanonicalName();
@@ -322,12 +323,6 @@ public abstract class BaseAspectRoutingResource<
                 if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
                   return;
                 }
-              }
-              // Get the fqcn of the aspect class
-              String aspectFQCN = aspect.getClass().getCanonicalName();
-              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-                return;
               }
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
@@ -369,6 +364,7 @@ public abstract class BaseAspectRoutingResource<
               // get the updated aspect if there is a preupdate routing lambda registered
               RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
               if (registry != null && registry.isRegistered(aspect.getClass())) {
+                log.info(String.format("Executing registered pre-update routing lambda for aspect class %s.", aspect.getClass()));
                 aspect = preUpdateRouting(urn, aspect, registry);
                 // Get the fqcn of the aspect class
                 String aspectFQCN = aspect.getClass().getCanonicalName();
@@ -376,12 +372,6 @@ public abstract class BaseAspectRoutingResource<
                 if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
                   return;
                 }
-              }
-              // Get the fqcn of the aspect class
-              String aspectFQCN = aspect.getClass().getCanonicalName();
-              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-                return;
               }
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass())

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -679,7 +679,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     // Should check for pre lambda
     verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     // Should continue to dual-write into local DAO
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(any(), any(), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -306,7 +306,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSimple(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -326,7 +326,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingestWithTracking(eq(urn), eq(foo), eq(trackingContext), eq(null));
     verify(_mockAspectAttributeGmsClient, times(1)).ingestWithTracking(eq(urn), eq(attributes), eq(trackingContext), eq(null));
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSimple(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -354,7 +354,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     runAndWait(_resource.ingest(snapshot));
 
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSimple(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
     // verify(_mockGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
@@ -570,9 +570,9 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     AspectFoo foobar = new AspectFoo().setValue("foobar");
     // dual write pt1: ensure the ingestion request is forwarded to the routed GMS.
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foobar));
-    // dual write pt2: ensure local write using addSimple() and not add().
+    // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
-    verify(_mockLocalDAO, times(1)).addSimple(eq(urn), eq(foobar), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foobar), any(), any(), any());
   }
 
   @Test
@@ -589,9 +589,9 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     // expected: the aspect value remains unchanged and the aspect is dual-written.
     // dual write pt1: ensure the ingestion request is forwarded to the routed GMS.
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
-    // dual write pt2: ensure local write using addSimple() and not add().
+    // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
-    verify(_mockLocalDAO, times(1)).addSimple(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -606,7 +606,9 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     // given: ingest a snapshot which contains a non-routed aspect which has a registered pre-update lambda.
     runAndWait(_resource.ingest(snapshot));
 
-    // expected: the aspect value is changed (bar -> foobar) and the aspect is ingested locally only (not dual written).
+    // expected: the aspect is ingested locally only (not dual written). BaseLocalDAO::add will execute any pre-ingestion
+    // lambdas which will change the aspect value from bar -> foobar. But no pre-ingestion lambdas are run from within
+    // the BaseAspectRoutingResource class.
     verify(_mockAspectBarGmsClient, times(0)).ingest(any(), any());
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(null), eq(null));
     verifyNoMoreInteractions(_mockLocalDAO);

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/ingestion/SamplePreUpdateAspectRegistryImpl.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/ingestion/SamplePreUpdateAspectRegistryImpl.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.ingestion.RestliCompliantPreUpdateRoutingClient;
 import com.linkedin.metadata.dao.ingestion.RestliPreUpdateAspectRegistry;
+import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,6 +16,7 @@ public class SamplePreUpdateAspectRegistryImpl implements RestliPreUpdateAspectR
   public SamplePreUpdateAspectRegistryImpl() {
     registry = new ImmutableMap.Builder<Class<? extends RecordTemplate>, RestliCompliantPreUpdateRoutingClient>()
         .put(AspectFoo.class, new SamplePreUpdateRoutingClient())
+        .put(AspectBar.class, new SamplePreUpdateRoutingClient())
         .build();
   }
   @Nullable

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/ingestion/SamplePreUpdateRoutingClient.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/ingestion/SamplePreUpdateRoutingClient.java
@@ -12,8 +12,8 @@ import com.linkedin.testing.AspectFoo;
 public class SamplePreUpdateRoutingClient implements RestliCompliantPreUpdateRoutingClient {
   @Override
   public Message routingLambda(Message urn, Message aspect) {
-    // For testing, change the aspect value to "bar"
-    return Any.pack(StringValue.of("bar"));
+    // For testing, change the aspect value to "foobar"
+    return Any.pack(StringValue.of("foobar"));
   }
 
   @Override
@@ -35,7 +35,7 @@ public class SamplePreUpdateRoutingClient implements RestliCompliantPreUpdateRou
   @Override
   public RecordTemplate convertAspectToRecordTemplate(Message messageAspect) {
     // For testing, convert TestMessageProtos.AspectMessage back to AspectFoo
-    // Create a new RecordTemplate (AspectFoo in this case) and set the value field
-    return new AspectFoo().setValue("bar");
+    // Create a new RecordTemplate (AspectFoo in this case) and set the value field to foobar
+    return new AspectFoo().setValue("foobar");
   }
 }


### PR DESCRIPTION
## Summary
Change the behavior of BaseAspectRoutingResource's ingestInternal method to write any routed aspects locally in addition to routing the request to another GMS.

### Details
1) Update ingestInternal and ingestAssetInternal with the same logic
2) Move resource-level pre-ingestion lambdas into the if statement which checks if an aspect has a registered routing client.
3) In the aspect routing branch of the if statement, also call a new local DAO API `addSimple` which will store the aspect locally without executing any pre-ingestion lambdas within BaseLocalDAO. This is to prevent the case where a pre-ingestion lambda is executed twice in one ingestion (one before the routing, one within the local DAO).

## Testing Done
Update existing unit tests to expect dual-write behavior. Added some comments for context.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
