### PR TITLE
support relationship v2

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
@@ -7,7 +7,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import static com.linkedin.metadata.dao.utils.ModelUtils.*;
-import static com.linkedin.metadata.dao.utils.RecordUtils.*;
 
 
 public class GraphUtils {
@@ -25,6 +24,7 @@ public class GraphUtils {
       return;
     }
 
+    // ToDo: how to handle this for Relationship V2?
     final Urn sourceUrn = getSourceUrnFromRelationship(relationships.get(0));
     final Urn destinationUrn = getDestinationUrnFromRelationship(relationships.get(0));
 
@@ -41,7 +41,7 @@ public class GraphUtils {
   private static void checkSameUrn(@Nonnull List<? extends RecordTemplate> records, @Nonnull String field,
       @Nonnull Urn compare) {
     for (RecordTemplate relation : records) {
-      if (!compare.equals(getRecordTemplateField(relation, field, Urn.class))) {
+      if (!compare.equals(ModelUtils.getUrnFromRelationship(relation, field))) {
         throw new IllegalArgumentException("Records have different " + field + " urn");
       }
     }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
@@ -44,9 +44,10 @@ public class ModelUtils {
 
   private static final ClassLoader CLASS_LOADER = DummySnapshot.class.getClassLoader();
   private static final String ASPECTS_FIELD = "aspects";
+  private static final String DESTINATION_FIELD = "destination";
   private static final String FIELD_FIELD_PREFIX = "FIELD_";
-  private static final String MEMBER_FIELD_PREFIX = "MEMBER_";
   private static final String METADATA_AUDIT_EVENT_PREFIX = "METADATA_AUDIT_EVENT";
+  private static final String SOURCE_FIELD = "source";
   private static final String URN_FIELD = "urn";
 
   private ModelUtils() {
@@ -293,7 +294,9 @@ public class ModelUtils {
   private static <RELATIONSHIP extends RecordTemplate> Urn getUrnFromRelationship(@Nonnull RELATIONSHIP relationship,
       @Nonnull String fieldName) {
     RelationshipValidator.validateRelationshipSchema(relationship.getClass());
-    final Urn urn = RecordUtils.getRecordTemplateField(relationship, fieldName, urnClassForRelationship(relationship.getClass(), fieldName));
+    boolean isRelationshipInV2 = isRelationshipInV2(relationship);
+    final Urn urn = RecordUtils.getRecordTemplateField(relationship, fieldName,
+        urnClassForRelationship(relationship.getClass(), fieldName, isRelationshipInV2));
     if (urn == null) {
       ValidationUtils.throwNullFieldException(URN_FIELD);
     }
@@ -306,7 +309,12 @@ public class ModelUtils {
   @Nonnull
   public static <RELATIONSHIP extends RecordTemplate> Urn getSourceUrnFromRelationship(
       @Nonnull RELATIONSHIP relationship) {
-    return getUrnFromRelationship(relationship, "source");
+    //ToDo: remove this if statement after all relationships are in Relationship model V2.
+    if (!isRelationshipInV2(relationship)) {
+      return getUrnFromRelationship(relationship, SOURCE_FIELD);
+    }
+
+    return getUrnFromRelationship(relationship, extractFieldNameFromUnionField(relationship, SOURCE_FIELD));
   }
 
   /**
@@ -315,7 +323,26 @@ public class ModelUtils {
   @Nonnull
   public static <RELATIONSHIP extends RecordTemplate> Urn getDestinationUrnFromRelationship(
       @Nonnull RELATIONSHIP relationship) {
-    return getUrnFromRelationship(relationship, "destination");
+    //ToDo: remove this if statement after all relationships are in Relationship model V2.
+    if (!isRelationshipInV2(relationship)) {
+      return getUrnFromRelationship(relationship, DESTINATION_FIELD);
+    }
+
+    return getUrnFromRelationship(relationship, extractFieldNameFromUnionField(relationship, DESTINATION_FIELD));
+  }
+
+  /**
+   * Get the field name within a union type. e.g. to get "sourceDemoAsset" from the following "source" union type.
+   *   source: optional union[
+   *     sourceDemoAsset: DemoAssetUrn
+   *   ]
+   */
+  public static <RELATIONSHIP extends RecordTemplate> String extractFieldNameFromUnionField(RELATIONSHIP relationship, String fieldName) {
+    final DataMap dataMap = RecordUtils.getRecordTemplateField(relationship, fieldName, DataMap.class);
+    if (dataMap == null) {
+      ValidationUtils.throwNullFieldException(fieldName);
+    }
+    return dataMap.keySet().iterator().next();
   }
 
   /**
@@ -717,10 +744,19 @@ public class ModelUtils {
    * Gets the expected {@link Urn} class for a specific kind of relationship.
    */
   @Nonnull
-  private static Class<? extends Urn> urnClassForRelationship(
+  static Class<? extends Urn> urnClassForRelationship(
       @Nonnull Class<? extends RecordTemplate> relationshipClass, @Nonnull String fieldName) {
+    return urnClassForRelationship(relationshipClass, fieldName, false);
+  }
+
+  /**
+   * Gets the expected {@link Urn} class for a specific kind of relationship.
+   */
+  @Nonnull
+  static Class<? extends Urn> urnClassForRelationship(
+      @Nonnull Class<? extends RecordTemplate> relationshipClass, @Nonnull String fieldName, boolean isRelationshipInV2) {
     RelationshipValidator.validateRelationshipSchema(relationshipClass);
-    return urnClassForField(relationshipClass, fieldName);
+    return urnClassForField(relationshipClass, fieldName, isRelationshipInV2);
   }
 
   /**
@@ -729,7 +765,7 @@ public class ModelUtils {
   @Nonnull
   public static Class<? extends Urn> sourceUrnClassForRelationship(
       @Nonnull Class<? extends RecordTemplate> relationshipClass) {
-    return urnClassForRelationship(relationshipClass, "source");
+    return urnClassForRelationship(relationshipClass, SOURCE_FIELD);
   }
 
   /**
@@ -738,7 +774,7 @@ public class ModelUtils {
   @Nonnull
   public static Class<? extends Urn> destinationUrnClassForRelationship(
       @Nonnull Class<? extends RecordTemplate> relationshipClass) {
-    return urnClassForRelationship(relationshipClass, "destination");
+    return urnClassForRelationship(relationshipClass, DESTINATION_FIELD);
   }
 
   @Nonnull
@@ -750,6 +786,29 @@ public class ModelUtils {
         .getProperties()
         .get("java")).getString("class");
 
+    return getClassFromName(urnClassName, Urn.class);
+  }
+
+  @Nonnull
+  private static Class<? extends Urn> urnClassForField(@Nonnull Class<? extends RecordTemplate> recordClass,
+      @Nonnull String fieldName, boolean isRelationshipInV2) {
+    String urnClassName;
+    if (!isRelationshipInV2) {
+      urnClassName = ((DataMap) ValidationUtils.getRecordSchema(recordClass)
+          .getField(fieldName)
+          .getType()
+          .getProperties()
+          .get("java")).getString("class");
+    } else {
+      urnClassName =((DataMap)  ValidationUtils.getRecordSchema(recordClass)
+          .getField(fieldName)
+          .getType()
+          .getMembers()
+          .get(0)
+          .getType()
+          .getProperties()
+          .get("java")).getString("class");
+    }
     return getClassFromName(urnClassName, Urn.class);
   }
 
@@ -845,6 +904,31 @@ public class ModelUtils {
   public static boolean isCommonAspect(@Nonnull Class<? extends RecordTemplate> clazz) {
     return clazz.getPackage().getName().startsWith("com.linkedin.common");
   }
+
+  /**
+   * Check if a given relationship is in MG model v2 or not.
+   * @param relationship must be a valid relationship model defined in com.linkedin.metadata.relationship
+   * @return boolean. True if the relationship is in MG model V2.
+   */
+  static <RELATIONSHIP extends RecordTemplate> boolean isRelationshipInV2(RELATIONSHIP relationship) {
+    final RecordDataSchema schema = ValidationUtils.getRecordSchema(relationship.getClass());
+    return isRelationshipInV2(schema);
+  }
+
+  /**
+   * Check if a given relationship schema is in MG model v2 or not.
+   * Returns TRUE if source and destination fields are of union type.
+   * @param schema schema of a valid relationship model defined in com.linkedin.metadata.relationship
+   * @return boolean. True if the relationship is in MG model V2.
+   */
+  static boolean isRelationshipInV2(@Nonnull RecordDataSchema schema) {
+    // check the data type of the source and destination fields in schema and see if it's a union type
+    return schema.getFields().stream().anyMatch(
+        field -> field.getName().equals(SOURCE_FIELD) && field.getType().getType() == DataSchema.Type.UNION)
+        && schema.getFields().stream().anyMatch(
+        field -> field.getName().equals(DESTINATION_FIELD) && field.getType().getType() == DataSchema.Type.UNION);
+  }
+
 
   /**
    * Creates an entity union with a specific entity set.

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
@@ -301,9 +301,15 @@ public class ModelUtils {
     final Urn urn;
     if (!relationshipInV2) {
       // if V1, get the urn from the given field name, "source" or "destination"
+      if (!fieldName.equals(DESTINATION_FIELD) && !fieldName.equals(SOURCE_FIELD)) {
+        throw new IllegalArgumentException("Expecting destination or source field, but got " + fieldName);
+      }
       urn = RecordUtils.getRecordTemplateField(relationship, fieldName, urnClassForRelationship(relationship.getClass(), fieldName));
     } else {
       // if V2, get the urn from the union field, "destination"
+      if (!fieldName.equals(DESTINATION_FIELD)) {
+        throw new IllegalArgumentException("Expecting destination field, but got " + fieldName);
+      }
       urn = getUrnFromString(RecordUtils.extractFieldValueFromUnionField(relationship, fieldName), Urn.class);
     }
     if (urn == null) {

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
@@ -321,6 +321,7 @@ public class ModelUtils {
     if (!isRelationshipInV2(relationship.getClass())) {
       return getUrnFromRelationship(relationship, SOURCE_FIELD);
     } else {
+      // ToDo: how to get source urn for a given relationship in V2?
       throw new UnsupportedOperationException("Relationship V2 models don't have a source field.");
     }
   }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -15,6 +15,7 @@ import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.exception.ModelConversionException;
 import com.linkedin.metadata.validator.InvalidSchemaException;
+import com.linkedin.metadata.validator.ValidationUtils;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -584,4 +585,28 @@ public class RecordUtils {
     }
     return Optional.of(reference);
   }
+
+//  /**
+//   * Get the field name within a union type. e.g. to get "sourceDemoAsset" from the following "source" union type.
+//   *   source: optional union[
+//   *     sourceDemoAsset: DemoAssetUrn
+//   *   ]
+//   */
+//  public static <RELATIONSHIP extends RecordTemplate> String getFieldNameFromUnionType(
+//      @Nonnull RELATIONSHIP relationship, @Nonnull String unionFieldName) {
+//    RecordDataSchema.Field field = getRecordDataSchemaField(relationship, unionFieldName);
+//    if (field.getType() instanceof UnionDataSchema) {
+//      String temp = ((UnionDataSchema) field.getType()).getMembers().get(0).getUnionMemberKey();
+//      return ((UnionDataSchema) field.getType()).getMembers().get(0).getUnionMemberKey();
+//    }
+//    throw new IllegalArgumentException("Field " + unionFieldName + " is not union type");
+//  }
+//
+//  public static <RELATIONSHIP extends RecordTemplate> String extractFieldNameFromUnionField(RELATIONSHIP relationship, String fieldName) {
+//    final DataMap dataMap = RecordUtils.getRecordTemplateField(relationship, fieldName, DataMap.class);
+//    if (dataMap == null) {
+//      ValidationUtils.throwNullFieldException(fieldName);
+//    }
+//    return dataMap.keySet().iterator().next();
+//  }
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -601,7 +601,7 @@ public class RecordUtils {
   }
 
   /**
-   * Get the field name within a union type. e.g. to get "sourceDemoAsset" from the following "source" union type.
+   * Get the field value within a union type. e.g. to get "DemoAssetUrn" from the following "source" union type.
    *   source: optional union[
    *     sourceDemoAsset: DemoAssetUrn
    *   ]

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -586,27 +586,31 @@ public class RecordUtils {
     return Optional.of(reference);
   }
 
-//  /**
-//   * Get the field name within a union type. e.g. to get "sourceDemoAsset" from the following "source" union type.
-//   *   source: optional union[
-//   *     sourceDemoAsset: DemoAssetUrn
-//   *   ]
-//   */
-//  public static <RELATIONSHIP extends RecordTemplate> String getFieldNameFromUnionType(
-//      @Nonnull RELATIONSHIP relationship, @Nonnull String unionFieldName) {
-//    RecordDataSchema.Field field = getRecordDataSchemaField(relationship, unionFieldName);
-//    if (field.getType() instanceof UnionDataSchema) {
-//      String temp = ((UnionDataSchema) field.getType()).getMembers().get(0).getUnionMemberKey();
-//      return ((UnionDataSchema) field.getType()).getMembers().get(0).getUnionMemberKey();
-//    }
-//    throw new IllegalArgumentException("Field " + unionFieldName + " is not union type");
-//  }
-//
-//  public static <RELATIONSHIP extends RecordTemplate> String extractFieldNameFromUnionField(RELATIONSHIP relationship, String fieldName) {
-//    final DataMap dataMap = RecordUtils.getRecordTemplateField(relationship, fieldName, DataMap.class);
-//    if (dataMap == null) {
-//      ValidationUtils.throwNullFieldException(fieldName);
-//    }
-//    return dataMap.keySet().iterator().next();
-//  }
+  /**
+   * Get the field name within a union type. e.g. to get "sourceDemoAsset" from the following "source" union type.
+   *   source: optional union[
+   *     sourceDemoAsset: DemoAssetUrn
+   *   ]
+   */
+  public static <RELATIONSHIP extends RecordTemplate> String extractFieldNameFromUnionField(RELATIONSHIP relationship, String fieldName) {
+    final DataMap dataMap = RecordUtils.getRecordTemplateField(relationship, fieldName, DataMap.class);
+    if (dataMap == null) {
+      ValidationUtils.throwNullFieldException(fieldName);
+    }
+    return dataMap.keySet().iterator().next();
+  }
+
+  /**
+   * Get the field name within a union type. e.g. to get "sourceDemoAsset" from the following "source" union type.
+   *   source: optional union[
+   *     sourceDemoAsset: DemoAssetUrn
+   *   ]
+   */
+  public static <RELATIONSHIP extends RecordTemplate> String extractFieldValueFromUnionField(RELATIONSHIP relationship, String fieldName) {
+    final DataMap dataMap = RecordUtils.getRecordTemplateField(relationship, fieldName, DataMap.class);
+    if (dataMap == null) {
+      ValidationUtils.throwNullFieldException(fieldName);
+    }
+    return dataMap.values().iterator().next().toString();
+  }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/GraphUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/GraphUtilsTest.java
@@ -1,0 +1,120 @@
+package com.linkedin.metadata.dao.utils;
+
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
+import com.linkedin.testing.RelationshipBar;
+import com.linkedin.testing.RelationshipFoo;
+import com.linkedin.testing.RelationshipV2Bar;
+import com.linkedin.testing.urn.BarUrn;
+import com.linkedin.testing.urn.BazUrn;
+import com.linkedin.testing.urn.FooUrn;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import static org.testng.Assert.*;
+
+public class GraphUtilsTest {
+
+  @Test
+  public void testCheckSameUrnWithEmptyRelationships() {
+    List<RecordTemplate> relationships = Collections.emptyList();
+    GraphUtils.checkSameUrn(relationships, BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE, "source", "destination");
+    // No exception should be thrown
+  }
+
+  @Test
+  public void testCheckSameUrnWithSameSourceUrn() {
+    // ToDo: Add test cases for relationship V2
+
+    RelationshipFoo relationship;
+    try {
+      relationship = mockRelationshipFoo(new FooUrn(1), new BarUrn(2));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    List<RecordTemplate> relationships = Lists.newArrayList(relationship, relationship);
+    try {
+      GraphUtils.checkSameUrn(relationships, BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE, "source", "destination");
+    } catch (IllegalArgumentException e) {
+      fail("Expected no IllegalArgumentException to be thrown, but got: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckSameUrnWithDifferentSourceUrn() {
+    RecordTemplate relationship1;
+    RecordTemplate relationship2;
+    try {
+      relationship1 = mockRelationshipFoo(new FooUrn(1), new BarUrn(2));
+      relationship2 = mockRelationshipFoo(new FooUrn(3), new BarUrn(2));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    List<RecordTemplate> relationships = Lists.newArrayList(relationship1, relationship2);
+    assertThrows(IllegalArgumentException.class,
+        () -> GraphUtils.checkSameUrn(
+            relationships,
+            BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE,
+            "source",
+            "destination")
+    );
+  }
+
+  @Test
+  public void testCheckSameUrnWithSameDestinationUrn() {
+    RelationshipFoo relationship1;
+    RelationshipV2Bar relationship2;
+    try {
+      relationship1 = mockRelationshipFoo(new FooUrn(1), new BarUrn(2));
+      relationship2 = mockRelationshipV2Bar(new BarUrn(2));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    List<RecordTemplate> relationships = Lists.newArrayList(relationship1, relationship2);
+
+    try {
+      GraphUtils.checkSameUrn(relationships, BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_TO_DESTINATION, "source",
+          "destination");
+    } catch (IllegalArgumentException e) {
+      fail("Expected no IllegalArgumentException to be thrown, but got: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckSameUrnWithDifferentDestinationUrn() {
+    RelationshipFoo relationship1;
+    RelationshipBar relationship2;
+    RelationshipV2Bar relationship3;
+    try {
+      relationship1 = mockRelationshipFoo(new FooUrn(1), new BarUrn(2));
+      relationship2 = new RelationshipBar().setSource(new FooUrn(4)).setDestination(new BazUrn(2));
+      relationship3 = mockRelationshipV2Bar(new BarUrn(3));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    List<RecordTemplate> relationships = Lists.newArrayList(relationship1, relationship2, relationship3);
+    assertThrows(IllegalArgumentException.class,
+        () -> GraphUtils.checkSameUrn(
+            relationships,
+            BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_TO_DESTINATION,
+            "source",
+            "destination")
+    );
+  }
+
+  private RelationshipFoo mockRelationshipFoo(FooUrn expectedSource, BarUrn expectedDestination) {
+    return new RelationshipFoo().setSource(expectedSource).setDestination(expectedDestination);
+  }
+
+  private RelationshipV2Bar mockRelationshipV2Bar(BarUrn barUrn) {
+    RelationshipV2Bar.Destination destination = new RelationshipV2Bar.Destination();
+    destination.setDestinationBar(barUrn);
+    return new RelationshipV2Bar().setDestination(destination);
+  }
+}

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -3,69 +3,68 @@ package com.linkedin.metadata.dao.utils;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.CommonTestAspect;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.validator.InvalidSchemaException;
 import com.linkedin.metadata.validator.NullFieldException;
 import com.linkedin.testing.AspectAttributes;
+import com.linkedin.testing.AspectBar;
+import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.AspectFooEvolved;
 import com.linkedin.testing.AspectUnionWithSoftDeletedAspect;
 import com.linkedin.testing.BarAsset;
 import com.linkedin.testing.BarUrnArray;
-import com.linkedin.testing.BazUrn;
 import com.linkedin.testing.DatasetInfo;
+import com.linkedin.testing.DeltaUnion;
 import com.linkedin.testing.DeltaUnionAlias;
+import com.linkedin.testing.EntityAspectUnion;
+import com.linkedin.testing.EntityAspectUnionAlias;
 import com.linkedin.testing.EntityAspectUnionAliasArray;
+import com.linkedin.testing.EntityAspectUnionArray;
 import com.linkedin.testing.EntityAsset;
+import com.linkedin.testing.EntityBar;
+import com.linkedin.testing.EntityDelta;
 import com.linkedin.testing.EntityDeltaAlias;
+import com.linkedin.testing.EntityDocument;
+import com.linkedin.testing.EntityDocumentInvalid;
+import com.linkedin.testing.EntityDocumentOptionalUrn;
 import com.linkedin.testing.EntityFoo;
 import com.linkedin.testing.EntityFooInvalid;
 import com.linkedin.testing.EntityFooOptionalUrn;
+import com.linkedin.testing.EntitySnapshot;
 import com.linkedin.testing.EntitySnapshotAlias;
 import com.linkedin.testing.EntitySnapshotAliasOptionalFields;
+import com.linkedin.testing.EntitySnapshotInvalid;
+import com.linkedin.testing.EntitySnapshotOptionalFields;
 import com.linkedin.testing.EntityUnion;
 import com.linkedin.testing.EntityUnionAlias;
 import com.linkedin.testing.EntityValue;
 import com.linkedin.testing.InternalEntityAspectUnion;
 import com.linkedin.testing.InternalEntityAspectUnionArray;
 import com.linkedin.testing.InternalEntitySnapshot;
+import com.linkedin.testing.InvalidAspectUnion;
 import com.linkedin.testing.PizzaInfo;
 import com.linkedin.testing.PizzaOrder;
+import com.linkedin.testing.RelationshipFoo;
+import com.linkedin.testing.RelationshipFooOptionalFields;
+import com.linkedin.testing.RelationshipUnion;
+import com.linkedin.testing.RelationshipUnionAlias;
+import com.linkedin.testing.RelationshipV2Bar;
+import com.linkedin.testing.SnapshotUnion;
 import com.linkedin.testing.SnapshotUnionAlias;
 import com.linkedin.testing.SnapshotUnionAliasWithEntitySnapshotAliasOptionalFields;
+import com.linkedin.testing.SnapshotUnionWithEntitySnapshotOptionalFields;
 import com.linkedin.testing.TyperefPizzaAspect;
 import com.linkedin.testing.localrelationship.AspectFooBar;
 import com.linkedin.testing.localrelationship.AspectFooBarBaz;
-import com.linkedin.testing.namingedgecase.InternalEntitySnapshotNamingEdgeCase;
-import com.linkedin.testing.urn.PizzaUrn;
-import com.linkedin.testing.urn.BarUrn;
-import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.metadata.validator.InvalidSchemaException;
-import com.linkedin.testing.AspectBar;
-import com.linkedin.testing.AspectFoo;
-import com.linkedin.testing.DeltaUnion;
-import com.linkedin.testing.EntityAspectUnion;
-import com.linkedin.testing.EntityAspectUnionAlias;
-import com.linkedin.testing.EntityAspectUnionArray;
-import com.linkedin.testing.EntityBar;
-import com.linkedin.testing.EntityDelta;
-import com.linkedin.testing.EntityDocument;
-import com.linkedin.testing.EntityDocumentInvalid;
-import com.linkedin.testing.EntityDocumentOptionalUrn;
-import com.linkedin.testing.EntitySnapshot;
-import com.linkedin.testing.EntitySnapshotInvalid;
-import com.linkedin.testing.EntitySnapshotOptionalFields;
-import com.linkedin.testing.InvalidAspectUnion;
-import com.linkedin.testing.RelationshipFoo;
-import com.linkedin.testing.RelationshipFooOptionalFields;
-import com.linkedin.testing.RelationshipV2Bar;
-import com.linkedin.testing.RelationshipUnion;
-import com.linkedin.testing.RelationshipUnionAlias;
-import com.linkedin.testing.SnapshotUnion;
-import com.linkedin.testing.SnapshotUnionWithEntitySnapshotOptionalFields;
-import com.linkedin.testing.urn.FooUrn;
 import com.linkedin.testing.namingedgecase.EntityValueNamingEdgeCase;
 import com.linkedin.testing.namingedgecase.InternalEntityAspectUnionNamingEdgeCase;
 import com.linkedin.testing.namingedgecase.InternalEntityAspectUnionNamingEdgeCaseArray;
+import com.linkedin.testing.namingedgecase.InternalEntitySnapshotNamingEdgeCase;
+import com.linkedin.testing.urn.BarUrn;
+import com.linkedin.testing.urn.FooUrn;
+import com.linkedin.testing.urn.PizzaUrn;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -252,6 +251,7 @@ public class ModelUtilsTest {
 
   @Test
   public void testGetUrnFromRelationship() {
+    // test Relationship model V1
     FooUrn expectedSource = makeFooUrn(1);
     BarUrn expectedDestination = makeBarUrn(1);
     RelationshipFoo relationship = new RelationshipFoo().setSource(expectedSource).setDestination(expectedDestination);
@@ -260,6 +260,13 @@ public class ModelUtilsTest {
     Urn destinationUrn = ModelUtils.getDestinationUrnFromRelationship(relationship);
     assertEquals(sourceUrn, expectedSource);
     assertEquals(destinationUrn, expectedDestination);
+
+    // test Relationship model V2
+    BarUrn barUrn = makeBarUrn(2);
+    RelationshipV2Bar relationshipv2 = mockRelationshipV2Bar(barUrn);
+    destinationUrn = ModelUtils.getDestinationUrnFromRelationship(relationshipv2);
+    assertThrows(UnsupportedOperationException.class, () -> ModelUtils.getSourceUrnFromRelationship(relationshipv2));
+    assertEquals(destinationUrn, ModelUtils.getDestinationUrnFromRelationship(relationshipv2));
   }
 
   @Test
@@ -839,58 +846,27 @@ public class ModelUtilsTest {
   }
 
   @Test
-  public void testGetSourceUrnFromRelationship() {
-    assertEquals("a", "a");
-  }
-
-  @Test
-  public void testGetDestinationUrnFromRelationship() {
-    FooUrn expectedSource = makeFooUrn(1);
-    BarUrn expectedDestination = makeBarUrn(1);
-    // relationship model v1 should return false
-    RelationshipFoo relationship = mockRelationshipFoo(expectedSource, expectedDestination);
-    Urn result = ModelUtils.getDestinationUrnFromRelationship(relationship);
-    try {
-      assertEquals(result, Urn.createFromString("urn:li:bar:1"));
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
-
-    // relationship model v2 should return true
-    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(expectedSource, expectedDestination);
-    result = ModelUtils.getDestinationUrnFromRelationship(relationshipV2);
-    try {
-      assertEquals(result, Urn.createFromString("urn:li:bar:1"));
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Test
-  public void testExtractFieldNameFromUnionField() {
-    FooUrn fooUrn = makeFooUrn(1);
-    BarUrn barUrn = makeBarUrn(1);
-    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(fooUrn, barUrn);
-
-    String sourceFieldName = ModelUtils.extractFieldNameFromUnionField(relationshipV2, "source");
-    assertEquals(sourceFieldName, "sourceFoo");
-
-    String destinationFieldName = ModelUtils.extractFieldNameFromUnionField(relationshipV2, "destination");
-    assertEquals(destinationFieldName, "destinationBar");
-  }
-
-  @Test
   public void testIsRelationshipInV2() {
+    // testing isRelationshipInV2(Class<? extends RecordTemplate> relationship)
+    // test relationship model v1
     FooUrn expectedSource = makeFooUrn(1);
     BarUrn expectedDestination = makeBarUrn(1);
-    // relationship model v1 should return false
     RelationshipFoo relationship = mockRelationshipFoo(expectedSource, expectedDestination);
-    boolean result = ModelUtils.isRelationshipInV2(relationship);
+    boolean result = ModelUtils.isRelationshipInV2(relationship.getClass());
     assertFalse(result);
 
-    // relationship model v2 should return true
-    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(expectedSource, expectedDestination);
-    result = ModelUtils.isRelationshipInV2(relationshipV2);
+    // test relationship model v2
+    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(expectedDestination);
+    result = ModelUtils.isRelationshipInV2(relationshipV2.getClass());
+    assertTrue(result);
+
+    // testing isRelationshipInV2(@Nonnull RecordDataSchema schema)
+    // test relationship model v1
+    result = ModelUtils.isRelationshipInV2(relationship.schema());
+    assertFalse(result);
+
+    // test relationship model v2
+    result = ModelUtils.isRelationshipInV2(relationshipV2.schema());
     assertTrue(result);
   }
 
@@ -898,9 +874,9 @@ public class ModelUtilsTest {
     return new RelationshipFoo().setSource(expectedSource).setDestination(expectedDestination);
   }
 
-  private RelationshipV2Bar mockRelationshipV2Bar(FooUrn expectedSource, BarUrn expectedDestination) {
-    RelationshipV2Bar.Source source = new RelationshipV2Bar().getSource().createWithSourceFoo(expectedSource);
-    RelationshipV2Bar.Destination destination = new RelationshipV2Bar().getDestination().createWithDestinationBar(expectedDestination);
-    return new RelationshipV2Bar().setSource(source).setDestination(destination);
+  private RelationshipV2Bar mockRelationshipV2Bar(BarUrn barUrn) {
+    RelationshipV2Bar.Destination destination = new RelationshipV2Bar.Destination();
+    destination.setDestinationBar(barUrn);
+    return new RelationshipV2Bar().setDestination(destination);
   }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -11,6 +11,7 @@ import com.linkedin.testing.AspectFooEvolved;
 import com.linkedin.testing.AspectUnionWithSoftDeletedAspect;
 import com.linkedin.testing.BarAsset;
 import com.linkedin.testing.BarUrnArray;
+import com.linkedin.testing.BazUrn;
 import com.linkedin.testing.DatasetInfo;
 import com.linkedin.testing.DeltaUnionAlias;
 import com.linkedin.testing.EntityAspectUnionAliasArray;
@@ -56,6 +57,7 @@ import com.linkedin.testing.EntitySnapshotOptionalFields;
 import com.linkedin.testing.InvalidAspectUnion;
 import com.linkedin.testing.RelationshipFoo;
 import com.linkedin.testing.RelationshipFooOptionalFields;
+import com.linkedin.testing.RelationshipV2Bar;
 import com.linkedin.testing.RelationshipUnion;
 import com.linkedin.testing.RelationshipUnionAlias;
 import com.linkedin.testing.SnapshotUnion;
@@ -834,5 +836,71 @@ public class ModelUtilsTest {
     } catch (Exception e) {
 
     }
+  }
+
+  @Test
+  public void testGetSourceUrnFromRelationship() {
+    assertEquals("a", "a");
+  }
+
+  @Test
+  public void testGetDestinationUrnFromRelationship() {
+    FooUrn expectedSource = makeFooUrn(1);
+    BarUrn expectedDestination = makeBarUrn(1);
+    // relationship model v1 should return false
+    RelationshipFoo relationship = mockRelationshipFoo(expectedSource, expectedDestination);
+    Urn result = ModelUtils.getDestinationUrnFromRelationship(relationship);
+    try {
+      assertEquals(result, Urn.createFromString("urn:li:bar:1"));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    // relationship model v2 should return true
+    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(expectedSource, expectedDestination);
+    result = ModelUtils.getDestinationUrnFromRelationship(relationshipV2);
+    try {
+      assertEquals(result, Urn.createFromString("urn:li:bar:1"));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testExtractFieldNameFromUnionField() {
+    FooUrn fooUrn = makeFooUrn(1);
+    BarUrn barUrn = makeBarUrn(1);
+    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(fooUrn, barUrn);
+
+    String sourceFieldName = ModelUtils.extractFieldNameFromUnionField(relationshipV2, "source");
+    assertEquals(sourceFieldName, "sourceFoo");
+
+    String destinationFieldName = ModelUtils.extractFieldNameFromUnionField(relationshipV2, "destination");
+    assertEquals(destinationFieldName, "destinationBar");
+  }
+
+  @Test
+  public void testIsRelationshipInV2() {
+    FooUrn expectedSource = makeFooUrn(1);
+    BarUrn expectedDestination = makeBarUrn(1);
+    // relationship model v1 should return false
+    RelationshipFoo relationship = mockRelationshipFoo(expectedSource, expectedDestination);
+    boolean result = ModelUtils.isRelationshipInV2(relationship);
+    assertFalse(result);
+
+    // relationship model v2 should return true
+    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(expectedSource, expectedDestination);
+    result = ModelUtils.isRelationshipInV2(relationshipV2);
+    assertTrue(result);
+  }
+
+  private RelationshipFoo mockRelationshipFoo(FooUrn expectedSource, BarUrn expectedDestination) {
+    return new RelationshipFoo().setSource(expectedSource).setDestination(expectedDestination);
+  }
+
+  private RelationshipV2Bar mockRelationshipV2Bar(FooUrn expectedSource, BarUrn expectedDestination) {
+    RelationshipV2Bar.Source source = new RelationshipV2Bar().getSource().createWithSourceFoo(expectedSource);
+    RelationshipV2Bar.Destination destination = new RelationshipV2Bar().getDestination().createWithDestinationBar(expectedDestination);
+    return new RelationshipV2Bar().setSource(source).setDestination(destination);
   }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -522,4 +522,14 @@ public class RecordUtilsTest {
     return RecordUtils.toRecordTemplate(AspectBaz.class,
         IOUtils.toString(ClassLoader.getSystemResourceAsStream(resourceName), StandardCharsets.UTF_8));
   }
+
+//  @Test
+//  public void testGetFieldNameFromUnionType() {
+//    AspectBaz baz = new AspectBaz();
+//    baz.setUnionField(new AspectBaz.UnionField());
+//    baz.getUnionField().setAspectFoo(new AspectFoo().setValue("foo"));
+//
+//    String tmpFieldName = RecordUtils.getFieldNameFromUnionType(baz, "unionField");
+//    assertEquals(tmpFieldName, "com.linkedin.testing.AspectFoo");
+//  }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -20,9 +20,11 @@ import com.linkedin.testing.EntitySnapshot;
 import com.linkedin.testing.EntityValueArray;
 import com.linkedin.testing.MixedRecord;
 import com.linkedin.testing.PizzaInfo;
+import com.linkedin.testing.RelationshipV2Bar;
 import com.linkedin.testing.StringUnion;
 import com.linkedin.testing.StringUnionArray;
 import com.linkedin.testing.singleaspectentity.EntityValue;
+import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.FooUrn;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -518,18 +520,23 @@ public class RecordUtilsTest {
     assertEquals(RecordUtils.capitalizeFirst(s), "");
   }
 
+  @Test
+  public void testExtractFieldNameFromUnionField() {
+    BarUrn barUrn = makeBarUrn(1);
+    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(barUrn);
+
+    String destinationFieldName = RecordUtils.extractFieldNameFromUnionField(relationshipV2, "destination");
+    assertEquals(destinationFieldName, "destinationBar");
+  }
+
   private AspectBaz loadAspectBaz(String resourceName) throws IOException {
     return RecordUtils.toRecordTemplate(AspectBaz.class,
         IOUtils.toString(ClassLoader.getSystemResourceAsStream(resourceName), StandardCharsets.UTF_8));
   }
 
-//  @Test
-//  public void testGetFieldNameFromUnionType() {
-//    AspectBaz baz = new AspectBaz();
-//    baz.setUnionField(new AspectBaz.UnionField());
-//    baz.getUnionField().setAspectFoo(new AspectFoo().setValue("foo"));
-//
-//    String tmpFieldName = RecordUtils.getFieldNameFromUnionType(baz, "unionField");
-//    assertEquals(tmpFieldName, "com.linkedin.testing.AspectFoo");
-//  }
+  private RelationshipV2Bar mockRelationshipV2Bar(BarUrn barUrn) {
+    RelationshipV2Bar.Destination destination = new RelationshipV2Bar.Destination();
+    destination.setDestinationBar(barUrn);
+    return new RelationshipV2Bar().setDestination(destination);
+  }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -539,4 +539,24 @@ public class RecordUtilsTest {
     destination.setDestinationBar(barUrn);
     return new RelationshipV2Bar().setDestination(destination);
   }
+
+  @Test
+  public void testExtractFieldValueFromUnionField() {
+    BarUrn barUrn = makeBarUrn(1);
+    RelationshipV2Bar relationshipV2 = mockRelationshipV2Bar(barUrn);
+
+    String destinationFieldValue = RecordUtils.extractFieldValueFromUnionField(relationshipV2, "destination");
+    assertEquals(destinationFieldValue, makeBarUrn(1).toString());
+  }
+
+  private AspectBaz loadAspectBaz(String resourceName) throws IOException {
+    return RecordUtils.toRecordTemplate(AspectBaz.class,
+        IOUtils.toString(ClassLoader.getSystemResourceAsStream(resourceName), StandardCharsets.UTF_8));
+  }
+
+  private RelationshipV2Bar mockRelationshipV2Bar(BarUrn barUrn) {
+    RelationshipV2Bar.Destination destination = new RelationshipV2Bar.Destination();
+    destination.setDestinationBar(barUrn);
+    return new RelationshipV2Bar().setDestination(destination);
+  }
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectWithRelationship.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectWithRelationship.pdl
@@ -1,0 +1,18 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+@gma.aspect.column.name = "aspectwithrelationship"
+record AspectWithRelationship {
+
+  /**
+   * For unit tests
+   */
+  value: string
+
+  /**
+   * Relationship field for unit tests
+   */
+  testRelationship: RelationshipV2Bar
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/AssetWithRelationship.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/AssetWithRelationship.pdl
@@ -14,5 +14,5 @@ record AssetWithRelationship {
   /**
    * For unit tests
    */
-  aspect_with_relationship: AspectWithRelationship
+  aspectWithRelationship: AspectWithRelationship
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/AssetWithRelationship.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/AssetWithRelationship.pdl
@@ -1,0 +1,18 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.Urn
+
+/**
+ * For unit tests
+ */
+record AssetWithRelationship {
+  /**
+   * For unit tests
+   */
+  urn: optional FooUrn
+
+  /**
+   * For unit tests
+   */
+  aspect_with_relationship: AspectWithRelationship
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/RelationshipV2Bar.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/RelationshipV2Bar.pdl
@@ -1,0 +1,28 @@
+namespace com.linkedin.testing
+
+import com.linkedin.common.AuditStamp
+
+/**
+ * * Test Relationship
+ */
+record RelationshipV2Bar {
+
+  /**
+   * The audit stamp of the relationship
+   */
+  auditStamp: optional AuditStamp
+
+  /**
+   * Urn of the source asset
+   */
+  source: optional union[
+    sourceFoo: FooUrn
+  ]
+
+  /**
+   * Urn of the destination asset
+   */
+  destination: optional union[
+    destinationBar: BarUrn
+  ]
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/RelationshipV2Bar.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/RelationshipV2Bar.pdl
@@ -10,19 +10,12 @@ record RelationshipV2Bar {
   /**
    * The audit stamp of the relationship
    */
-  auditStamp: optional AuditStamp
-
-  /**
-   * Urn of the source asset
-   */
-  source: optional union[
-    sourceFoo: FooUrn
-  ]
+  auditStamp: AuditStamp
 
   /**
    * Urn of the destination asset
    */
-  destination: optional union[
+  destination: union[
     destinationBar: BarUrn
   ]
 }

--- a/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -97,6 +97,18 @@ public final class ValidationUtils {
   }
 
   /**
+   * Similar to {@link #isValidUrnField(RecordDataSchema.Field, String)} but with a fixed field "urn".
+   */
+  public static boolean isValidUrnField(@Nonnull RecordDataSchema.Field field) {
+    return isValidUrnField(field, "urn");
+  }
+
+  public static boolean isValidUnionField(@Nonnull RecordDataSchema.Field field, @Nonnull String fieldName) {
+    return field.getName().equals(fieldName)
+        && field.getType().getType() == DataSchema.Type.UNION;
+  }
+
+  /**
    * Returns the Java class for an URN typeref field.
    */
   public static Class<Urn> getUrnClass(@Nonnull RecordDataSchema.Field field) {
@@ -108,13 +120,6 @@ public final class ValidationUtils {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  /**
-   * Similar to {@link #isValidUrnField(RecordDataSchema.Field, String)} but with a fixed field "urn".
-   */
-  public static boolean isValidUrnField(@Nonnull RecordDataSchema.Field field) {
-    return isValidUrnField(field, "urn");
   }
 
   /**

--- a/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -103,6 +103,9 @@ public final class ValidationUtils {
     return isValidUrnField(field, "urn");
   }
 
+  /**
+   * Returns true if the passed-in field matches the field name and is of UNION type.
+   */
   public static boolean isValidUnionField(@Nonnull RecordDataSchema.Field field, @Nonnull String fieldName) {
     return field.getName().equals(fieldName)
         && field.getType().getType() == DataSchema.Type.UNION;


### PR DESCRIPTION
## Summary
This PR is to ensure the EbeanLocalWriterDAO can support both relationship V1 and relationship V2.
The changes are in Schema Validation for Relationship v2, RecordUtils, ModelUtils, and GraphUtils.

Question though is `checkSameUrn` logic in GraphUtils.java. They are related to the removal option, and for some options, they check for source Urn. But in Relationship model v2, there is no source field. Should it just skip the check for source field for V2, or should it look at the belonging aspect to find the source Urn? I feel looking at belonging aspect can have problems too because one relationship can be included in multiple different aspects.

## Testing Done
Unit test cases added.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
