### PR TITLE
feat(dual-write): add new ingestSkipPreUpdates resource endpoints

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -853,7 +853,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
     ASPECT updatedAspect = preUpdateRouting(urn, newValue);
-    return addSkipPreIngestionUpdates(urn, updatedAspect, auditStamp, trackingContext, ingestionParams);
+    return addSkipPreUpdates(urn, updatedAspect, auditStamp, trackingContext, ingestionParams);
   }
 
   /**
@@ -862,7 +862,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Please use the regular add method linked above.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT addSkipPreIngestionUpdates(@Nonnull URN urn, @Nonnull ASPECT newValue,
+  public <ASPECT extends RecordTemplate> ASPECT addSkipPreUpdates(@Nonnull URN urn, @Nonnull ASPECT newValue,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
     final IngestionParams nonNullIngestionParams =

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -853,7 +853,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
     ASPECT updatedAspect = preUpdateRouting(urn, newValue);
-    return addSkipPreUpdates(urn, updatedAspect, auditStamp, trackingContext, ingestionParams);
+    return rawAdd(urn, updatedAspect, auditStamp, trackingContext, ingestionParams);
   }
 
   /**
@@ -862,7 +862,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Please use the regular add method linked above.
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> ASPECT addSkipPreUpdates(@Nonnull URN urn, @Nonnull ASPECT newValue,
+  public <ASPECT extends RecordTemplate> ASPECT rawAdd(@Nonnull URN urn, @Nonnull ASPECT newValue,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
     final IngestionParams nonNullIngestionParams =

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -395,8 +395,19 @@ public abstract class BaseAspectRoutingResource<
     });
   }
 
-  private void ingestAspect(Set<Class<? extends RecordTemplate>> aspectsToIgnore,
-      Urn urn, RecordTemplate aspect, IngestionTrackingContext trackingContext, IngestionParams ingestionParams, AuditStamp auditStamp,
+  /**
+   * Helper function to ingest an inspect either via routing or locally (or both). There is a flag that can be toggled
+   * to indicate whether to execute pre-ingestion updates if they exist.
+   * @param aspectsToIgnore set of aspect classes to ignore, if any
+   * @param urn urn associated with the aspect to ingest
+   * @param aspect aspect to ingest
+   * @param trackingContext context for tracking ingestion health
+   * @param ingestionParams optional ingestion parameters
+   * @param auditStamp audit information of the update
+   * @param skipPreIngestionUpdates flag to indicate whether to execute pre-ingestion updates
+   */
+  private void ingestAspect(Set<Class<? extends RecordTemplate>> aspectsToIgnore, Urn urn, RecordTemplate aspect,
+      IngestionTrackingContext trackingContext, IngestionParams ingestionParams, AuditStamp auditStamp,
       boolean skipPreIngestionUpdates) {
     if (!aspectsToIgnore.contains(aspect.getClass())) {
       if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -299,6 +299,15 @@ public abstract class BaseAspectRoutingResource<
     });
   }
 
+  /**
+   * Internal ingest method for snapshots. First execute any pre-ingestion updates. Then, route any aspects which have a registered routing
+   * GMS client to the respective GMS for ingestion. Finally, continue to save the aspect locally as well (i.e. dual write)
+   * @param snapshot snapshot to process
+   * @param aspectsToIgnore aspects to ignore
+   * @param trackingContext context for tracking ingestion health
+   * @param ingestionParams optional ingestion parameters
+   * @return Restli Task for metadata ingestion
+   */
   @Nonnull
   @Override
   protected Task<Void> ingestInternal(@Nonnull SNAPSHOT snapshot,
@@ -308,80 +317,43 @@ public abstract class BaseAspectRoutingResource<
     return RestliUtils.toTask(() -> {
       final URN urn = (URN) ModelUtils.getUrnFromSnapshot(snapshot);
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
-      ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {
-        if (!aspectsToIgnore.contains(aspect.getClass())) {
-          if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
-            try {
-              // get the updated aspect if there is a preupdate routing lambda registered
-              RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
-              if (registry != null && registry.isRegistered(aspect.getClass())) {
-                log.info(String.format("Executing registered pre-update routing lambda for aspect class %s.", aspect.getClass()));
-                aspect = preUpdateRouting(urn, aspect, registry);
-                log.info("PreUpdateRouting completed in ingestInternal, urn: {}, updated aspect: {}", urn, aspect);
-                // Get the fqcn of the aspect class
-                String aspectFQCN = aspect.getClass().getCanonicalName();
-                //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-                if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-                  log.info("Skip ingestion in ingestInternal for urn: {}, aspectFQCN: {}", urn, aspectFQCN);
-                  return;
-                }
-              }
-              if (trackingContext != null) {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
-              } else {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingest(urn, aspect);
-              }
-              // since we already called any pre-update lambdas earlier, call a simple version of BaseLocalDAO::add
-              // which skips pre-update lambdas.
-              getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
-            } catch (Exception exception) {
-              log.error(
-                  String.format("Couldn't ingest routing aspect %s for %s", aspect.getClass().getSimpleName(), urn),
-                  exception);
-            }
-          } else {
-            getLocalDAO().add(urn, aspect, auditStamp, trackingContext, ingestionParams);
-          }
-        }
-      });
+      ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect ->
+        ingestAspect(aspectsToIgnore, urn, aspect, trackingContext, ingestionParams, auditStamp, false));
       return null;
     });
   }
 
+  /**
+   * Internal ingest method for snapshots which skips any pre-ingestion updates. Route any aspects which have a registered routing
+   * GMS client to the respective GMS for ingestion. Finally, continue to save the aspect locally as well (i.e. dual write)
+   * @param snapshot snapshot to process
+   * @param aspectsToIgnore aspects to ignore
+   * @param trackingContext context for tracking ingestion health
+   * @param ingestionParams optional ingestion parameters
+   * @return Restli Task for metadata ingestion
+   */
   @Nonnull
-  protected Task<Void> ingestInternalSkipPreIngestionUpdates(@Nonnull SNAPSHOT snapshot,
+  protected Task<Void> ingestInternalSkipPreUpdates(@Nonnull SNAPSHOT snapshot,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectsToIgnore, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
     // TODO: META-18950: add trackingContext to BaseAspectRoutingResource. currently the param is unused.
     return RestliUtils.toTask(() -> {
       final URN urn = (URN) ModelUtils.getUrnFromSnapshot(snapshot);
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
-      ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {
-        if (!aspectsToIgnore.contains(aspect.getClass())) {
-          if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
-            try {
-              if (trackingContext != null) {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
-              } else {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingest(urn, aspect);
-              }
-              // call a simple version of BaseLocalDAO::add which skips pre-update lambdas.
-              getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
-            } catch (Exception exception) {
-              log.error(
-                  String.format("Couldn't ingest routing aspect %s for %s", aspect.getClass().getSimpleName(), urn),
-                  exception);
-            }
-          } else {
-            // call a simple version of BaseLocalDAO::add which skips pre-update lambdas.
-            getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
-          }
-        }
-      });
+      ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect ->
+          ingestAspect(aspectsToIgnore, urn, aspect, trackingContext, ingestionParams, auditStamp, true));
       return null;
     });
   }
 
+  /**
+   * Internal ingest method for assets. First execute any pre-ingestion updates. Then, route any aspects which have a registered routing
+   * GMS client to the respective GMS for ingestion. Finally, continue to save the aspect locally as well (i.e. dual write)
+   * @param asset asset to process
+   * @param aspectsToIgnore aspects to ignore
+   * @param ingestionParams optional ingestion parameters
+   * @return Restli Task for metadata ingestion
+   */
   @Nonnull
   @Override
   protected Task<Void> ingestInternalAsset(@Nonnull ASSET asset,
@@ -393,47 +365,22 @@ public abstract class BaseAspectRoutingResource<
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       IngestionTrackingContext trackingContext =
           ingestionParams != null ? ingestionParams.getIngestionTrackingContext() : null;
-      ModelUtils.getAspectsFromAsset(asset).forEach(aspect -> {
-        if (!aspectsToIgnore.contains(aspect.getClass())) {
-          if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
-            try {
-              // get the updated aspect if there is a preupdate routing lambda registered
-              RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
-              if (registry != null && registry.isRegistered(aspect.getClass())) {
-                log.info(String.format("Executing registered pre-update routing lambda for aspect class %s.", aspect.getClass()));
-                aspect = preUpdateRouting(urn, aspect, registry);
-                log.info("PreUpdateRouting completed in ingestInternalAsset, urn: {}, updated aspect: {}", urn, aspect);
-                // Get the fqcn of the aspect class
-                String aspectFQCN = aspect.getClass().getCanonicalName();
-                //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
-                if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
-                  log.info("Skip ingestion in ingestInternalAsset for urn: {}, aspectFQCN: {}", urn, aspectFQCN);
-                  return;
-                }
-              }
-              if (trackingContext != null) {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass())
-                    .ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
-              } else {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingest(urn, aspect);
-              }
-              // since we already called any pre-update lambdas earlier, call a simple version of BaseLocalDAO::add
-              // which skips pre-update lambdas.
-              getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
-            } catch (Exception exception) {
-              log.error("Couldn't ingest routing aspect {} for {}", aspect.getClass().getSimpleName(), urn, exception);
-            }
-          } else {
-            getLocalDAO().add(urn, aspect, auditStamp, trackingContext, ingestionParams);
-          }
-        }
-      });
+      ModelUtils.getAspectsFromAsset(asset).forEach(aspect ->
+          ingestAspect(aspectsToIgnore, urn, aspect, trackingContext, ingestionParams, auditStamp, false));
       return null;
     });
   }
 
+  /**
+   * Internal ingest method for assets which skips any pre-ingestion updates. Route any aspects which have a registered routing
+   * GMS client to the respective GMS for ingestion. Finally, continue to save the aspect locally as well (i.e. dual write)
+   * @param asset asset to process
+   * @param aspectsToIgnore aspects to ignore
+   * @param ingestionParams optional ingestion parameters
+   * @return Restli Task for metadata ingestion
+   */
   @Nonnull
-  protected Task<Void> ingestInternalAssetSkipPreIngestionUpdates(@Nonnull ASSET asset,
+  protected Task<Void> ingestInternalAssetSkipPreUpdates(@Nonnull ASSET asset,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectsToIgnore,
       @Nullable IngestionParams ingestionParams) {
     // TODO: META-18950: add trackingContext to BaseAspectRoutingResource. currently the param is unused.
@@ -442,29 +389,54 @@ public abstract class BaseAspectRoutingResource<
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       IngestionTrackingContext trackingContext =
           ingestionParams != null ? ingestionParams.getIngestionTrackingContext() : null;
-      ModelUtils.getAspectsFromAsset(asset).forEach(aspect -> {
-        if (!aspectsToIgnore.contains(aspect.getClass())) {
-          if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
-            try {
-              if (trackingContext != null) {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass())
-                    .ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
-              } else {
-                getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingest(urn, aspect);
-              }
-              // call a simple version of BaseLocalDAO::add which skips pre-update lambdas.
-              getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
-            } catch (Exception exception) {
-              log.error("Couldn't ingest routing aspect {} for {}", aspect.getClass().getSimpleName(), urn, exception);
-            }
-          } else {
-            // call a simple version of BaseLocalDAO::add which skips pre-update lambdas.
-            getLocalDAO().addSkipPreIngestionUpdates(urn, aspect, auditStamp, trackingContext, ingestionParams);
-          }
-        }
-      });
+      ModelUtils.getAspectsFromAsset(asset).forEach(aspect ->
+          ingestAspect(aspectsToIgnore, urn, aspect, trackingContext, ingestionParams, auditStamp, true));
       return null;
     });
+  }
+
+  private void ingestAspect(Set<Class<? extends RecordTemplate>> aspectsToIgnore,
+      Urn urn, RecordTemplate aspect, IngestionTrackingContext trackingContext, IngestionParams ingestionParams, AuditStamp auditStamp,
+      boolean skipPreIngestionUpdates) {
+    if (!aspectsToIgnore.contains(aspect.getClass())) {
+      if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
+        try {
+          // get the updated aspect if there is a preupdate routing lambda registered
+          RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
+          if (!skipPreIngestionUpdates && registry != null && registry.isRegistered(aspect.getClass())) {
+            log.info(String.format("Executing registered pre-update routing lambda for aspect class %s.", aspect.getClass()));
+            aspect = preUpdateRouting((URN) urn, aspect, registry);
+            log.info("PreUpdateRouting completed in ingestInternalAsset, urn: {}, updated aspect: {}", urn, aspect);
+            // Get the fqcn of the aspect class
+            String aspectFQCN = aspect.getClass().getCanonicalName();
+            //TODO: META-21112: Remove this check after adding annotations at model level; to handle SKIP/PROCEED for preUpdateRouting
+            if (SKIP_INGESTION_FOR_ASPECTS.contains(aspectFQCN)) {
+              log.info("Skip ingestion in ingestInternalAsset for urn: {}, aspectFQCN: {}", urn, aspectFQCN);
+              return;
+            }
+          }
+          if (trackingContext != null) {
+            getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass())
+                .ingestWithTracking(urn, aspect, trackingContext, ingestionParams);
+          } else {
+            getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingest(urn, aspect);
+          }
+          // here, always call a simple version of BaseLocalDAO::add which skips pre-update lambdas regardless of
+          // the value of param skipPreIngestionUpdates since any pre-update lambdas would have already been executed
+          // in the code above.
+          getLocalDAO().addSkipPreUpdates((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
+        } catch (Exception exception) {
+          log.error("Couldn't ingest routing aspect {} for {}", aspect.getClass().getSimpleName(), urn, exception);
+        }
+      } else {
+        if (skipPreIngestionUpdates) {
+          // call a simple version of BaseLocalDAO::add which skips pre-update lambdas.
+          getLocalDAO().addSkipPreUpdates((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
+        } else {
+          getLocalDAO().add((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
+        }
+      }
+    }
   }
 
   /**

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -324,8 +324,9 @@ public abstract class BaseAspectRoutingResource<
   }
 
   /**
-   * Internal ingest method for snapshots which skips any pre-ingestion updates. Route any aspects which have a registered routing
-   * GMS client to the respective GMS for ingestion. Finally, continue to save the aspect locally as well (i.e. dual write)
+   * Raw internal ingest method for snapshots which skips any pre-, intra-, or post-processing. Route any aspects which
+   * have a registered routing GMS client to the respective GMS for ingestion. Finally, continue to save the aspect
+   * locally as well (i.e. dual write)
    * @param snapshot snapshot to process
    * @param aspectsToIgnore aspects to ignore
    * @param trackingContext context for tracking ingestion health
@@ -333,7 +334,7 @@ public abstract class BaseAspectRoutingResource<
    * @return Restli Task for metadata ingestion
    */
   @Nonnull
-  protected Task<Void> ingestInternalSkipPreUpdates(@Nonnull SNAPSHOT snapshot,
+  protected Task<Void> rawIngestInternal(@Nonnull SNAPSHOT snapshot,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectsToIgnore, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
     // TODO: META-18950: add trackingContext to BaseAspectRoutingResource. currently the param is unused.
@@ -372,15 +373,16 @@ public abstract class BaseAspectRoutingResource<
   }
 
   /**
-   * Internal ingest method for assets which skips any pre-ingestion updates. Route any aspects which have a registered routing
-   * GMS client to the respective GMS for ingestion. Finally, continue to save the aspect locally as well (i.e. dual write)
+   * Raw internal ingest method for assets which skips any pre-, intra-, or post-processing. Route any aspects which
+   * have a registered routing GMS client to the respective GMS for ingestion. Finally, continue to save the aspect
+   * locally as well (i.e. dual write)
    * @param asset asset to process
    * @param aspectsToIgnore aspects to ignore
    * @param ingestionParams optional ingestion parameters
    * @return Restli Task for metadata ingestion
    */
   @Nonnull
-  protected Task<Void> ingestInternalAssetSkipPreUpdates(@Nonnull ASSET asset,
+  protected Task<Void> rawIngestInternalAsset(@Nonnull ASSET asset,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectsToIgnore,
       @Nullable IngestionParams ingestionParams) {
     // TODO: META-18950: add trackingContext to BaseAspectRoutingResource. currently the param is unused.
@@ -397,24 +399,24 @@ public abstract class BaseAspectRoutingResource<
 
   /**
    * Helper function to ingest an aspect either via routing or locally (or both). There is a flag that can be toggled
-   * to indicate whether to execute pre-ingestion updates if they exist.
+   * to indicate whether to execute pre-, intra-, or post-ingestion updates if they exist.
    * @param aspectsToIgnore set of aspect classes to ignore, if any
    * @param urn urn associated with the aspect to ingest
    * @param aspect aspect to ingest
    * @param trackingContext context for tracking ingestion health
    * @param ingestionParams optional ingestion parameters
    * @param auditStamp audit information of the update
-   * @param skipPreIngestionUpdates flag to indicate whether to execute pre-ingestion updates
+   * @param skipExtraProcessing flag to indicate whether to execute pre-, intra-, or post-ingestion updates
    */
   private void ingestAspect(Set<Class<? extends RecordTemplate>> aspectsToIgnore, Urn urn, RecordTemplate aspect,
       IngestionTrackingContext trackingContext, IngestionParams ingestionParams, AuditStamp auditStamp,
-      boolean skipPreIngestionUpdates) {
+      boolean skipExtraProcessing) {
     if (!aspectsToIgnore.contains(aspect.getClass())) {
       if (getAspectRoutingGmsClientManager().hasRegistered(aspect.getClass())) {
         try {
           // get the updated aspect if there is a preupdate routing lambda registered
           RestliPreUpdateAspectRegistry registry = getLocalDAO().getRestliPreUpdateAspectRegistry();
-          if (!skipPreIngestionUpdates && registry != null && registry.isRegistered(aspect.getClass())) {
+          if (!skipExtraProcessing && registry != null && registry.isRegistered(aspect.getClass())) {
             log.info(String.format("Executing registered pre-update routing lambda for aspect class %s.", aspect.getClass()));
             aspect = preUpdateRouting((URN) urn, aspect, registry);
             log.info("PreUpdateRouting completed in ingestInternalAsset, urn: {}, updated aspect: {}", urn, aspect);
@@ -433,16 +435,16 @@ public abstract class BaseAspectRoutingResource<
             getAspectRoutingGmsClientManager().getRoutingGmsClient(aspect.getClass()).ingest(urn, aspect);
           }
           // here, always call a simple version of BaseLocalDAO::add which skips pre-update lambdas regardless of
-          // the value of param skipPreIngestionUpdates since any pre-update lambdas would have already been executed
+          // the value of param skipExtraProcessing since any pre-update lambdas would have already been executed
           // in the code above.
-          getLocalDAO().addSkipPreUpdates((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
+          getLocalDAO().rawAdd((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
         } catch (Exception exception) {
           log.error("Couldn't ingest routing aspect {} for {}", aspect.getClass().getSimpleName(), urn, exception);
         }
       } else {
-        if (skipPreIngestionUpdates) {
+        if (skipExtraProcessing) {
           // call a simple version of BaseLocalDAO::add which skips pre-update lambdas.
-          getLocalDAO().addSkipPreUpdates((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
+          getLocalDAO().rawAdd((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
         } else {
           getLocalDAO().add((URN) urn, aspect, auditStamp, trackingContext, ingestionParams);
         }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -396,7 +396,7 @@ public abstract class BaseAspectRoutingResource<
   }
 
   /**
-   * Helper function to ingest an inspect either via routing or locally (or both). There is a flag that can be toggled
+   * Helper function to ingest an aspect either via routing or locally (or both). There is a flag that can be toggled
    * to indicate whether to execute pre-ingestion updates if they exist.
    * @param aspectsToIgnore set of aspect classes to ignore, if any
    * @param urn urn associated with the aspect to ingest

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -25,7 +25,7 @@ public final class RestliConstants {
   public static final String ACTION_GET_SNAPSHOT = "getSnapshot";
   public static final String ACTION_INGEST = "ingest";
   public static final String ACTION_INGEST_ASSET = "ingestAsset";
-  public static final String ACTION_INGEST_ASSET_SKIP_PRE_INGESTION_UPDATES = "ingestAssetSkipPreIngestionUpdates";
+  public static final String ACTION_INGEST_ASSET_SKIP_PRE_UPDATES = "ingestAssetSkipPreUpdates";
   public static final String ACTION_INGEST_WITH_TRACKING = "ingestWithTracking";
   public static final String ACTION_INGEST_SKIP_PRE_INGESTION_UPDATES = "ingestSkipPreIngestionUpdates";
   public static final String ACTION_QUERY = "query";

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -25,7 +25,9 @@ public final class RestliConstants {
   public static final String ACTION_GET_SNAPSHOT = "getSnapshot";
   public static final String ACTION_INGEST = "ingest";
   public static final String ACTION_INGEST_ASSET = "ingestAsset";
+  public static final String ACTION_INGEST_ASSET_SKIP_PRE_INGESTION_UPDATES = "ingestAssetSkipPreIngestionUpdates";
   public static final String ACTION_INGEST_WITH_TRACKING = "ingestWithTracking";
+  public static final String ACTION_INGEST_SKIP_PRE_INGESTION_UPDATES = "ingestSkipPreIngestionUpdates";
   public static final String ACTION_QUERY = "query";
   public static final String ACTION_LIST_URNS_FROM_INDEX = "listUrnsFromIndex";
   public static final String ACTION_LIST_URNS = "listUrns";

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -25,10 +25,10 @@ public final class RestliConstants {
   public static final String ACTION_GET_SNAPSHOT = "getSnapshot";
   public static final String ACTION_INGEST = "ingest";
   public static final String ACTION_INGEST_ASSET = "ingestAsset";
-  public static final String ACTION_INGEST_ASSET_SKIP_PRE_UPDATES = "ingestAssetSkipPreUpdates";
   public static final String ACTION_INGEST_WITH_TRACKING = "ingestWithTracking";
-  public static final String ACTION_INGEST_SKIP_PRE_INGESTION_UPDATES = "ingestSkipPreIngestionUpdates";
   public static final String ACTION_QUERY = "query";
+  public static final String ACTION_RAW_INGEST = "rawIngest";
+  public static final String ACTION_RAW_INGEST_ASSET = "rawIngestAsset";
   public static final String ACTION_LIST_URNS_FROM_INDEX = "listUrnsFromIndex";
   public static final String ACTION_LIST_URNS = "listUrns";
   public static final String PARAM_INPUT = "input";

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -570,7 +570,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     AspectFoo foobar = new AspectFoo().setValue("foobar");
     // dual write pt1: ensure the ingestion request is forwarded to the routed GMS.
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foobar));
-    // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
+    // dual write pt2: ensure local write using rawAdd() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
     verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foobar), any(), any(), any());
   }
@@ -589,7 +589,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     // expected: the aspect value remains unchanged and the aspect is dual-written.
     // dual write pt1: ensure the ingestion request is forwarded to the routed GMS.
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
-    // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
+    // dual write pt2: ensure local write using rawAdd() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
     verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foo), any(), any(), any());
   }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -306,7 +306,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -326,7 +326,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingestWithTracking(eq(urn), eq(foo), eq(trackingContext), eq(null));
     verify(_mockAspectAttributeGmsClient, times(1)).ingestWithTracking(eq(urn), eq(attributes), eq(trackingContext), eq(null));
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -354,7 +354,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     runAndWait(_resource.ingest(snapshot));
 
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
     // verify(_mockGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
@@ -572,7 +572,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foobar));
     // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foobar), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foobar), any(), any(), any());
   }
 
   @Test
@@ -591,7 +591,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -679,7 +679,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     // Should check for pre lambda
     verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     // Should continue to dual-write into local DAO
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseAspectRoutingResourceTest.java
@@ -306,7 +306,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -326,7 +326,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingestWithTracking(eq(urn), eq(foo), eq(trackingContext), eq(null));
     verify(_mockAspectAttributeGmsClient, times(1)).ingestWithTracking(eq(urn), eq(attributes), eq(trackingContext), eq(null));
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -354,7 +354,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     runAndWait(_resource.ingest(snapshot));
 
     verify(_mockLocalDAO, times(2)).getRestliPreUpdateAspectRegistry();
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foo), any(), any(), any());
     // verify(_mockGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     verify(_mockAspectAttributeGmsClient, times(1)).ingest(eq(urn), eq(attributes));
@@ -572,7 +572,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foobar));
     // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foobar), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foobar), any(), any(), any());
   }
 
   @Test
@@ -591,7 +591,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     verify(_mockAspectFooGmsClient, times(1)).ingest(eq(urn), eq(foo));
     // dual write pt2: ensure local write using addSkipPreIngestionUpdates() and not add().
     verify(_mockLocalDAO, times(0)).add(any(), any(), any(), any(), any());
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foo), any(), any(), any());
   }
 
   @Test
@@ -679,7 +679,7 @@ public class BaseAspectRoutingResourceTest extends BaseEngineTest {
     // Should check for pre lambda
     verify(_mockLocalDAO, times(1)).getRestliPreUpdateAspectRegistry();
     // Should continue to dual-write into local DAO
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), any());
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foo), any(), any(), any());
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -1519,12 +1519,12 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         ModelUtils.newAspectUnion(EntityAspectUnion.class, bar));
     EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
 
-    runAndWait(_resource.ingestSkipPreIngestionUpdates(snapshot, new IngestionTrackingContext(), null));
+    runAndWait(_resource.rawIngest(snapshot, new IngestionTrackingContext(), null));
 
     verify(_mockLocalDAO, times(0)).add(eq(urn), eq(foo), any(), any(), eq(null));
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), eq(null));
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(foo), any(), any(), eq(null));
     verify(_mockLocalDAO, times(0)).add(eq(urn), eq(bar), any(), any(), eq(null));
-    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(bar), any(), any(), eq(null));
+    verify(_mockLocalDAO, times(1)).rawAdd(eq(urn), eq(bar), any(), any(), eq(null));
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -1509,4 +1509,22 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(asset.getAspectFooBar(), fooBar);
     assertEquals(asset.getAspectAttributes(), attributes);
   }
+
+  @Test
+  public void testIngestSkipPreIngestionUpdates() {
+    FooUrn urn = makeFooUrn(1);
+    AspectFoo foo = new AspectFoo().setValue("foo");
+    AspectBar bar = new AspectBar().setValue("bar");
+    List<EntityAspectUnion> aspects = Arrays.asList(ModelUtils.newAspectUnion(EntityAspectUnion.class, foo),
+        ModelUtils.newAspectUnion(EntityAspectUnion.class, bar));
+    EntitySnapshot snapshot = ModelUtils.newSnapshot(EntitySnapshot.class, urn, aspects);
+
+    runAndWait(_resource.ingestSkipPreIngestionUpdates(snapshot, new IngestionTrackingContext(), null));
+
+    verify(_mockLocalDAO, times(0)).add(eq(urn), eq(foo), any(), any(), eq(null));
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), eq(null));
+    verify(_mockLocalDAO, times(0)).add(eq(urn), eq(bar), any(), any(), eq(null));
+    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(bar), any(), any(), eq(null));
+    verifyNoMoreInteractions(_mockLocalDAO);
+  }
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -1511,7 +1511,7 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   }
 
   @Test
-  public void testIngestSkipPreIngestionUpdates() {
+  public void testRawIngestSkipPreIngestionUpdates() {
     FooUrn urn = makeFooUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -1522,9 +1522,9 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     runAndWait(_resource.ingestSkipPreIngestionUpdates(snapshot, new IngestionTrackingContext(), null));
 
     verify(_mockLocalDAO, times(0)).add(eq(urn), eq(foo), any(), any(), eq(null));
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(foo), any(), any(), eq(null));
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(foo), any(), any(), eq(null));
     verify(_mockLocalDAO, times(0)).add(eq(urn), eq(bar), any(), any(), eq(null));
-    verify(_mockLocalDAO, times(1)).addSkipPreIngestionUpdates(eq(urn), eq(bar), any(), any(), eq(null));
+    verify(_mockLocalDAO, times(1)).addSkipPreUpdates(eq(urn), eq(bar), any(), any(), eq(null));
     verifyNoMoreInteractions(_mockLocalDAO);
   }
 }


### PR DESCRIPTION


## Summary
Users who have received explicit permission to use this API may do so to follow the ingestion path where all pre-ingestion update lambdas are skipped. This is useful to prevent loops like `ingest() -> lambda -> ingest() -> lambda -> so on`. Instead, the path will be `ingest() -> lambda -> ingestSkipPreIngestionUpdates()`.
## Testing Done
added a unit test
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
