### PR TITLE
Fix: aspectUpdateHelper result is null due to isSkipProcessing enabled so unwrapAddResult() hits NPE

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -817,9 +817,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         runInTransactionWithRetry(() -> aspectUpdateHelper(urn, updateLambda, auditStamp, trackingContext, isRawUpdate),
             maxTransactionRetry);
 
-    // skip MAE producing and post update hook in test mode
+    // skip MAE producing and post update hook in test mode or if the result is null (no actual update with addCommon)
     return updateLambda.getIngestionParams().isTestMode() ? result.newValue
-        : unwrapAddResult(urn, result, auditStamp, trackingContext);
+        : result == null ? null : unwrapAddResult(urn, result, auditStamp, trackingContext);
   }
 
   /**


### PR DESCRIPTION
## Summary
`aspectUpdateHelper` allows to return NULL when `isSkipProcessing` enabled so there is no real DAO save happen.
However the `unwrapAddResult()`doesn't expect result as NULL so it hits NPE. Also both MAE producing and post update hook should not happen because no real DAO happens.
Thus add NULL for return. 

## Testing Done
./gradlew idea

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
