### PR TITLE
feat: disable test mode to dual write in dao.

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -767,14 +767,13 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull AuditStamp auditStamp, int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext) {
     final Class<ASPECT> aspectClass = updateLambda.getAspectClass();
     checkValidAspect(aspectClass);
-    // dual-write to test table while test mode is enabled.
-    if (updateLambda.getIngestionParams().isTestMode()) {
-      runInTransactionWithRetry(() -> aspectUpdateHelper(urn, updateLambda, auditStamp, trackingContext),
-          maxTransactionRetry);
-    }
-    final AddResult<ASPECT> result = runInTransactionWithRetry(() -> aspectUpdateHelper(urn,
-        new AspectUpdateLambda<>(aspectClass, updateLambda.getUpdateLambda(),
-            updateLambda.getIngestionParams().setTestMode(false)), auditStamp, trackingContext), maxTransactionRetry);
+
+    // default test mode is false being set in
+    // {@link #rawAdd(Urn, RecordTemplate, AuditStamp, IngestionTrackingContext, IngestionParams)}}
+    final AddResult<ASPECT> result =
+        runInTransactionWithRetry(() -> aspectUpdateHelper(urn, updateLambda, auditStamp, trackingContext),
+            maxTransactionRetry);
+
     return unwrapAddResult(urn, result, auditStamp, trackingContext);
   }
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -648,12 +648,12 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
   private <ASPECT extends RecordTemplate> ASPECT_UNION unwrapAddResultToUnion(URN urn, AddResult<ASPECT> result,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext) {
-    ASPECT rawResult = unwrapAddResult(urn, result, auditStamp, trackingContext, false);
+    ASPECT rawResult = unwrapAddResult(urn, result, auditStamp, trackingContext);
     return ModelUtils.newEntityUnion(_aspectUnionClass, rawResult);
   }
 
   private <ASPECT extends RecordTemplate> ASPECT unwrapAddResult(URN urn, AddResult<ASPECT> result, @Nonnull AuditStamp auditStamp,
-      @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
+      @Nullable IngestionTrackingContext trackingContext) {
     if (trackingContext != null) {
       trackingContext.setBackfill(false); // reset backfill since MAE won't be a backfill event
     }
@@ -670,30 +670,27 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       _aspectPostUpdateHooksMap.get(aspectClass).forEach(hook -> hook.accept(urn, newValue));
     }
 
-    // Skip producing MAE in test mode
-    if (!isTestMode) {
-      // Produce MAE after a successful update
-      if (_emitAuditEvent) {
-        // https://jira01.corp.linkedin.com:8443/browse/APA-80115
-        if (_alwaysEmitAuditEvent || !oldAndNewEqual) {
-          if (_trackingProducer != null) {
-            _trackingProducer.produceMetadataAuditEvent(urn, oldValue, newValue);
-          } else {
-            _producer.produceMetadataAuditEvent(urn, oldValue, newValue);
-          }
+    // Produce MAE after a successful update
+    if (_emitAuditEvent) {
+      // https://jira01.corp.linkedin.com:8443/browse/APA-80115
+      if (_alwaysEmitAuditEvent || !oldAndNewEqual) {
+        if (_trackingProducer != null) {
+          _trackingProducer.produceMetadataAuditEvent(urn, oldValue, newValue);
+        } else {
+          _producer.produceMetadataAuditEvent(urn, oldValue, newValue);
         }
       }
+    }
 
-      // TODO: Replace the previous step with the step below, after pipeline is fully migrated to aspect specific events.
-      // Produce aspect specific MAE after a successful update
-      if (_emitAspectSpecificAuditEvent) {
-        if (_alwaysEmitAspectSpecificAuditEvent || !oldAndNewEqual) {
-          if (_trackingProducer != null) {
-            _trackingProducer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, auditStamp,
-                trackingContext, IngestionMode.LIVE);
-          } else {
-            _producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, auditStamp, IngestionMode.LIVE);
-          }
+    // TODO: Replace the previous step with the step below, after pipeline is fully migrated to aspect specific events.
+    // Produce aspect specific MAE after a successful update
+    if (_emitAspectSpecificAuditEvent) {
+      if (_alwaysEmitAspectSpecificAuditEvent || !oldAndNewEqual) {
+        if (_trackingProducer != null) {
+          _trackingProducer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, auditStamp,
+              trackingContext, IngestionMode.LIVE);
+        } else {
+          _producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, auditStamp, IngestionMode.LIVE);
         }
       }
     }
@@ -777,7 +774,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         runInTransactionWithRetry(() -> aspectUpdateHelper(urn, updateLambda, auditStamp, trackingContext),
             maxTransactionRetry);
 
-    return unwrapAddResult(urn, result, auditStamp, trackingContext, updateLambda.getIngestionParams().isTestMode());
+    // skip MAE producing and post update hook in test mode
+    return updateLambda.getIngestionParams().isTestMode() ? result.newValue
+        : unwrapAddResult(urn, result, auditStamp, trackingContext);
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
@@ -86,6 +86,9 @@ ALTER TABLE metadata_entity_foo_test ADD a_aspectfoo JSON;
 -- add bar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
 
+-- add bar aspect to foo test entity
+ALTER TABLE metadata_entity_foo_test ADD a_aspectbar JSON;
+
 -- add foobar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -86,6 +86,9 @@ ALTER TABLE metadata_entity_foo_test ADD a_aspectfoo JSON;
 -- add bar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectbar JSON;
 
+-- add bar aspect to foo test entity
+ALTER TABLE metadata_entity_foo_test ADD a_aspectbar JSON;
+
 -- add foobar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
 


### PR DESCRIPTION
## Summary
To disable DAO dual write in test mode by leveraging clients' calls.

## Testing Done
./gradlew build

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
