### PR TITLE
read column from aspect alias part 2

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/AspectField.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/AspectField.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.metadata.query
 record AspectField {
 
   /**
-   * Asset type (entityType) this aspect belongs to. When running a query filtered by an aspect field (aspect alias),
+   * FQCN of the asset this aspect belongs to. When running a query filtered by an aspect field (aspect alias),
    * depends on which asset this aspect belongs to, the field (aspect alias) can be different. For more context, check
    * the decision on aspect alias: go/mg/aspect-alias-decision. The underlying logic requires asset type information
    * to query on the right target. e.g. DB column name, which is from the aspect-alias defined on Asset.

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -8,6 +8,7 @@ import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.validator.NullFieldException;
 import com.linkedin.testing.AspectAttributes;
 import com.linkedin.testing.AspectUnionWithSoftDeletedAspect;
+import com.linkedin.testing.BarAsset;
 import com.linkedin.testing.BarUrnArray;
 import com.linkedin.testing.DatasetInfo;
 import com.linkedin.testing.DeltaUnionAlias;
@@ -793,5 +794,23 @@ public class ModelUtilsTest {
 
     assertEquals(entityType, expectedUrn.getEntityType());
     assertNull(ModelUtils.getEntityType(null));
+  }
+
+  @Test
+  public void testGetUrnTypeFromAssetType() {
+    String assetType = ModelUtils.getUrnTypeFromAsset(BarAsset.class);
+    assertEquals(BarUrn.ENTITY_TYPE, assetType);
+  }
+
+  @Test
+  public void testGetAspectAlias() {
+    assertEquals(ModelUtils.getAspectAlias(BarAsset.class, AspectBar.class.getCanonicalName()), "aspect_bar");
+    assertNull(ModelUtils.getAspectAlias(BarAsset.class, AspectFoo.class.getCanonicalName()), "aspect_foo");
+    try {
+      ModelUtils.getAspectAlias(AspectBar.class, AspectFoo.class.getCanonicalName());
+      fail("should fail on non-Asset template");
+    } catch (Exception e) {
+
+    }
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/GlobalAssetRegistry.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/GlobalAssetRegistry.java
@@ -1,0 +1,62 @@
+package com.linkedin.metadata.dao;
+
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.dao.utils.ModelUtils;
+import com.linkedin.metadata.validator.AssetValidator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.reflections.Reflections;
+
+
+/**
+ * This class tracks the (entityType, Asset) map.
+ */
+@Slf4j
+public class GlobalAssetRegistry {
+  private final Map<String, Class<? extends RecordTemplate>> registry = new ConcurrentHashMap<>();
+
+  private GlobalAssetRegistry() {
+    preLoadInternalAssets();
+  }
+
+  // thread-safe, lazy-load singleton instance.
+  // JVM guarantees static fields is only instantiated once and in a thread-safe manner when class is first being loaded.
+  // Putting it in the inner class makes this inner only being loaded when getInstance() is called.
+  private static class InnerHolder {
+    private static final GlobalAssetRegistry INSTANCE = new GlobalAssetRegistry();
+  }
+
+  private static GlobalAssetRegistry getInstance() {
+    return InnerHolder.INSTANCE;
+  }
+
+  public static void register(@Nonnull String assetType, @Nonnull Class<? extends RecordTemplate> assetClass) {
+    AssetValidator.validateAssetSchema(assetClass);
+    getInstance().registry.put(assetType, assetClass);
+  }
+
+  public static Class<? extends RecordTemplate> get(@Nonnull String assetType) {
+    return getInstance().registry.get(assetType);
+  }
+
+  /**
+   * TODO: moving this loading logic into internal-models.
+   */
+  private void preLoadInternalAssets() {
+    Reflections reflections = new Reflections(INTERNAL_ASSET_PACKAGE); // Change to your package
+    Set<Class<? extends RecordTemplate>> assetClasses = reflections.getSubTypesOf(RecordTemplate.class);
+    for (Class<? extends RecordTemplate> assetClass : assetClasses) {
+      try {
+        register(ModelUtils.getUrnTypeFromAsset(assetClass), assetClass);
+      } catch (Exception e) {
+        log.error("failed to load asset: " + assetClass, e);
+      }
+    }
+  }
+
+  private static final String INTERNAL_ASSET_PACKAGE = "pegasus.com.linkedin.metadata.asset";
+}
+

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/GlobalAssetRegistryTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/GlobalAssetRegistryTest.java
@@ -1,0 +1,24 @@
+package com.linkedin.metadata.dao;
+
+import com.linkedin.testing.AspectBar;
+import com.linkedin.testing.BarAsset;
+import com.linkedin.testing.urn.BarUrn;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class GlobalAssetRegistryTest {
+  @Test
+  public void testGetInstance() {
+    GlobalAssetRegistry.register(BarUrn.ENTITY_TYPE, BarAsset.class);
+    try {
+      GlobalAssetRegistry.register(BarUrn.ENTITY_TYPE, AspectBar.class);
+      fail("should fail because of invalid aspect");
+    } catch (Exception e) {
+    }
+
+    assertEquals(GlobalAssetRegistry.get(BarUrn.ENTITY_TYPE), BarAsset.class);
+    assertNull(GlobalAssetRegistry.get("unknownType"));
+  }
+}

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLSchemaUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLSchemaUtilsTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.metadata.dao.GlobalAssetRegistry;
 import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.BarAsset;
 import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.FooUrn;
 import org.testng.annotations.Test;
@@ -24,7 +26,8 @@ public class SQLSchemaUtilsTest {
 
   @Test
   public void testGetAspectColumnName() {
-    assertEquals("a_aspectbar",
+    GlobalAssetRegistry.register(BarUrn.ENTITY_TYPE, BarAsset.class);
+    assertEquals("a_aspect_bar",
         SQLSchemaUtils.getAspectColumnName(BarUrn.ENTITY_TYPE, "com.linkedin.testing.AspectBar"));
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.dao.utils;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.query.AspectField;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.IndexCriterion;
@@ -14,7 +15,10 @@ import com.linkedin.metadata.query.LocalRelationshipFilter;
 import com.linkedin.metadata.query.LocalRelationshipValue;
 import com.linkedin.metadata.query.RelationshipField;
 import com.linkedin.metadata.query.UrnField;
+import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.BarAsset;
+import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.FooUrn;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -26,6 +30,7 @@ import java.util.Set;
 import org.javatuples.Pair;
 import org.testng.annotations.Test;
 
+import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
 import static com.linkedin.testing.TestUtils.*;
 import static org.testng.Assert.*;
 
@@ -378,5 +383,37 @@ public class SQLStatementUtilsTest {
     assertEquals(
         SQLStatementUtils.createAspectUpdateWithOptimisticLockSql(fooUrn, AspectFoo.class, false, false),
         expectedSql);
+  }
+
+  @Test
+  public void testAspectField() {
+    AspectField aspectField = new AspectField();
+    aspectField.setAspect(AspectBar.class.getCanonicalName());
+    // unknown if asset field is not set
+    assertEquals(SQLStatementUtils.getAssetType(aspectField), UNKNOWN_ASSET);
+
+    try {
+      aspectField.setAsset("invalid_class");
+      SQLStatementUtils.getAssetType(aspectField);
+      fail("should fail because invalid asset class");
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      aspectField.setAsset(String.class.getCanonicalName());
+      SQLStatementUtils.getAssetType(aspectField);
+      fail("should fail because not RecordTemplate");
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      aspectField.setAsset(RecordTemplate.class.getCanonicalName());
+      SQLStatementUtils.getAssetType(aspectField);
+      fail("should fail because not an valid Asset");
+    } catch (IllegalArgumentException e) {
+    }
+
+    aspectField.setAsset(BarAsset.class.getCanonicalName());
+    assertEquals(SQLStatementUtils.getAssetType(aspectField), BarUrn.ENTITY_TYPE);
   }
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/BarAsset.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/BarAsset.pdl
@@ -15,5 +15,5 @@ record BarAsset {
   /**
    * For unit tests
    */
-  aspectbar: optional AspectBar,
+  aspect_bar: optional AspectBar,
 }


### PR DESCRIPTION
## Summary

this is the 2nd part of PR: https://github.com/linkedin/datahub-gma/pull/433.

## Implementation Details

it is using a reflection to load all the asset classes with an lazy loading cache to map the requested `aspect` to the `aspect_alias`, which is the DB column stored on the database.

TODO

1. The reflection of loading all the assets can be moved to Li's internal code, will need horizontal update on the GMSes
2. Need a comprehensive unit test on metadata-models to ensure the calculated aspect_alias names are matching the "column" annotation.

## Testing Done

./gradlew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
