### PR TITLE
soft delete relationships when aspects are soft deleted (ASPECT_METADATA only)

### DIFF
--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -33,6 +33,7 @@ import com.linkedin.testing.SnapshotUnionAlias;
 import com.linkedin.testing.SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields;
 import com.linkedin.testing.TyperefPizzaAspect;
 import com.linkedin.testing.localrelationship.AspectFooBar;
+import com.linkedin.testing.localrelationship.AspectFooBarBaz;
 import com.linkedin.testing.namingedgecase.InternalEntitySnapshotNamingEdgeCase;
 import com.linkedin.testing.urn.PizzaUrn;
 import com.linkedin.testing.urn.BarUrn;
@@ -106,7 +107,7 @@ public class ModelUtilsTest {
     Set<Class<? extends RecordTemplate>> validTypes = ModelUtils.getValidAspectTypes(EntityAspectUnion.class);
 
     assertEquals(validTypes,
-        ImmutableSet.of(AspectFoo.class, AspectBar.class, AspectFooBar.class, AspectAttributes.class));
+        ImmutableSet.of(AspectFoo.class, AspectBar.class, AspectFooBar.class, AspectFooBarBaz.class, AspectAttributes.class));
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -611,10 +611,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
                 aspectClass.getCanonicalName()));
       }
 
-      if (_relationshipSource == RelationshipSource.ASPECT_METADATA) {
-        // TODO: not yet implemented -> add support for removing relationships when the aspect is to be soft-deleted
-        throw new UnsupportedOperationException("This method has not been implemented yet to support the "
-            + "ASPECT_METADATA RelationshipSource type yet.");
+      if (_relationshipSource == RelationshipSource.ASPECT_METADATA && oldValue != null) {
+        List<RecordTemplate> relationships = extractRelationshipsFromAspect(oldValue).stream()
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+        _localRelationshipWriterDAO.removeRelationships(relationships);
       }
     }
 
@@ -887,6 +888,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   public <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<LocalRelationshipUpdates> addRelationshipsIfAny(
       @Nonnull URN urn, @Nullable ASPECT aspect, @Nonnull Class<ASPECT> aspectClass, boolean isTestMode) {
+    if (aspect == null) {
+      return Collections.emptyList();
+    }
     List<LocalRelationshipUpdates> localRelationshipUpdates = Collections.emptyList();
     if (_relationshipSource == RelationshipSource.ASPECT_METADATA) {
       List<List<RELATIONSHIP>> allRelationships = EBeanDAOUtils.extractRelationshipsFromAspect(aspect);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -337,7 +337,7 @@ public class SQLStatementUtils {
 
   @Nonnull
   @ParametersAreNonnullByDefault
-  public static String deleteLocaRelationshipSQL(final String tableName, final BaseGraphWriterDAO.RemovalOption removalOption) {
+  public static String deleteLocalRelationshipSQL(final String tableName, final BaseGraphWriterDAO.RemovalOption removalOption) {
     if (removalOption == BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE) {
       return String.format(DELETE_BY_SOURCE, tableName);
     } else if (removalOption == BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -219,7 +219,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Soft (set delete_ts = now()) Delete Jack reports-to ALice relationship
     SqlUpdate deletionSQL = _server.createSqlUpdate(
-        SQLStatementUtils.deleteLocaRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice),
+        SQLStatementUtils.deleteLocalRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice),
             BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE));
     deletionSQL.setParameter("source", jack.toString());
     deletionSQL.execute();
@@ -368,7 +368,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Soft (set delete_ts = now()) Delete Jack reports-to ALice relationship
     SqlUpdate deletionSQL = _server.createSqlUpdate(
-        SQLStatementUtils.deleteLocaRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice),
+        SQLStatementUtils.deleteLocalRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice),
             BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE));
     deletionSQL.setParameter("source", jack.toString());
     deletionSQL.execute();

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
@@ -44,9 +44,9 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata LONGTEXT NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
@@ -54,7 +54,20 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (id)
-    );
+);
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
 
 CREATE TABLE metadata_id (
                              namespace VARCHAR(255) NOT NULL,
@@ -91,6 +104,9 @@ ALTER TABLE metadata_entity_foo_test ADD a_aspectbar JSON;
 
 -- add foobar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
+
+-- add foobar aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectfoobarbaz JSON;
 
 -- add array aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectattributes JSON;

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -56,6 +56,19 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     PRIMARY KEY (id)
 );
 
+CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
 CREATE TABLE metadata_id (
     namespace VARCHAR(255) NOT NULL,
     id BIGINT NOT NULL,
@@ -91,6 +104,9 @@ ALTER TABLE metadata_entity_foo_test ADD a_aspectbar JSON;
 
 -- add foobar aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectfoobar JSON;
+
+-- add foobar aspect to foo entity
+ALTER TABLE metadata_entity_foo ADD a_aspectfoobarbaz JSON;
 
 -- add array aspect to foo entity
 ALTER TABLE metadata_entity_foo ADD a_aspectattributes JSON;

--- a/dao-impl/ebean-dao/src/test/resources/gma-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/gma-create-all.sql
@@ -43,3 +43,16 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     deleted_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (id)
 );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(500) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(500) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);

--- a/dao-impl/ebean-dao/src/test/resources/gma-drop-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/gma-drop-all.sql
@@ -5,3 +5,5 @@ drop table if exists metadata_aspect;
 drop table if exists metadata_index;
 
 drop table if exists metadata_relationship_belongsto;
+
+drop table if exists metadata_relationship_reportsto;

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
@@ -3,8 +3,14 @@ namespace com.linkedin.testing
 /**
  * For unit tests
  */
-@gma.aspect.column.name = "annotatedaspectbarwithrelationshipfields"
-@gma.model = "ASPECT"
+@gma = {
+  "aspect": {
+    "column": {
+      "name": "annotatedaspectbarwithrelationshipfields"
+    }
+  },
+  "model": "ASPECT"
+}
 record AnnotatedAspectBarWithRelationshipFields {
   /**
    * For unit tests

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectFooWithRelationshipField.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectFooWithRelationshipField.pdl
@@ -3,8 +3,14 @@ namespace com.linkedin.testing
 /**
  * For unit tests
  */
-@gma.aspect.column.name = "annotatedaspectfoowithrelationshipfield"
-@gma.model = "ASPECT"
+@gma = {
+  "aspect": {
+    "column": {
+      "name": "annotatedaspectbarwithrelationshipfield"
+    }
+  },
+  "model": "ASPECT"
+}
 record AnnotatedAspectFooWithRelationshipField {
   /**
    * For unit tests

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -49,6 +49,7 @@ import com.linkedin.testing.EntityValue;
 import com.linkedin.testing.InternalEntityAspectUnion;
 import com.linkedin.testing.InternalEntitySnapshot;
 import com.linkedin.testing.localrelationship.AspectFooBar;
+import com.linkedin.testing.localrelationship.AspectFooBarBaz;
 import com.linkedin.testing.localrelationship.BelongsTo;
 import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.FooUrn;
@@ -251,9 +252,10 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectKey<FooUrn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     AspectKey<FooUrn, AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
     AspectKey<FooUrn, AspectFooBar> aspect3Key = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
-    AspectKey<FooUrn, AspectAttributes> aspect4Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
+    AspectKey<FooUrn, AspectFooBarBaz> aspect4Key = new AspectKey<>(AspectFooBarBaz.class, urn, LATEST_VERSION);
+    AspectKey<FooUrn, AspectAttributes> aspect5Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
-    when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key, aspect4Key)))).thenReturn(
+    when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key, aspect4Key, aspect5Key)))).thenReturn(
         Collections.singletonMap(aspect1Key, Optional.of(foo)));
 
     EntityValue value = runAndWait(_resource.get(makeResourceKey(urn), null));
@@ -357,14 +359,16 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectKey<FooUrn, AspectFoo> aspectFooKey1 = new AspectKey<>(AspectFoo.class, urn1, LATEST_VERSION);
     AspectKey<FooUrn, AspectBar> aspectBarKey1 = new AspectKey<>(AspectBar.class, urn1, LATEST_VERSION);
     AspectKey<FooUrn, AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
+    AspectKey<FooUrn, AspectFooBarBaz> aspectFooBarBazKey1 = new AspectKey<>(AspectFooBarBaz.class, urn1, LATEST_VERSION);
     AspectKey<FooUrn, AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
     AspectKey<FooUrn, AspectFoo> aspectFooKey2 = new AspectKey<>(AspectFoo.class, urn2, LATEST_VERSION);
     AspectKey<FooUrn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
     AspectKey<FooUrn, AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
+    AspectKey<FooUrn, AspectFooBarBaz> aspectFooBarBazKey2 = new AspectKey<>(AspectFooBarBaz.class, urn2, LATEST_VERSION);
     AspectKey<FooUrn, AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
 
-    when(_mockLocalDAO.get(ImmutableSet.of(aspectFooBarKey1, aspectFooBarKey2, aspectFooKey1, aspectBarKey1, aspectFooKey2,
-        aspectBarKey2, aspectAttKey1, aspectAttKey2)))
+    when(_mockLocalDAO.get(ImmutableSet.of(aspectFooBarKey1, aspectFooBarKey2, aspectFooBarBazKey1, aspectFooBarBazKey2,
+        aspectFooKey1, aspectBarKey1, aspectFooKey2, aspectBarKey2, aspectAttKey1, aspectAttKey2)))
         .thenReturn(ImmutableMap.of(aspectFooKey1, Optional.of(foo), aspectFooKey2, Optional.of(bar)));
 
     Map<EntityKey, EntityValue> keyValueMap =
@@ -711,16 +715,18 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectFoo bar = new AspectFoo().setValue("bar");
     AspectFooBar fooBar = new AspectFooBar().setBars(new BarUrnArray(new BarUrn(1)));
+    AspectFooBarBaz fooBarBaz = new AspectFooBarBaz().setBars(new BarUrnArray(new BarUrn(1)));
     AspectAttributes attributes = new AspectAttributes().setAttributes(new StringArray("a"));
 
     AspectKey<FooUrn, ? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     AspectKey<FooUrn, ? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
     AspectKey<FooUrn, ? extends RecordTemplate> fooBarKey = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
+    AspectKey<FooUrn, ? extends RecordTemplate> fooBarBazKey = new AspectKey<>(AspectFooBarBaz.class, urn, LATEST_VERSION);
     AspectKey<FooUrn, ? extends RecordTemplate> attKey = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
 
-    Set<AspectKey<FooUrn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, attKey);
+    Set<AspectKey<FooUrn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, fooBarBazKey, attKey);
     when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo), barKey, Optional.of(bar),
-        fooBarKey, Optional.of(fooBar), attKey, Optional.of(attributes)));
+        fooBarKey, Optional.of(fooBar), fooBarBazKey, Optional.of(fooBarBaz), attKey, Optional.of(attributes)));
 
     EntitySnapshot snapshot = runAndWait(_resource.getSnapshot(urn.toString(), null));
 
@@ -1152,7 +1158,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     // case 2: null aspects is provided i.e. all aspects in the aspect union will be returned, non-null last urn
     List<UrnAspectEntry<FooUrn>> listResult2 = Collections.singletonList(entry2);
 
-    when(_mockLocalDAO.getAspects(ImmutableSet.of(AspectFoo.class, AspectBar.class, AspectFooBar.class, AspectAttributes.class), indexFilter, null, urn1, 2))
+    when(_mockLocalDAO.getAspects(ImmutableSet.of(AspectFoo.class, AspectBar.class, AspectFooBar.class, AspectFooBarBaz.class,
+        AspectAttributes.class), indexFilter, null, urn1, 2))
         .thenReturn(listResult2);
 
     List<EntityValue> actual2 =
@@ -1300,10 +1307,11 @@ public class BaseEntityResourceTest extends BaseEngineTest {
 
     // All aspects
     aspectClasses = _resource.parseAspectsParam(null, false);
-    assertEquals(aspectClasses.size(), 4);
+    assertEquals(aspectClasses.size(), 5);
     assertTrue(aspectClasses.contains(AspectFoo.class));
     assertTrue(aspectClasses.contains(AspectBar.class));
     assertTrue(aspectClasses.contains(AspectFooBar.class));
+    assertTrue(aspectClasses.contains(AspectFooBarBaz.class));
     assertTrue(aspectClasses.contains(AspectAttributes.class));
   }
 

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResourceTest.java
@@ -28,6 +28,7 @@ import com.linkedin.testing.EntityValue;
 import com.linkedin.testing.InternalEntityAspectUnion;
 import com.linkedin.testing.InternalEntitySnapshot;
 import com.linkedin.testing.localrelationship.AspectFooBar;
+import com.linkedin.testing.localrelationship.AspectFooBarBaz;
 import com.linkedin.testing.urn.BarUrn;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -68,10 +69,11 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     AspectKey<Urn, AspectFoo> aspect1Key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     AspectKey<Urn, AspectBar> aspect2Key = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
     AspectKey<Urn, AspectFooBar> aspect3Key = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
-    AspectKey<Urn, AspectAttributes> aspect4Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
+    AspectKey<Urn, AspectFooBarBaz> aspect4Key = new AspectKey<>(AspectFooBarBaz.class, urn, LATEST_VERSION);
+    AspectKey<Urn, AspectAttributes> aspect5Key = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
 
     when(_mockLocalDAO.exists(urn)).thenReturn(true);
-    when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key, aspect4Key))))
+    when(_mockLocalDAO.get(new HashSet<>(Arrays.asList(aspect1Key, aspect2Key, aspect3Key, aspect4Key, aspect5Key))))
         .thenReturn(Collections.singletonMap(aspect1Key, Optional.of(foo)));
 
     EntityValue value = runAndWait(_resource.get(id, null));
@@ -187,11 +189,13 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     AspectKey<Urn, AspectBar> aspectBarKey2 = new AspectKey<>(AspectBar.class, urn2, LATEST_VERSION);
     AspectKey<Urn, AspectFooBar> aspectFooBarKey1 = new AspectKey<>(AspectFooBar.class, urn1, LATEST_VERSION);
     AspectKey<Urn, AspectFooBar> aspectFooBarKey2 = new AspectKey<>(AspectFooBar.class, urn2, LATEST_VERSION);
+    AspectKey<Urn, AspectFooBarBaz> aspectFooBarBazKey1 = new AspectKey<>(AspectFooBarBaz.class, urn1, LATEST_VERSION);
+    AspectKey<Urn, AspectFooBarBaz> aspectFooBarBazKey2 = new AspectKey<>(AspectFooBarBaz.class, urn2, LATEST_VERSION);
     AspectKey<Urn, AspectAttributes> aspectAttKey1 = new AspectKey<>(AspectAttributes.class, urn1, LATEST_VERSION);
     AspectKey<Urn, AspectAttributes> aspectAttKey2 = new AspectKey<>(AspectAttributes.class, urn2, LATEST_VERSION);
 
     when(_mockLocalDAO.get(ImmutableSet.of(aspectFooKey1, aspectBarKey1, aspectAttKey1, aspectFooKey2, aspectBarKey2,
-        aspectAttKey2, aspectFooBarKey1, aspectFooBarKey2))).thenReturn(
+        aspectAttKey2, aspectFooBarKey1, aspectFooBarKey2, aspectFooBarBazKey1, aspectFooBarBazKey2))).thenReturn(
         ImmutableMap.of(aspectFooKey1, Optional.of(foo), aspectFooKey2, Optional.of(bar)));
 
     Map<Long, EntityValue> keyValueMap = runAndWait(_resource.batchGet(ImmutableSet.of(id1, id2), null))
@@ -297,14 +301,16 @@ public class BaseEntitySimpleKeyResourceTest extends BaseEngineTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
     AspectFooBar fooBar = new AspectFooBar().setBars(new BarUrnArray(new BarUrn(1)));
+    AspectFooBarBaz fooBarBaz = new AspectFooBarBaz().setBars(new BarUrnArray(new BarUrn(1)));
     AspectAttributes att = new AspectAttributes().setAttributes(new StringArray("a"));
     AspectKey<Urn, ? extends RecordTemplate> fooKey = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
     AspectKey<Urn, ? extends RecordTemplate> barKey = new AspectKey<>(AspectBar.class, urn, LATEST_VERSION);
     AspectKey<Urn, ? extends RecordTemplate> fooBarKey = new AspectKey<>(AspectFooBar.class, urn, LATEST_VERSION);
+    AspectKey<Urn, ? extends RecordTemplate> fooBarBazKey = new AspectKey<>(AspectFooBarBaz.class, urn, LATEST_VERSION);
     AspectKey<Urn, ? extends RecordTemplate> attKey = new AspectKey<>(AspectAttributes.class, urn, LATEST_VERSION);
-    Set<AspectKey<Urn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, attKey);
+    Set<AspectKey<Urn, ? extends RecordTemplate>> aspectKeys = ImmutableSet.of(fooKey, barKey, fooBarKey, fooBarBazKey, attKey);
     when(_mockLocalDAO.get(aspectKeys)).thenReturn(ImmutableMap.of(fooKey, Optional.of(foo), barKey, Optional.of(bar),
-        fooBarKey, Optional.of(fooBar), attKey, Optional.of(att)));
+        fooBarKey, Optional.of(fooBar), fooBarBazKey, Optional.of(fooBarBaz), attKey, Optional.of(att)));
 
     EntitySnapshot snapshot = runAndWait(_resource.getSnapshot(urn.toString(), null));
 

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAspectUnion.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/EntityAspectUnion.pdl
@@ -1,7 +1,8 @@
 namespace com.linkedin.testing
 
 import com.linkedin.testing.localrelationship.AspectFooBar
+import com.linkedin.testing.localrelationship.AspectFooBarBaz
 /**
  * For unit tests
  */
-typeref EntityAspectUnion = union[AspectFoo, AspectBar, AspectFooBar, AspectAttributes]
+typeref EntityAspectUnion = union[AspectFoo, AspectBar, AspectFooBar, AspectFooBarBaz, AspectAttributes]

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AspectFooBarBaz.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AspectFooBarBaz.pdl
@@ -2,9 +2,8 @@ namespace com.linkedin.testing.localrelationship
 
 import com.linkedin.testing.BarUrn
 
-@gma.aspect.column.name = "aspectfoobar"
-record AspectFooBar {
+@gma.aspect.column.name = "aspectfoobarbaz"
+record AspectFooBarBaz {
   bars: array[BarUrn]
   belongsTos: optional array[BelongsTo]
-  reportsTos: optional array[ReportsTo]
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/ReportsTo.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/ReportsTo.pdl
@@ -4,5 +4,6 @@ namespace com.linkedin.testing.localrelationship
   "destination": "com.linkedin.testing.urn.FooUrn",
   "source": "com.linkedin.testing.urn.BarUrn"
 } ]
+@gma.model = "RELATIONSHIP"
 record ReportsTo includes BaseRelationship {
 }


### PR DESCRIPTION
## Summary
Previously, there was a gap when using relationship builders where an aspect that was registered with a relationship builder could not be soft deleted since there was no agreed-upon way to remove relationships associated with that aspect.

Now, when deriving relationships directly from aspect metadata, we can handle soft deletion gracefully. When the source aspect is marked as soft deleted, also mark any of the relationships from the old aspect value (existing in the db) as deleted in the corresponding relationship tables.

Note on the large number of files changed in this PR. I had to add a new test aspect model which required making many minor changes to other unit tests. No need to closely review those minor changes.

## Testing Done
added a unit test
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
