### PR TITLE
Fix for duplicate writing in test mode

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -863,8 +863,12 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       _localAccess.add(urn, (ASPECT) value, aspectClass, auditStamp, trackingContext, isTestMode);
     }
 
-    if (_changeLogEnabled) {
-      // skip appending change log table (metadata_aspect) if not enabled
+    // DO append change log table (metadata_aspect) if:
+    //   1. explicitly enabled
+    //   AND
+    //   2. if NOT in test mode
+    //      -> which is ALWAYS a dual-write operation (meaning this insertion will already happen in the "other" write)
+    if (_changeLogEnabled && !isTestMode) {
       _server.insert(aspect);
     }
   }


### PR DESCRIPTION
## Summary
Context is the Proto Migration testing employs Dual-Write testing logic, and with `changelogEnabled = true`, it attempts to write 2 records to metadata_aspect with the same Primary Key.

In `BaseLocalDAO.java`: ([ref](https://github.com/linkedin/datahub-gma/blob/af0995a2cedb75170354fec79501b90a44c5e78c/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java#L771))

```java
/**
   * Same as above {@link #add(Urn, AspectUpdateLambda, AuditStamp, int)} but with tracking context.
   */
  @Nonnull
  public <ASPECT extends RecordTemplate> ASPECT add(@Nonnull URN urn, [AspectUpdateLambda](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#139)<ASPECT> updateLambda,
      @Nonnull AuditStamp auditStamp, int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext) {
    final Class<ASPECT> aspectClass = updateLambda.getAspectClass();
    checkValidAspect(aspectClass);
    // dual-write to test table while test mode is enabled.
    if (updateLambda.getIngestionParams().isTestMode()) {
      [runInTransactionWithRetry](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#1080)(() -> [aspectUpdateHelper](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#604)(urn, updateLambda, auditStamp, trackingContext),
          maxTransactionRetry);
    }
    final [AddResult](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#124)<ASPECT> result = [runInTransactionWithRetry](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#1080)(() -> [aspectUpdateHelper](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#604)(urn,
        new [AspectUpdateLambda](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#139)<>(aspectClass, updateLambda.getUpdateLambda(),
            updateLambda.getIngestionParams().setTestMode(false)), auditStamp, trackingContext), maxTransactionRetry);
    return [unwrapAddResult](https://jarvis.corp.linkedin.com/codesearch/result/?name=BaseLocalDAO.java&path=datahub-gma%2Fdao-api%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao&reponame=linkedin%2Fdatahub-gma#648)(urn, result, auditStamp, trackingContext);
  }
```

Note how `aspectUpdateHelper()` is called TWICE when running `testMode = true`.

These both call `insert()` in `EbeanLocalDAO.java` with the same Aspect and without any sort of locking: ([ref](https://github.com/linkedin/datahub-gma/blob/af0995a2cedb75170354fec79501b90a44c5e78c/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java#L868))

### Solution

It's safe to make the assumption that:

* since the second call to aspectUpdateHelper() is always `testMode = false` (see first snippet)...
* the "testMode = true" call to insert() can ALWAYS ignore a write to metadata_aspect, since the "actual" write will insert into the changelog properly

## Testing Done
n/a

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
