### PR TITLE
Fixed RestliPreUpdateAspectRegistry ingestion bug

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -407,6 +407,13 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     _restliPreUpdateAspectRegistry = restliPreUpdateAspectRegistry;
   }
 
+  /**
+   * Get pre ingestion aspect registry.
+   */
+  public RestliPreUpdateAspectRegistry getRestliPreUpdateAspectRegistry() {
+    return _restliPreUpdateAspectRegistry;
+  }
+
 
   /**
    * Enables or disables atomic updates of multiple aspects.

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1656,7 +1656,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
           _restliPreUpdateAspectRegistry.getPreUpdateRoutingClient(newValue);
       Message updatedAspect =
           client.routingLambda(client.convertUrnToMessage(urn), client.convertAspectToMessage(newValue));
-      RecordTemplate convertedAspect = client.convertAspectFromMessage(updatedAspect);
+      RecordTemplate convertedAspect = client.convertAspectToRecordTemplate(updatedAspect);
       return (ASPECT) convertedAspect;
     }
     return newValue;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -402,7 +402,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * Set pre ingestion aspect registry.
    */
-  public void setRestliPreIngestionAspectRegistry(
+  public void setRestliPreUpdateAspectRegistry(
       @Nullable RestliPreUpdateAspectRegistry restliPreUpdateAspectRegistry) {
     _restliPreUpdateAspectRegistry = restliPreUpdateAspectRegistry;
   }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/RestliCompliantPreUpdateRoutingClient.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/RestliCompliantPreUpdateRoutingClient.java
@@ -36,5 +36,5 @@ public interface RestliCompliantPreUpdateRoutingClient<ASPECT extends Message> e
    * @param messageAspect the Protobuf message aspect to be converted
    * @return the converted {@link RecordTemplate} aspect
    */
-  RecordTemplate convertAspectFromMessage(ASPECT messageAspect);
+  RecordTemplate convertAspectToRecordTemplate(ASPECT messageAspect);
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -658,7 +658,7 @@ public class BaseLocalDAOTest {
     FooUrn urn = new FooUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectFoo bar = new AspectFoo().setValue("bar");
-    _dummyLocalDAO.setRestliPreIngestionAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
+    _dummyLocalDAO.setRestliPreUpdateAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
     AspectFoo result = _dummyLocalDAO.preUpdateRouting(urn, foo);
     assertEquals(result, bar);
   }
@@ -669,7 +669,7 @@ public class BaseLocalDAOTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectFoo bar = new AspectFoo().setValue("bar");
     _dummyLocalDAO.setAlwaysEmitAuditEvent(true);
-    _dummyLocalDAO.setRestliPreIngestionAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
+    _dummyLocalDAO.setRestliPreUpdateAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
     expectGetLatest(urn, AspectFoo.class,
         Arrays.asList(makeAspectEntry(null, null), makeAspectEntry(foo, _dummyAuditStamp)));
 
@@ -687,7 +687,7 @@ public class BaseLocalDAOTest {
     AspectBar foo = new AspectBar().setValue("foo");
 
     // Inject RestliPreIngestionAspectRegistry with no registered aspect
-    _dummyLocalDAO.setRestliPreIngestionAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
+    _dummyLocalDAO.setRestliPreUpdateAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
 
     // Call the add method
     AspectBar result = _dummyLocalDAO.preUpdateRouting(urn, foo);

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/ingestion/SamplePreUpdateRoutingClient.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/ingestion/SamplePreUpdateRoutingClient.java
@@ -32,7 +32,7 @@ public class SamplePreUpdateRoutingClient implements RestliCompliantPreUpdateRou
   }
 
   @Override
-  public RecordTemplate convertAspectFromMessage(Message messageAspect) {
+  public RecordTemplate convertAspectToRecordTemplate(Message messageAspect) {
     // For testing, convert TestMessageProtos.AspectMessage back to AspectFoo
     // Create a new RecordTemplate (AspectFoo in this case) and set the value field
     return new AspectFoo().setValue("bar");

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -94,11 +94,6 @@ public abstract class BaseAspectRoutingResource<
    */
   public abstract AspectRoutingGmsClientManager getAspectRoutingGmsClientManager();
 
-  /** Set the restliPreUpdateAspectRegistry. */
-  public void setRestliPreUpdateAspectRegistry(RestliPreUpdateAspectRegistry restliPreUpdateAspectRegistry) {
-    _restliPreUpdateAspectRegistry = restliPreUpdateAspectRegistry;
-  }
-
   /**
    * Retrieves the value for an entity that is made up of latest versions of specified aspects.
    */
@@ -315,9 +310,10 @@ public abstract class BaseAspectRoutingResource<
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {
         if (!aspectsToIgnore.contains(aspect.getClass())) {
-          if (_restliPreUpdateAspectRegistry != null && _restliPreUpdateAspectRegistry.isRegistered(
-              aspect.getClass())) {
-            aspect = preUpdateRouting(urn, aspect);
+          // get the updated aspect if there is a preupdate routing lambda registered
+          RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
+          if (registry != null && registry.isRegistered(aspect.getClass())) {
+            aspect = preUpdateRouting(urn, aspect, registry);
           }
           // Get the fqcn of the aspect class
           String aspectFQCN = aspect.getClass().getCanonicalName();
@@ -359,9 +355,10 @@ public abstract class BaseAspectRoutingResource<
           ingestionParams != null ? ingestionParams.getIngestionTrackingContext() : null;
       ModelUtils.getAspectsFromAsset(asset).forEach(aspect -> {
         if (!aspectsToIgnore.contains(aspect.getClass())) {
-          if (_restliPreUpdateAspectRegistry != null && _restliPreUpdateAspectRegistry.isRegistered(
-              aspect.getClass())) {
-            aspect = preUpdateRouting(urn, aspect);
+          // get the updated aspect if there is a preupdate routing lambda registered
+          RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
+          if (registry != null && registry.isRegistered(aspect.getClass())) {
+            aspect = preUpdateRouting(urn, aspect, registry);
           }
           // Get the fqcn of the aspect class
           String aspectFQCN = aspect.getClass().getCanonicalName();
@@ -622,11 +619,10 @@ public abstract class BaseAspectRoutingResource<
    * @param aspect the new aspect value
    * @return the updated aspect
    */
-  private RecordTemplate preUpdateRouting(URN urn, RecordTemplate aspect) {
-    RestliCompliantPreUpdateRoutingClient client =
-        _restliPreUpdateAspectRegistry.getPreUpdateRoutingClient(aspect);
-    Message updatedAspect =
-        client.routingLambda(client.convertUrnToMessage(urn), client.convertAspectToMessage(aspect));
-    return client.convertAspectFromMessage(updatedAspect);
+  private RecordTemplate preUpdateRouting(URN urn, RecordTemplate aspect, RestliPreUpdateAspectRegistry registry) {
+      RestliCompliantPreUpdateRoutingClient client = registry.getPreUpdateRoutingClient(aspect);
+      Message updatedAspect =
+          client.routingLambda(client.convertUrnToMessage(urn), client.convertAspectToMessage(aspect));
+      return client.convertAspectFromMessage(updatedAspect);
   }
 }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -623,6 +623,6 @@ public abstract class BaseAspectRoutingResource<
       RestliCompliantPreUpdateRoutingClient client = registry.getPreUpdateRoutingClient(aspect);
       Message updatedAspect =
           client.routingLambda(client.convertUrnToMessage(urn), client.convertAspectToMessage(aspect));
-      return client.convertAspectFromMessage(updatedAspect);
+      return client.convertAspectToRecordTemplate(updatedAspect);
   }
 }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -310,19 +310,19 @@ public abstract class BaseAspectRoutingResource<
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {
         if (!aspectsToIgnore.contains(aspect.getClass())) {
-          // get the updated aspect if there is a preupdate routing lambda registered
-          RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
-          if (registry != null && registry.isRegistered(aspect.getClass())) {
-            aspect = preUpdateRouting(urn, aspect, registry);
-          }
-          // Get the fqcn of the aspect class
-          String aspectFQCN = aspect.getClass().getCanonicalName();
-          //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-          if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-            return;
-          }
           if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
             try {
+              // get the updated aspect if there is a preupdate routing lambda registered
+              RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
+              if (registry != null && registry.isRegistered(aspect.getClass())) {
+                aspect = preUpdateRouting(urn, aspect, registry);
+              }
+              // Get the fqcn of the aspect class
+              String aspectFQCN = aspect.getClass().getCanonicalName();
+              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
+              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
+                return;
+              }
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
               } else {
@@ -355,19 +355,19 @@ public abstract class BaseAspectRoutingResource<
           ingestionParams != null ? ingestionParams.getIngestionTrackingContext() : null;
       ModelUtils.getAspectsFromAsset(asset).forEach(aspect -> {
         if (!aspectsToIgnore.contains(aspect.getClass())) {
-          // get the updated aspect if there is a preupdate routing lambda registered
-          RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
-          if (registry != null && registry.isRegistered(aspect.getClass())) {
-            aspect = preUpdateRouting(urn, aspect, registry);
-          }
-          // Get the fqcn of the aspect class
-          String aspectFQCN = aspect.getClass().getCanonicalName();
-          //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-          if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-            return;
-          }
           if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
             try {
+              // get the updated aspect if there is a preupdate routing lambda registered
+              RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
+              if (registry != null && registry.isRegistered(aspect.getClass())) {
+                aspect = preUpdateRouting(urn, aspect, registry);
+              }
+              // Get the fqcn of the aspect class
+              String aspectFQCN = aspect.getClass().getCanonicalName();
+              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
+              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
+                return;
+              }
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass())
                     .ingestWithTracking(urn, aspect, trackingContext, ingestionParams);

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -305,7 +305,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(null), eq(null));
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
-    verify(_mockLocalDAO, times(3)).getRestliPreUpdateAspectRegistry();
+    verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 
@@ -325,7 +325,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(trackingContext), eq(null));
     verify(_mockAspectFooGmsClient, times(1)).ingestWithTracking(eq(urn), eq(foo), eq(trackingContext), eq(null));
     verify(_mockAspectAttributeGmsClient, times(1)).ingestWithTracking(eq(urn), eq(attributes), eq(trackingContext), eq(null));
-    verify(_mockLocalDAO, times(3)).getRestliPreUpdateAspectRegistry();
+    verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 
@@ -337,7 +337,6 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
 
     runAndWait(_resource.ingest(snapshot));
-    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(null), eq(null));
     verifyZeroInteractions(_mockAspectFooGmsClient);
     verifyNoMoreInteractions(_mockLocalDAO);
@@ -582,7 +581,6 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     runAndWait(_resource.ingest(snapshot));
     verify(_mockAspectBarGmsClient, times(0)).ingest(any(), any());
-    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(null), eq(null));
     verifyNoMoreInteractions(_mockLocalDAO);
   }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -325,7 +325,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(trackingContext), eq(null));
     verify(_mockAspectFooGmsClient, times(1)).ingestWithTracking(eq(urn), eq(foo), eq(trackingContext), eq(null));
     verify(_mockAspectAttributeGmsClient, times(1)).ingestWithTracking(eq(urn), eq(attributes), eq(trackingContext), eq(null));
-    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
+    verify(_mockLocalDAO, times(3)).getRestliPreUpdateAspectRegistry();
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -305,6 +305,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(null), eq(null));
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
+    verify(_mockLocalDAO, times(3)).getRestliPreUpdateAspectRegistry();
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 
@@ -324,6 +325,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(trackingContext), eq(null));
     verify(_mockAspectFooGmsClient, times(1)).ingestWithTracking(eq(urn), eq(foo), eq(trackingContext), eq(null));
     verify(_mockAspectAttributeGmsClient, times(1)).ingestWithTracking(eq(urn), eq(attributes), eq(trackingContext), eq(null));
+    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 
@@ -335,7 +337,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
 
     runAndWait(_resource.ingest(snapshot));
-
+    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(null), eq(null));
     verifyZeroInteractions(_mockAspectFooGmsClient);
     verifyNoMoreInteractions(_mockLocalDAO);
@@ -352,7 +354,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     runAndWait(_resource.ingest(snapshot));
 
-    verifyZeroInteractions(_mockLocalDAO);
+    verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
     // verify(_mockGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
@@ -557,9 +559,13 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     List<EntityAspectUnion> aspects = Arrays.asList(ModelUtils.newAspectUnion(EntityAspectUnion.class, foo));
     EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
-    _resource.setRestliPreUpdateAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
+
+    SamplePreUpdateAspectRegistryImpl registry = new SamplePreUpdateAspectRegistryImpl();
+    when(_mockLocalDAO.getRestliPreUpdateAspectRegistry()).thenReturn(registry);
+
     runAndWait(_resource.ingest(snapshot));
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(bar));
+    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
     verifyNoMoreInteractions(_mockLocalDAO);
   }
@@ -570,9 +576,13 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     AspectBar bar = new AspectBar().setValue("bar");
     List<EntityAspectUnion> aspects = Arrays.asList(ModelUtils.newAspectUnion(EntityAspectUnion.class, bar));
     EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
-    _resource.setRestliPreUpdateAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
+
+    SamplePreUpdateAspectRegistryImpl registry = new SamplePreUpdateAspectRegistryImpl();
+    when(_mockLocalDAO.getRestliPreUpdateAspectRegistry()).thenReturn(registry);
+
     runAndWait(_resource.ingest(snapshot));
     verify(_mockAspectBarGmsClient, times(0)).ingest(any(), any());
+    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     verify(_mockLocalDAO, times(1)).add(eq(urn), eq(bar), any(), eq(null), eq(null));
     verifyNoMoreInteractions(_mockLocalDAO);
   }
@@ -594,10 +604,14 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     List<EntityAspectUnion> aspects = Arrays.asList(ModelUtils.newAspectUnion(EntityAspectUnion.class, foo));
     EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
-    _resource.setRestliPreUpdateAspectRegistry(new SamplePreUpdateAspectRegistryImpl());
+    SamplePreUpdateAspectRegistryImpl registry = new SamplePreUpdateAspectRegistryImpl();
+    when(_mockLocalDAO.getRestliPreUpdateAspectRegistry()).thenReturn(registry);
+
     runAndWait(_resource.ingest(snapshot));
     verify(_mockAspectFooGmsClient, times(0)).ingest(any(), any());
+    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
+    verifyNoMoreInteractions(_mockLocalDAO);
   }
 
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/ingestion/SamplePreUpdateRoutingClient.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/ingestion/SamplePreUpdateRoutingClient.java
@@ -33,7 +33,7 @@ public class SamplePreUpdateRoutingClient implements RestliCompliantPreUpdateRou
   }
 
   @Override
-  public RecordTemplate convertAspectFromMessage(Message messageAspect) {
+  public RecordTemplate convertAspectToRecordTemplate(Message messageAspect) {
     // For testing, convert TestMessageProtos.AspectMessage back to AspectFoo
     // Create a new RecordTemplate (AspectFoo in this case) and set the value field
     return new AspectFoo().setValue("bar");


### PR DESCRIPTION
## Summary
Fixed RestliPreUpdateAspectRegistry ingestion bug by getting the registry from BaseLocalDAO 
## Testing Done

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
