### PR TITLE
fix glboal asset registry instantiation issue

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/GlobalAssetRegistry.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/GlobalAssetRegistry.java
@@ -19,7 +19,6 @@ public class GlobalAssetRegistry {
   private final Map<String, Class<? extends RecordTemplate>> registry = new ConcurrentHashMap<>();
 
   private GlobalAssetRegistry() {
-    preLoadInternalAssets();
   }
 
   // thread-safe, lazy-load singleton instance.
@@ -27,6 +26,14 @@ public class GlobalAssetRegistry {
   // Putting it in the inner class makes this inner only being loaded when getInstance() is called.
   private static class InnerHolder {
     private static final GlobalAssetRegistry INSTANCE = new GlobalAssetRegistry();
+
+    static {
+      try {
+        INSTANCE.preLoadInternalAssets();
+      } catch (Exception e) {
+        log.error("Failed to pre-load internal assets", e);
+      }
+    }
   }
 
   private static GlobalAssetRegistry getInstance() {


### PR DESCRIPTION
## Summary

fix a bug in the `GlobalAssetRegistry` class that caused the `preLoadInternalAssets` method to not be called during the instantiation of the class.

## Testing Done

./gradlew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
