### PR TITLE
feat(model 2.0): implement extractRelationshipsFromAspect util method

### DIFF
--- a/dao-impl/ebean-dao/build.gradle
+++ b/dao-impl/ebean-dao/build.gradle
@@ -9,6 +9,7 @@ configurations {
 dependencies {
   compile project(':core-models-utils')
   compile project(':dao-api')
+  compile project(':gradle-plugins:metadata-annotations-lib')
   compile externalDependency.ebean
   compile externalDependency.flywayCore
   compile externalDependency.guava
@@ -20,6 +21,7 @@ dependencies {
 
   annotationProcessor externalDependency.lombok
 
+  testCompile project(':gradle-plugins:metadata-annotations-test-models')
   testCompile project(':testing:core-models-testing')
   testCompile project(':testing:test-models')
   testCompile externalDependency.mysql

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -375,9 +375,9 @@ public class EBeanDAOUtils {
   }
 
   /**
-   * Extract the non-null values from all relationship fields of an aspect.
+   * Extract the non-null values from all top-level relationship fields of an aspect.
    * @param aspect aspect (possibly with relationships) to be ingested
-   * @return a list of relationship arrays, with each array representing the relationship(s) present in each relationship
+   * @return a list of relationship arrays, with each array representing the relationship(s) present in each top-level relationship
    * field in the aspect. An empty list means that there is no non-null relationship metadata attached to the given aspect.
    */
   @Nonnull

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -378,7 +378,7 @@ public class EBeanDAOUtils {
    * Extract the non-null values from all top-level relationship fields of an aspect.
    * @param aspect aspect (possibly with relationships) to be ingested
    * @return a list of relationship arrays, with each array representing the relationship(s) present in each top-level relationship
-   * field in the aspect. An empty list means that there is no non-null relationship metadata attached to the given aspect.
+   *     field in the aspect. An empty list means that there is no non-null relationship metadata attached to the given aspect.
    */
   @Nonnull
   public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate> List<List<RELATIONSHIP>> extractRelationshipsFromAspect(ASPECT aspect) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -386,14 +386,17 @@ public class EBeanDAOUtils {
       String fieldName = field.getName();
       Class<RecordTemplate> clazz = (Class<RecordTemplate>) aspect.getClass();
       try {
-        Method getMethod = clazz.getMethod("get" + StringUtils.capitalize(fieldName));
-        Object obj = getMethod.invoke(aspect);
+        Method getMethod = clazz.getMethod("get" + StringUtils.capitalize(fieldName)); // getFieldName
+        Object obj = getMethod.invoke(aspect); // invoke getFieldName
+        // all relationship fields will be represented as Arrays so filter out any non-lists, empty lists, and lists that don't contain RecordTemplates
         if (!(obj instanceof List) || ((List) obj).isEmpty() || !(((List) obj).get(0) instanceof RecordTemplate)) {
           return null;
         }
         List<RecordTemplate> relationshipsList = (List<RecordTemplate>) obj;
         ModelType modelType = parseModelTypeFromGmaAnnotation(relationshipsList.get(0));
         if (modelType == ModelType.RELATIONSHIP) {
+          log.debug(String.format("Found {%d} relationships of type {%s} for field {%s} of aspect class {%s}.",
+              relationshipsList.size(), relationshipsList.get(0).getClass(), fieldName, clazz.getName()));
           return (List<RELATIONSHIP>) relationshipsList;
         }
       } catch (ReflectiveOperationException e) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.dao.utils;
 
 import com.google.common.io.Resources;
+import com.linkedin.data.template.IntegerArray;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.aspect.AuditedAspect;
@@ -21,6 +22,8 @@ import com.linkedin.testing.AnnotatedRelationshipFoo;
 import com.linkedin.testing.AnnotatedRelationshipFooArray;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.AnnotatedAspectFooWithRelationshipField;
+import com.linkedin.testing.CommonAspect;
+import com.linkedin.testing.CommonAspectArray;
 import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
@@ -40,7 +43,6 @@ import javax.annotation.Nonnull;
 import org.testng.annotations.Test;
 
 import static com.linkedin.testing.TestUtils.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -600,13 +602,16 @@ public class EBeanDAOUtilsTest {
     AnnotatedAspectFooWithRelationshipField fooWithNullRelationshipField = new AnnotatedAspectFooWithRelationshipField();
     assertTrue(EBeanDAOUtils.extractRelationshipsFromAspect(fooWithNullRelationshipField).isEmpty());
 
-    // case 4: aspect model contains multiple relationship fields, some null and some non-null
+    // case 4: aspect model contains multiple relationship fields, some null and some non-null, as well as array fields
+    //         containing non-Relationship objects
     // expected: return only the non-null relationships
     relationshipFoos = new AnnotatedRelationshipFooArray(new AnnotatedRelationshipFoo(), new AnnotatedRelationshipFoo());
     AnnotatedRelationshipBarArray relationshipBars = new AnnotatedRelationshipBarArray(new AnnotatedRelationshipBar());
     // given:
     // aspect = {
     //     value -> "abc"
+    //     integers -> [1]
+    //     nonRelationshipStructs -> [commonAspect1]
     //     relationshipFoos -> [foo1, foo2]
     //     relationshipBars -> [bar1]
     //     moreRelationshipFoos -> not present
@@ -615,6 +620,8 @@ public class EBeanDAOUtilsTest {
     // [[foo1, foo2], [bar1]]
     AnnotatedAspectBarWithRelationshipFields barWithRelationshipFields = new AnnotatedAspectBarWithRelationshipFields()
         .setValue("abc")
+        .setIntegers(new IntegerArray(1))
+        .setNonRelationshipStructs(new CommonAspectArray(new CommonAspect()))
         .setRelationshipFoos(relationshipFoos)
         .setRelationshipBars(relationshipBars); // don't set moreRelationshipFoos field
 
@@ -626,4 +633,6 @@ public class EBeanDAOUtilsTest {
     assertEquals(new AnnotatedRelationshipFoo(), results.get(0).get(1));
     assertEquals(new AnnotatedRelationshipBar(), results.get(1).get(0));
   }
+
+
 }

--- a/gradle-plugins/metadata-annotations-schema/src/main/pegasus/com/linkedin/metadata/annotations/GmaAnnotation.pdl
+++ b/gradle-plugins/metadata-annotations-schema/src/main/pegasus/com/linkedin/metadata/annotations/GmaAnnotation.pdl
@@ -15,6 +15,15 @@ record GmaAnnotation {
   delta: optional DeltaAnnotation
 
   /**
+   * The type of model
+   */
+  model: optional enum ModelType {
+    ASSET,
+    ASPECT,
+    RELATIONSHIP
+  }
+
+  /**
    * Information about GMA Search functionality.
    */
   search: optional SearchAnnotation

--- a/gradle-plugins/metadata-annotations-test-models/src/main/java/com/linkedin/testing/urn/BarUrn.java
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/java/com/linkedin/testing/urn/BarUrn.java
@@ -6,7 +6,7 @@ import java.net.URISyntaxException;
 
 public final class BarUrn extends Urn {
 
-  public static final String ENTITY_TYPE = "entityBar";
+  public static final String ENTITY_TYPE = "bar";
 
   public BarUrn(int id) throws URISyntaxException {
     super(ENTITY_TYPE, Integer.toString(id));

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
@@ -1,0 +1,28 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+@gma.aspect.column.name = "annotatedaspectbarwithrelationshipfields"
+@gma.model = "ASPECT"
+record AnnotatedAspectBarWithRelationshipFields {
+  /**
+   * For unit tests
+   */
+  value: string
+
+  /**
+   * For unit tests
+   */
+  relationshipFoos: optional array[AnnotatedRelationshipFoo]
+
+  /**
+   * For unit tests
+   */
+  relationshipBars: optional array[AnnotatedRelationshipBar]
+
+  /**
+   * For unit tests
+   */
+  moreRelationshipFoos: optional array[AnnotatedRelationshipFoo]
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
@@ -14,6 +14,16 @@ record AnnotatedAspectBarWithRelationshipFields {
   /**
    * For unit tests
    */
+  integers: optional array[int]
+
+  /**
+   * For unit tests
+   */
+  nonRelationshipStructs: optional array[CommonAspect]
+
+  /**
+   * For unit tests
+   */
   relationshipFoos: optional array[AnnotatedRelationshipFoo]
 
   /**

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectFooWithRelationshipField.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectFooWithRelationshipField.pdl
@@ -1,0 +1,18 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+@gma.aspect.column.name = "annotatedaspectfoowithrelationshipfield"
+@gma.model = "ASPECT"
+record AnnotatedAspectFooWithRelationshipField {
+  /**
+   * For unit tests
+   */
+  value: string
+
+  /**
+   * For unit tests
+   */
+  relationshipFoo: optional array[AnnotatedRelationshipFoo]
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedRelationshipBar.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedRelationshipBar.pdl
@@ -1,0 +1,24 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+@pairings = [ {
+  "destination" : "com.linkedin.common.urn.Urn",
+  "source" : "com.linkedin.common.urn.Urn"
+} ]
+@gma.model = "RELATIONSHIP"
+record AnnotatedRelationshipBar {
+
+  /**
+   * For unit tests
+   */
+  source: Urn
+
+  /**
+   * For unit tests
+   */
+  destination: Urn
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedRelationshipFoo.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedRelationshipFoo.pdl
@@ -1,0 +1,24 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+@pairings = [ {
+  "destination" : "com.linkedin.common.urn.Urn",
+  "source" : "com.linkedin.common.urn.Urn"
+} ]
+@gma.model = "RELATIONSHIP"
+record AnnotatedRelationshipFoo {
+
+  /**
+   * For unit tests
+   */
+  source: Urn
+
+  /**
+   * For unit tests
+   */
+  destination: Urn
+}

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/BarUrn.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/BarUrn.pdl
@@ -9,7 +9,7 @@ namespace com.linkedin.testing
 }
 @validate.`com.linkedin.common.validator.TypedUrnValidator` = {
   "owningTeam" : "urn:li:internalTeam:metadata",
-  "entityType" : "entityBar",
+  "entityType" : "bar",
   "namespace" : "li",
   "name" : "Bar",
   "doc" : "Bar identifier.",

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/BarUrn.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/BarUrn.pdl
@@ -9,7 +9,7 @@ namespace com.linkedin.testing
 }
 @validate.`com.linkedin.common.validator.TypedUrnValidator` = {
   "owningTeam" : "urn:li:internalTeam:metadata",
-  "entityType" : "entityBar",
+  "entityType" : "bar",
   "namespace" : "li",
   "name" : "Bar",
   "doc" : "Bar identifier.",

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/FooUrn.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/FooUrn.pdl
@@ -9,7 +9,7 @@ namespace com.linkedin.testing
 }
 @validate.`com.linkedin.common.validator.TypedUrnValidator` = {
   "owningTeam" : "urn:li:internalTeam:metadata",
-  "entityType" : "entityFoo",
+  "entityType" : "foo",
   "namespace" : "li",
   "name" : "Foo",
   "doc" : "Foo identifier.",


### PR DESCRIPTION
## Summary
Implement a util method to extract any relationship fields out of aspects. In a later PR, this util method will be used during relationship ingestion to retrieve relationships to ingest in place of relationship builders.

The logic relies on the assumption that all PDL relationship models are properly annotated with the `@gma.model = RELATIONSHIP` annotation.

## Testing Done
added a unit test.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
