### PR TITLE
Consolidate resource-lix into datahub-gma

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -21,7 +21,7 @@ import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.metadata.query.ListResultMetadata;
 import com.linkedin.metadata.query.MapMetadata;
-import com.linkedin.metadata.restli.lix.DummyResourceLix;
+import com.linkedin.metadata.restli.lix.RampedResourceImpl;
 import com.linkedin.metadata.restli.lix.ResourceLix;
 import com.linkedin.parseq.Task;
 import com.linkedin.restli.common.EmptyRecord;
@@ -96,7 +96,7 @@ public abstract class BaseEntityResource<
   private final Class<ASSET> _assetClass;
   protected final Class<URN> _urnClass;
   protected BaseTrackingManager _trackingManager = null;
-  private ResourceLix _defaultResourceLix = new DummyResourceLix();
+  private ResourceLix _defaultResourceLix = new RampedResourceImpl();
 
   /**
    * This method is to be overriden by specific resource endpoint implementation with real lix impl.

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/lix/LegacyResourceImpl.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/lix/LegacyResourceImpl.java
@@ -1,0 +1,87 @@
+package com.linkedin.metadata.restli.lix;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+/**
+ * Legacy Resource will always choose using the old MG Kernel logic, equivalent to Lix is always 'control'. Legacy
+ * Resource is only used for the GMSes are on the maintenance mode (using legacy models Snapshot, Aspect Union)
+ * and are not planning to evolve (e.g. the legacy. AIM ). Usage: assign to 'resourceLix' fields at each GMS entity resource.
+ */
+public class LegacyResourceImpl implements ResourceLix {
+  @Override
+  public boolean testGet(@Nonnull String urn, @Nonnull String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBatchGet(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBatchGetWithErrors(@Nullable String urn, @Nullable String type) {
+    return false;
+  }
+
+  @Override
+  public boolean testGetSnapshot(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBackfillLegacy(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBackfillWithUrns(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testEmitNoChangeMetadataAuditEvent(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBackfillWithNewValue(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBackfillEntityTables(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBackfillRelationshipTables(@Nullable String urn, @Nullable String entityType) {
+    return false;
+  }
+
+  @Override
+  public boolean testBackfill(@Nonnull String assetType, @Nonnull String mode) {
+    return false;
+  }
+
+  @Override
+  public boolean testFilter(@Nonnull String assetType) {
+    return false;
+  }
+
+  @Override
+  public boolean testGetAll(@Nullable String urnType) {
+    return false;
+  }
+
+  @Override
+  public boolean testSearch(@Nullable String urnType) {
+    return false;
+  }
+
+  @Override
+  public boolean testSearchV2(@Nullable String urnType) {
+    return false;
+  }
+}

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/lix/RampedResourceImpl.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/lix/RampedResourceImpl.java
@@ -4,80 +4,83 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 
-public class DummyResourceLix implements ResourceLix {
-
+/**
+ * Ramped Resource will always choose using the new MG Kernel logic, equivalent to Lix is always 'treatment'.
+ * Usage: assign to 'resourceLix' fields at each GMS entity resource.
+ */
+public class RampedResourceImpl implements ResourceLix {
   @Override
   public boolean testGet(@Nonnull String urn, @Nonnull String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBatchGet(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBatchGetWithErrors(@Nullable String urn, @Nullable String type) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testGetSnapshot(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillLegacy(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillWithUrns(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testEmitNoChangeMetadataAuditEvent(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillWithNewValue(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillEntityTables(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfillRelationshipTables(@Nullable String urn, @Nullable String entityType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testBackfill(@Nonnull String assetType, @Nonnull String mode) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testFilter(@Nonnull String assetType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testGetAll(@Nullable String urnType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testSearch(@Nullable String urnType) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean testSearchV2(@Nullable String urnType) {
-    return false;
+    return true;
   }
 }

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -24,6 +24,7 @@ import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.metadata.query.MapMetadata;
 import com.linkedin.metadata.query.SortOrder;
+import com.linkedin.metadata.restli.lix.LegacyResourceImpl;
 import com.linkedin.metadata.restli.lix.ResourceLix;
 import com.linkedin.parseq.BaseEngineTest;
 import com.linkedin.restli.common.ComplexResourceKey;
@@ -62,7 +63,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -81,6 +81,11 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   class TestResource extends
                      BaseEntityResource<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue, FooUrn, EntitySnapshot,
                          EntityAspectUnion, InternalEntitySnapshot, InternalEntityAspectUnion, EntityAsset> {
+
+    @Override
+    protected ResourceLix getResourceLix() {
+      return new LegacyResourceImpl();
+    }
 
     public TestResource() {
       super(EntitySnapshot.class, EntityAspectUnion.class, FooUrn.class, InternalEntitySnapshot.class,
@@ -159,86 +164,6 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   class TestInternalResource extends
                      BaseEntityResource<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue, FooUrn, EntitySnapshot,
                          EntityAspectUnion, InternalEntitySnapshot, InternalEntityAspectUnion, EntityAsset> {
-
-    @Override
-    protected ResourceLix getResourceLix() {
-      return new ResourceLix() {
-        @Override
-        public boolean testGet(@Nonnull String urn, @Nonnull String entityType) {
-          return true;
-        }
-
-        @Override
-        public boolean testBatchGet(@Nullable String urn, @Nullable String entityType) {
-          return true;
-        }
-
-        @Override
-        public boolean testBatchGetWithErrors(@Nullable String urn, @Nullable String type) {
-          return false;
-        }
-
-        @Override
-        public boolean testGetSnapshot(@Nullable String urn, @Nullable String entityType) {
-          return true;
-        }
-
-        @Override
-        public boolean testBackfillLegacy(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillWithUrns(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testEmitNoChangeMetadataAuditEvent(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillWithNewValue(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillEntityTables(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillRelationshipTables(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfill(@Nonnull String assetType, @Nonnull String mode) {
-          return false;
-        }
-
-        @Override
-        public boolean testFilter(@Nonnull String assetType) {
-          return true;
-        }
-
-        @Override
-        public boolean testGetAll(@Nullable String urnType) {
-          return false;
-        }
-
-        @Override
-        public boolean testSearch(@Nullable String urnType) {
-          return false;
-        }
-
-        @Override
-        public boolean testSearchV2(@Nullable String urnType) {
-          return false;
-        }
-      };
-    }
 
     public TestInternalResource() {
       super(EntitySnapshot.class, EntityAspectUnion.class, FooUrn.class, InternalEntitySnapshot.class,
@@ -518,7 +443,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         .thenReturn(Collections.emptyMap());
 
     BatchResult<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue> result =
-        runAndWait(_resource.batchGetWithErrors(ImmutableSet.of(makeResourceKey(urn1), makeResourceKey(urn2)), aspectNames));
+        runAndWait(
+            _resource.batchGetWithErrors(ImmutableSet.of(makeResourceKey(urn1), makeResourceKey(urn2)), aspectNames));
 
     // convert BatchResult<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue> to BatchResult<EntityKey, EntityValue>
     BatchResult<EntityKey, EntityValue> batchResultMap = convertBatchResult(result);
@@ -596,7 +522,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         .thenReturn(ImmutableMap.of(aspectFooKey1, Optional.of(foo), aspectBarKey2, Optional.of(bar)));
 
     BatchResult<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue> result =
-        runAndWait(_resource.batchGetWithErrors(ImmutableSet.of(makeResourceKey(urn1), makeResourceKey(urn2)), aspectNames));
+        runAndWait(
+            _resource.batchGetWithErrors(ImmutableSet.of(makeResourceKey(urn1), makeResourceKey(urn2)), aspectNames));
 
     // convert BatchResult<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue> to BatchResult<EntityKey, EntityValue>
     BatchResult<EntityKey, EntityValue> batchResultMap = convertBatchResult(result);
@@ -635,7 +562,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         .thenReturn(ImmutableMap.of(aspectFooKey1, Optional.of(foo), aspectBarKey2, Optional.empty()));
 
     BatchResult<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue> result =
-        runAndWait(_resource.batchGetWithErrors(ImmutableSet.of(makeResourceKey(urn1), makeResourceKey(urn2)), aspectNames));
+        runAndWait(
+            _resource.batchGetWithErrors(ImmutableSet.of(makeResourceKey(urn1), makeResourceKey(urn2)), aspectNames));
 
     // convert BatchResult<ComplexResourceKey<EntityKey, EmptyRecord>, EntityValue> to BatchResult<EntityKey, EntityValue>
     BatchResult<EntityKey, EntityValue> batchResultMap = convertBatchResult(result);
@@ -962,7 +890,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectBar bar1 = new AspectBar().setValue("bar1");
     AspectBar bar2 = new AspectBar().setValue("bar2");
     String[] aspects = new String[]{"com.linkedin.testing.AspectFoo", "com.linkedin.testing.AspectBar"};
-    when(_mockLocalDAO.backfillWithNewValue(_resource.parseAspectsParam(aspects, false), ImmutableSet.of(urn1, urn2)))
+    when(_mockLocalDAO.backfillWithNewValue(
+        _resource.parseAspectsParam(aspects, false), ImmutableSet.of(urn1, urn2)))
         .thenReturn(
             ImmutableMap.of(urn1, ImmutableMap.of(AspectFoo.class, Optional.of(foo1), AspectBar.class, Optional.of(bar1)),
             urn2, ImmutableMap.of(AspectBar.class, Optional.of(bar2)))
@@ -1001,7 +930,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         );
 
     BackfillResult backfillResult =
-        runAndWait(_resource.emitNoChangeMetadataAuditEvent(new String[]{urn1.toString(), urn2.toString()}, aspects,
+        runAndWait(
+            _resource.emitNoChangeMetadataAuditEvent(new String[]{urn1.toString(), urn2.toString()}, aspects,
             IngestionMode.BACKFILL));
     assertEquals(backfillResult.getEntities().size(), 2);
 
@@ -1034,7 +964,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         );
 
     BackfillResult backfillResult =
-        runAndWait(_resource.emitNoChangeMetadataAuditEvent(new String[]{urn1.toString(), urn2.toString()}, aspects,
+        runAndWait(
+            _resource.emitNoChangeMetadataAuditEvent(new String[]{urn1.toString(), urn2.toString()}, aspects,
             IngestionMode.BOOTSTRAP));
     assertEquals(backfillResult.getEntities().size(), 2);
 
@@ -1062,7 +993,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     String[] aspects = new String[]{"com.linkedin.testing.AspectFoo", "com.linkedin.testing.AspectBar"};
 
     BackfillResult backfillResult =
-        runAndWait(_resource.emitNoChangeMetadataAuditEvent(new String[]{urn1.toString(), urn2.toString()}, aspects,
+        runAndWait(
+            _resource.emitNoChangeMetadataAuditEvent(new String[]{urn1.toString(), urn2.toString()}, aspects,
             IngestionMode.LIVE));
     verify(_mockLocalDAO, times(0)).backfill(any(BackfillMode.class), any(Set.class), any(Set.class));
     assertFalse(backfillResult.hasEntities());
@@ -1082,7 +1014,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     List<LocalRelationshipUpdates> relationships = Collections.singletonList(updates);
 
     when(_mockLocalDAO.backfillLocalRelationships(fooUrn, AspectFoo.class)).thenReturn(relationships);
-    BackfillResult backfillResult = runAndWait(_resource.backfillRelationshipTables(new String[]{fooUrn.toString()}, aspects));
+    BackfillResult backfillResult = runAndWait(
+        _resource.backfillRelationshipTables(new String[]{fooUrn.toString()}, aspects));
 
     assertTrue(backfillResult.hasRelationships());
     assertEquals(backfillResult.getRelationships().size(), 1);
@@ -1171,7 +1104,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         .build();
     when(_mockLocalDAO.listUrns(null, indexSortCriterion, 0, 2)).thenReturn(urnsListResult);
     ListResult<EntityValue>
-        listResultActual = runAndWait(_resource.filter(null, indexSortCriterion, new String[0], new PagingContext(0, 2)));
+        listResultActual = runAndWait(
+        _resource.filter(null, indexSortCriterion, new String[0], new PagingContext(0, 2)));
     List<EntityValue> actualValues = listResultActual.getValues();
     assertEquals(actualValues.size(), 2);
     assertEquals(actualValues.get(0), new EntityValue());

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
@@ -9,6 +9,7 @@ import com.linkedin.metadata.dao.AspectKey;
 import com.linkedin.metadata.dao.BaseLocalDAO;
 import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.dao.utils.RecordUtils;
+import com.linkedin.metadata.restli.lix.LegacyResourceImpl;
 import com.linkedin.metadata.restli.lix.ResourceLix;
 import com.linkedin.parseq.BaseEngineTest;
 import com.linkedin.restli.common.HttpStatus;
@@ -38,7 +39,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -408,6 +408,10 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
           InternalEntityAspectUnion.class, EntityAsset.class);
     }
 
+    @Override
+    protected ResourceLix getResourceLix() {
+      return new LegacyResourceImpl();
+    }
 
 
     @Override
@@ -480,86 +484,6 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
   private class TestInternalResource extends
                              BaseEntityResource<Long, EntityValue, Urn, EntitySnapshot, EntityAspectUnion,
                                  InternalEntitySnapshot, InternalEntityAspectUnion, EntityAsset> {
-
-    @Override
-    protected ResourceLix getResourceLix() {
-      return new ResourceLix() {
-        @Override
-        public boolean testGet(@Nonnull String urn, @Nonnull String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBatchGet(@Nullable String urn, @Nullable String entityType) {
-          return true;
-        }
-
-        @Override
-        public boolean testBatchGetWithErrors(@Nullable String urn, @Nullable String type) {
-          return false;
-        }
-
-        @Override
-        public boolean testGetSnapshot(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillLegacy(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillWithUrns(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testEmitNoChangeMetadataAuditEvent(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillWithNewValue(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillEntityTables(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfillRelationshipTables(@Nullable String urn, @Nullable String entityType) {
-          return false;
-        }
-
-        @Override
-        public boolean testBackfill(@Nonnull String assetType, @Nonnull String mode) {
-          return false;
-        }
-
-        @Override
-        public boolean testFilter(@Nonnull String assetType) {
-          return false;
-        }
-
-        @Override
-        public boolean testGetAll(@Nullable String urnType) {
-          return false;
-        }
-
-        @Override
-        public boolean testSearch(@Nullable String urnType) {
-          return false;
-        }
-
-        @Override
-        public boolean testSearchV2(@Nullable String urnType) {
-          return false;
-        }
-      };
-    }
 
     TestInternalResource() {
       super(EntitySnapshot.class, EntityAspectUnion.class, InternalEntitySnapshot.class,

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/lix/DummyResourceLixTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/lix/DummyResourceLixTest.java
@@ -1,0 +1,31 @@
+package com.linkedin.metadata.restli.lix;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import javax.annotation.Nonnull;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class DummyResourceLixTest {
+  @Test
+  public void testDefaultResource() throws Exception {
+    testResourceSwitch(new LegacyResourceImpl(), false);
+    testResourceSwitch(new RampedResourceImpl(), true);
+  }
+
+  private void testResourceSwitch(@Nonnull ResourceLix instance, boolean expected) throws Exception {
+    Class<?> resourceLixClass = instance.getClass();
+    for (Method method : resourceLixClass.getMethods()) {
+      if (method.getName().startsWith("test") && !Modifier.isPrivate(method.getModifiers())) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        Object[] params = new Object[parameterTypes.length];
+        for (int i = 0; i < params.length; i++) {
+          params[i] = null;
+        }
+        assertEquals(method.invoke(instance, params), expected);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

1. Change default READ API behavior to Model 2.0
2. Consolidate resource-lix implementation into datahub-gma
3. add & fix unit tests


## Testing Done

./gradlew build

## Cleanup Steps

1. [P0] bump datahub-gms in metadata-models
2. [P0] bump corp-identity GMS or metric GMS with the following cleanup to make sure no regression
4. [P0] make sure AIM has getResource() to return LegacyResourceImpl(), so that AIM will be safe to bump metadata-models which has default READ API behavior changed to ramped. 
5. [P0] bump metadata-models on GMSes which needs to onboard new entities (e.g. service-gms, datahub-gms). So that new entities can get onboarded without using RampedResourceImpl()
6. [P1] bump metadata-models from all GMS with the cleanup
            - remove the ResourceLixFactory from each GMS
            - remove the _resourceLix, getResourceLix() on each resource endpoint.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
