### PR TITLE
Fixed bug which stopped all current DatasetAccountableOwnership ingestion

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports
           path: /home/runner/work/datahub-gma/datahub-gma/dao-impl/ebean-dao/build/reports/tests/test/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Needed to get all tags
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
         with:
           # Needed to get all tags
           fetch-depth: 0

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -72,7 +72,6 @@ public abstract class BaseAspectRoutingResource<
   private final Class<INTERNAL_SNAPSHOT> _internalSnapshotClass;
   private final Class<INTERNAL_ASPECT_UNION> _internalAspectUnionClass;
   private final Class<ASSET> _assetClass;
-  private RestliPreUpdateAspectRegistry _restliPreUpdateAspectRegistry = null;
   private static final List<String> SKIP_INGESTION_FOR_ASPECTS = Collections.singletonList("com.linkedin.dataset.DatasetAccountableOwnership");
 
   public BaseAspectRoutingResource(@Nullable Class<SNAPSHOT> snapshotClass,
@@ -316,13 +315,13 @@ public abstract class BaseAspectRoutingResource<
               RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
               if (registry != null && registry.isRegistered(aspect.getClass())) {
                 aspect = preUpdateRouting(urn, aspect, registry);
-              }
-              // Get the fqcn of the aspect class
-              String aspectFQCN = aspect.getClass().getCanonicalName();
-              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-                return;
-              }
+                // Get the fqcn of the aspect class
+                String aspectFQCN = aspect.getClass().getCanonicalName();
+                //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
+                if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
+                  return;
+                }
+              } 
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
               } else {
@@ -361,12 +360,12 @@ public abstract class BaseAspectRoutingResource<
               RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
               if (registry != null && registry.isRegistered(aspect.getClass())) {
                 aspect = preUpdateRouting(urn, aspect, registry);
-              }
-              // Get the fqcn of the aspect class
-              String aspectFQCN = aspect.getClass().getCanonicalName();
-              //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-              if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-                return;
+                // Get the fqcn of the aspect class
+                String aspectFQCN = aspect.getClass().getCanonicalName();
+                //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
+                if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
+                  return;
+                }
               }
               if (trackingContext != null) {
                 getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass())

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -631,7 +631,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
 
     runAndWait(_resource.ingest(snapshot));
     // Should not skip ingestion
-    verify(_mockAspectFooGmsClient, times(1)).ingest(any(), any());
+    verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     // Should check for pre lambda
     verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     // Should not add to localDAO

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -612,4 +612,31 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 
+  //Testing the case when aspect has no pre lambda but skipIngestion contains the aspect, so it should not skip ingestion
+  @Test
+  public void testPreUpdateRoutingWithSkipIngestionNoPreLambda() throws NoSuchFieldException, IllegalAccessException {
+
+    Field skipIngestionField = BaseAspectRoutingResource.class.getDeclaredField("SKIP_INGESTION_FOR_ASPECTS");
+    skipIngestionField.setAccessible(true);
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(skipIngestionField, skipIngestionField.getModifiers() & ~Modifier.FINAL);
+    List<String> newSkipIngestionList = Arrays.asList("com.linkedin.testing.AspectFoo");
+    skipIngestionField.set(null, newSkipIngestionList);
+
+    FooUrn urn = makeFooUrn(1);
+    AspectFoo foo = new AspectFoo().setValue("foo");
+    List<EntityAspectUnion> aspects = Arrays.asList(ModelUtils.newAspectUnion(EntityAspectUnion.class, foo));
+    EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
+
+    runAndWait(_resource.ingest(snapshot));
+    // Should not skip ingestion
+    verify(_mockAspectFooGmsClient, times(1)).ingest(any(), any());
+    // Should check for pre lambda
+    verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
+    // Should not add to localDAO
+    verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
+    verifyNoMoreInteractions(_mockLocalDAO);
+  }
+
 }


### PR DESCRIPTION
## Summary
Moved the skip logic inside preUpdateLambda check. That is, only skip ingestion when it has a prelambda registered.

Workflow failed because of deprecated version of actions/upload-artifact: updated to v3: Ref: https://github.com/reactjs/react.dev/issues/7148
## Testing Done
mint build
added a unit test for this case
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
