### PR TITLE
fix(findRelationshipsV2): change source/dest params from Urn to String

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -243,7 +243,7 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Checks if entity type name can be extracted from urn, and that entity type has a table in db.
+   * Checks if a given entity type has an entity table in the db.
    */
   @VisibleForTesting
   protected boolean isMgEntityType(@Nonnull String entityType) {
@@ -275,9 +275,9 @@ public class EbeanLocalRelationshipQueryDAO {
 
   /**
    * Validate:
-   * 1. The entity filter only contains supported condition.
-   * 2. if entity class is null, then filter should be emtpy.
-   * If any of above is violated, throw IllegalArgumentException.
+   * 1. The entity filter only contains supported conditions.
+   * 2. if the entity class is null, then the filter should be empty.
+   * If any of above is violated, throw an IllegalArgumentException.
    */
   private <ENTITY extends RecordTemplate> void validateEntityFilter(@Nonnull LocalRelationshipFilter filter, @Nullable Class<ENTITY> entityClass) {
     if (entityClass == null && filter.hasCriteria() && filter.getCriteria().size() > 0) {
@@ -289,10 +289,9 @@ public class EbeanLocalRelationshipQueryDAO {
 
   /**
    * Validate:
-   * 1. if entity urn is null or empty, then filter should be emtpy.
-   * 2. urn should be in valid format
-   * 3. the entity filter only contains supported condition.
-   * If any of above is violated, throw IllegalArgumentException.
+   * 1. if the entity type is null or empty, then the filter should also be emtpy.
+   * 2. the entity filter only contains supported conditions.
+   * If any of above is violated, throw an IllegalArgumentException.
    */
   private void validateEntityTypeAndFilter(@Nullable LocalRelationshipFilter filter, @Nullable String entityType) {
     if ((StringUtils.isBlank(entityType)) && filter != null && filter.hasCriteria() && !filter.getCriteria()

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -356,7 +356,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
-        null, null, fooEntityUrn, destFilter,
+        null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -374,7 +374,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     deletionSQL.execute();
 
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
-        null, null, fooEntityUrn, destFilter,
+        null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -430,7 +430,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filterUrn = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion));
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
-    List<ConsumeFrom> consumeFromSamza = _localRelationshipQueryDAO.findRelationshipsV2(barEntityUrn, filterUrn, fooEntityUrn, null,
+    List<ConsumeFrom> consumeFromSamza = _localRelationshipQueryDAO.findRelationshipsV2("bar", filterUrn, "foo", null,
         ConsumeFrom.class,
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
@@ -445,7 +445,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filterRelationship = new LocalRelationshipFilter().setCriteria(
         new LocalRelationshipCriterionArray(filterRelationshipCriterion)).setDirection(RelationshipDirection.OUTGOING);
 
-    List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationshipsV2(barEntityUrn, filterUrn, fooEntityUrn, null,
+    List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationshipsV2("bar", filterUrn, "foo", null,
         ConsumeFrom.class,
         filterRelationship,
         -1, -1);
@@ -512,7 +512,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
     // test owned by of crew1 can be found
-    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, crewEntityUrn, filterUrn,
+    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, "crew", filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -526,7 +526,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     LocalRelationshipFilter filterUrn2 = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterUrnCriterion2));
 
     // test owned by of crew2 can be found
-    List<OwnedBy> ownedByCrew2 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, crewEntityUrn, filterUrn2,
+    List<OwnedBy> ownedByCrew2 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, "crew", filterUrn2,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -580,7 +580,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
     // test owned by of crew can be filtered by source entity, e.g. only include kafka
-    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2(fooEntityUrn, filterUrn1, crewEntityUrn, filterUrn,
+    List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2("foo", filterUrn1, "crew", filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, -1);
 
@@ -606,7 +606,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // non-mg entity cannot be filtered by non-urn filter. This will throw an exception.
     assertThrows(IllegalArgumentException.class, () -> {
-      _localRelationshipQueryDAO.findRelationshipsV2(fooEntityUrn, filterUrn1, crewEntityUrn, filterUrn,
+      _localRelationshipQueryDAO.findRelationshipsV2("foo", filterUrn1, "crew", filterUrn,
           OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
           -1, -1);
     });
@@ -669,7 +669,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
-        null, null, fooEntityUrn, filter,
+        null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         -1, 3);
 
@@ -677,7 +677,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertEquals(reportsToAlice.size(), 3);
 
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
-        null, null, fooEntityUrn, filter,
+        null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         2, 10);
 
@@ -688,7 +688,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertEquals(actual, expected);
 
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
-        null, null, fooEntityUrn, filter,
+        null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         2, -1);
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -700,7 +700,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
-  public void testIsMgEntityUrn() throws Exception {
+  public void testIsMgEntityType() throws Exception {
     // EbeanLocalRelationshipQueryDAOTest does not have the same package as EbeanLocalRelationshipQueryDAO (cant access protected method directly).
     Method isMgEntityTypeMethod = EbeanLocalRelationshipQueryDAO.class.getDeclaredMethod("isMgEntityType", String.class);
     isMgEntityTypeMethod.setAccessible(true);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -701,19 +701,15 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
   @Test
   public void testIsMgEntityUrn() throws Exception {
-    // add foo to EBeanLocalAccess to create table
-    FooUrn fooUrn = new FooUrn(1);
-    _fooUrnEBeanLocalAccess.add(fooUrn, new AspectFoo().setValue("Alice"), AspectFoo.class, new AuditStamp(), null, false);
-
     // EbeanLocalRelationshipQueryDAOTest does not have the same package as EbeanLocalRelationshipQueryDAO (cant access protected method directly).
-    Method isMgEntityUrnMethod = EbeanLocalRelationshipQueryDAO.class.getDeclaredMethod("isMgEntityUrn", Urn.class);
-    isMgEntityUrnMethod.setAccessible(true);
+    Method isMgEntityTypeMethod = EbeanLocalRelationshipQueryDAO.class.getDeclaredMethod("isMgEntityType", String.class);
+    isMgEntityTypeMethod.setAccessible(true);
 
     // assert foo is an MG entity (has metadata_entity_foo table in db)
-    assertTrue((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, fooEntityUrn));
+    assertTrue((Boolean) isMgEntityTypeMethod.invoke(_localRelationshipQueryDAO, "foo"));
 
     // assert crew is not an MG entity (does not have metadata_entity_crew table in db)
-    assertFalse((Boolean) isMgEntityUrnMethod.invoke(_localRelationshipQueryDAO, crewEntityUrn));
+    assertFalse((Boolean) isMgEntityTypeMethod.invoke(_localRelationshipQueryDAO, "crew"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
There are cases when a user doesn't need to provide an urn for the destination. For example, they only specify the destination type (like "dataset") but without also providing a filter on the UrnField (like urn = "urn:li:dataset:foo"). The current implementation does not support this as it expects either an Urn or null for the source and destination entities. If null, there's no way to tell the API which type of destination to look for.

## Testing Done
adjusted unit tests. ./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
