### PR TITLE
feat: Support deletion in EbeanGenericLocalDAO and BaseEntityAgnosticAspectResource

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/GenericLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/GenericLocalDAO.java
@@ -54,4 +54,13 @@ public interface GenericLocalDAO {
    */
   Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(@Nonnull BackfillMode mode,
       @Nonnull Map<Urn, Set<Class<? extends RecordTemplate>>> urnToAspect);
+
+  /**
+   * Delete the metadata from database.
+   *
+   * @param urn The identifier of the entity which the metadata is associated with.
+   * @param aspectClass The aspect class for the metadata.
+   * @param auditStamp audit stamp containing information on who and when the metadata is deleted.
+   */
+  void delete(@Nonnull Urn urn, @Nonnull Class aspectClass, @Nonnull AuditStamp auditStamp);
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanGenericLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanGenericLocalDAO.java
@@ -103,10 +103,9 @@ public class EbeanGenericLocalDAO implements GenericLocalDAO {
 
       if (!latest.isPresent()) {
         saveLatest(urn, aspectClass, newValue, null, auditStamp, null);
-        if (shouldSkipMAEUpdate(newValue)) {
-          return null;
+        if (!shouldSkipMAEUpdate(newValue)) {
+          _producer.produceAspectSpecificMetadataAuditEvent(urn, null, newValue, auditStamp, trackingContext, ingestionMode);
         }
-        _producer.produceAspectSpecificMetadataAuditEvent(urn, null, newValue, auditStamp, trackingContext, ingestionMode);
       } else {
         RecordTemplate currentValue = toRecordTemplate(aspectClass, latest.get().getAspect());
         final AuditStamp oldAuditStamp = latest.get().getExtraInfo() == null ? null : latest.get().getExtraInfo().getAudit();
@@ -126,10 +125,9 @@ public class EbeanGenericLocalDAO implements GenericLocalDAO {
         }
         saveLatest(urn, aspectClass, newValue, currentValue, auditStamp, latest.get().getExtraInfo().getAudit());
 
-        if (shouldSkipMAEUpdate(newValue)) {
-          return null;
+        if (!shouldSkipMAEUpdate(newValue)) {
+          _producer.produceAspectSpecificMetadataAuditEvent(urn, currentValue, newValue, auditStamp, trackingContext, ingestionMode);
         }
-        _producer.produceAspectSpecificMetadataAuditEvent(urn, currentValue, newValue, auditStamp, trackingContext, ingestionMode);
       }
       return null;
     }, 5);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanGenericLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanGenericLocalDAOTest.java
@@ -248,11 +248,16 @@ public class EbeanGenericLocalDAOTest {
     _genericLocalDAO.save(fooUrn, AspectFoo.class, RecordUtils.toJsonString(aspectFoo),
         makeAuditStamp("tester"), null, null);
 
+    verify(_producer, times(1)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
+        eq(null), eq(aspectFoo), eq(makeAuditStamp("tester")), eq(null), eq(null));
+
     Optional<GenericLocalDAO.MetadataWithExtraInfo> metadata = _genericLocalDAO.queryLatest(fooUrn, AspectFoo.class);
 
     // {"value":"foo"} is inserted later so it is the latest metadata.
     assertTrue(metadata.isPresent());
     assertEquals(metadata.get().getAspect(), RecordUtils.toJsonString(aspectFoo));
+
+    reset(_producer);
 
     // Delete the record and verify it is deleted.
     _genericLocalDAO.delete(fooUrn, AspectFoo.class, makeAuditStamp("tester"));
@@ -262,7 +267,7 @@ public class EbeanGenericLocalDAOTest {
 
     // does not produce MAE for deletion
     verify(_producer, times(0)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
-        any(), any(), any(), eq(null), eq(null));
+        any(), any(), any(), any(), any());
     verifyNoMoreInteractions(_producer);
   }
 
@@ -283,7 +288,7 @@ public class EbeanGenericLocalDAOTest {
 
     // does not produce MAE for deletion
     verify(_producer, times(0)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
-        any(), any(), any(), eq(null), eq(null));
+        any(), any(), any(), any(), any());
     verifyNoMoreInteractions(_producer);
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanGenericLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanGenericLocalDAOTest.java
@@ -239,4 +239,45 @@ public class EbeanGenericLocalDAOTest {
     assertEquals(backfillResults.size(), 1);
     assertEquals(backfillResults.get(fooUrn).get(AspectFoo.class).get(), aspectFoo);
   }
+
+  @Test
+  public void testDelete() throws URISyntaxException {
+    FooUrn fooUrn1 = FooUrn.createFromString("urn:li:foo:1");
+    AspectFoo aspectFoo = new AspectFoo().setValue("foo");
+
+    _genericLocalDAO.save(fooUrn1, AspectFoo.class, RecordUtils.toJsonString(aspectFoo),
+        makeAuditStamp("tester"), null, null);
+
+    SqlQuery sqlQuery = _server.createSqlQuery("select * from metadata_aspect");
+    List<SqlRow> result = sqlQuery.findList();
+
+    // One record is returned.
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getString("urn"), "urn:li:foo:1");
+    assertEquals(result.get(0).getString("metadata"), RecordUtils.toJsonString(aspectFoo)); // {"value":"foo"}
+    assertEquals(result.get(0).getString("aspect"), AspectFoo.class.getCanonicalName());
+
+    // Delete the record and verify it is deleted.
+    _genericLocalDAO.delete(fooUrn1, AspectFoo.class, makeAuditStamp("tester"));
+
+    result = sqlQuery.findList();
+    assertEquals(result.size(), 0);
+  }
+
+  @Test
+  public void testDeleteVoid() throws URISyntaxException {
+    FooUrn fooUrn1 = FooUrn.createFromString("urn:li:foo:1");
+
+    SqlQuery sqlQuery = _server.createSqlQuery("select * from metadata_aspect");
+    List<SqlRow> result = sqlQuery.findList();
+
+    // no record is returned.
+    assertEquals(result.size(), 0);
+
+    // Delete the record and verify no record is returned.
+    _genericLocalDAO.delete(fooUrn1, AspectFoo.class, makeAuditStamp("tester"));
+
+    result = sqlQuery.findList();
+    assertEquals(result.size(), 0);
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -101,10 +101,6 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
-          configurationBuilder.setBaseDir("/opt/homebrew");
-          configurationBuilder.setUnpackingFromClasspath(false);
-          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
-
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EmbeddedMariaInstance.java
@@ -101,6 +101,10 @@ public class EmbeddedMariaInstance {
            * configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
            */
 
+          configurationBuilder.setBaseDir("/opt/homebrew");
+          configurationBuilder.setUnpackingFromClasspath(false);
+          configurationBuilder.setLibDir(System.getProperty("java.io.tmpdir") + "/MariaDB4j/no-libs");
+
           try {
             // ensure the DB directory is deleted before we start to have a clean start
             if (new File(baseDbDir).exists()) {

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResource.java
@@ -131,4 +131,22 @@ public abstract class BaseEntityAgnosticAspectResource extends ResourceContextHo
       throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, String.format("Urn %s is malformed.", urn));
     }
   }
+
+  @Action(name = ACTION_DELETE)
+  @Nonnull
+  public Task<Void> delete(
+      @ActionParam(PARAM_URN) @Nonnull String urn,
+      @ActionParam(PARAM_ASPECT_CLASS) @Nonnull String aspectClass) {
+    final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
+
+    try {
+      Class clazz = this.getClass().getClassLoader().loadClass(aspectClass);
+      genericLocalDAO().delete(Urn.createFromCharSequence(urn), clazz, auditStamp);
+      return Task.value(null);
+    } catch (ClassNotFoundException e) {
+      throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, String.format("No such class %s.", aspectClass));
+    } catch (URISyntaxException e) {
+      throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, String.format("Urn %s is malformed.", urn));
+    }
+  }
 }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -31,6 +31,7 @@ public final class RestliConstants {
   public static final String ACTION_RAW_INGEST_ASSET = "rawIngestAsset";
   public static final String ACTION_LIST_URNS_FROM_INDEX = "listUrnsFromIndex";
   public static final String ACTION_LIST_URNS = "listUrns";
+  public static final String ACTION_DELETE = "delete";
   public static final String PARAM_INPUT = "input";
   public static final String PARAM_ASPECTS = "aspects";
   public static final String PARAM_ASPECT = "aspect";

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityAgnosticAspectResourceTest.java
@@ -86,4 +86,13 @@ public class BaseEntityAgnosticAspectResourceTest extends BaseEngineTest {
 
     verifyNoMoreInteractions(_mockLocalDAO);
   }
+
+  @Test
+  public void testDelete() {
+    runAndWait(_resource.delete(ENTITY_URN.toString(), AspectFoo.class.getCanonicalName()));
+
+    verify(_mockLocalDAO, times(1)).delete(eq(ENTITY_URN), eq(AspectFoo.class), any(AuditStamp.class));
+
+    verifyNoMoreInteractions(_mockLocalDAO);
+  }
 }


### PR DESCRIPTION
## Summary
Support deletion in `EbeanGenericLocalDAO` and `BaseEntityAgnosticAspectResource`

We need to have generic deletion support for annotation metadata.

Long-term wise, team decided to have deletion support in every grpc endpoint.

However, to meet the timeline of the annotation use case, a `delete` method will be added in the `BaseEntityAgnosticAspectResource` so that `annotationGms` resource can expose this action.

## Details
- added a `delete` method and not send MAE for updates
- update `queryLatest` and `backfill` methods to accommodate deleted data 

## Testing Done
- unit test added
- ./gradlew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
