### PR TITLE
feat: enable HikariCP for server config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ project.ext.externalDependency = [
     'elasticSearchTransport7': 'org.elasticsearch.client:transport:7.17.24',
     'flywayCore': 'org.flywaydb:flyway-core:7.15.0',
     'guava': 'com.google.guava:guava:32.0.0-jre',
+    "hikariCP": "com.zaxxer:HikariCP:3.2.0",
     'h2': 'com.h2database:h2:1.4.196',
     'jacksonCore': 'com.fasterxml.jackson.core:jackson-core:2.17.2',
     'jacksonDataBind': 'com.fasterxml.jackson.core:jackson-databind:2.17.2',

--- a/dao-impl/ebean-dao/build.gradle
+++ b/dao-impl/ebean-dao/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   compile externalDependency.ebean
   compile externalDependency.flywayCore
   compile externalDependency.guava
+  implementation externalDependency.hikariCP
   compile externalDependency.jsonSimple
   compile externalDependency.log4j
 


### PR DESCRIPTION
## Summary
There was a mysql connection issue in TMS and AIM-service-gms, and the current ebean connection pool makes it impossible to investigate. The mysql team suggested we migrate to HikariCP for better support from them.

Migration guide: https://shiny-chainsaw-yr6m6q9.pages.github.io/pages/migrating/JMP7.html
TLDR; the ServerConfig was originally setting DataSourceConfig (Ebean), and after migration to HikariCP, we should put the config in a HikariDataSource and use setDataSource instead of setDataSourceConfig.

## Detail
To keep supporting Ebean pool, we will add a dual mode, so GMS that doesn't want to switch to Hikari can still make datahub-gma version upgrade. The only usage of the ServerConfig is changed to check if the config is a Hikari config first.

Note that Hikari config can't have a custom property like the old DataSourceConfig, so for GMS that needs to set values in custom property, e.g. SERVICE_IDENTIFIER, they have to stay with DataSourceConfig.

## Testing Done
./gradlew build

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
