### PR TITLE
Add RampedResourceImpl Lix to set New MG Kernal as default

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -21,7 +21,7 @@ import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.metadata.query.ListResultMetadata;
 import com.linkedin.metadata.query.MapMetadata;
-import com.linkedin.metadata.restli.lix.DummyResourceLix;
+import com.linkedin.metadata.restli.lix.RampedResourceImpl;
 import com.linkedin.metadata.restli.lix.ResourceLix;
 import com.linkedin.parseq.Task;
 import com.linkedin.restli.common.EmptyRecord;
@@ -96,7 +96,7 @@ public abstract class BaseEntityResource<
   private final Class<ASSET> _assetClass;
   protected final Class<URN> _urnClass;
   protected BaseTrackingManager _trackingManager = null;
-  private ResourceLix _defaultResourceLix = new DummyResourceLix();
+  private ResourceLix _defaultResourceLix = new RampedResourceImpl();
 
   /**
    * This method is to be overriden by specific resource endpoint implementation with real lix impl.

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/lix/RampedResourceImpl.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/lix/RampedResourceImpl.java
@@ -3,84 +3,84 @@ package com.linkedin.metadata.restli.lix;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/**
- * Dummy Resource Lix will always choose using the old GMA logic, equivalent to Lix is always 'control'.
- * Usage: assign to 'resourceLix' fields at each GMS entity resource.
- */
-public class DummyResourceLix implements ResourceLix {
 
+/**
+ * Ramped Resource will always choose using the new MG Kernel logic, equivalent to Lix is always 'treatment'.
+ * Usage: assign to 'resourceLix' fields at each GMS entity resource, after all validation is complete.
+ */
+public class RampedResourceImpl implements ResourceLix {
   @Override
   public boolean testGet(@Nonnull String urn, @Nonnull String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBatchGet(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBatchGetWithErrors(@Nullable String urn, @Nullable String type) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testGetSnapshot(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillLegacy(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillWithUrns(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testEmitNoChangeMetadataAuditEvent(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillWithNewValue(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillEntityTables(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillRelationshipTables(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfill(@Nonnull String assetType, @Nonnull String mode) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testFilter(@Nonnull String assetType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testGetAll(@Nullable String urnType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testSearch(@Nullable String urnType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testSearchV2(@Nullable String urnType) {
-    return false;
+    return true;
   }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.6.*
+version=1.0.*


### PR DESCRIPTION
## Summary

title

NOTE that I'm bumping the version to `1.0.*`, feel like since this changes the default state to `RAMPED` this is called for?

## Testing Done

./gradlew. build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
