### PR TITLE
feat(relationship 2.0): use REMOVE_ALL_EDGES_FROM_SOURCE by default for ingesting 2.0 relationships

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -896,8 +896,13 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       List<List<RELATIONSHIP>> allRelationships = EBeanDAOUtils.extractRelationshipsFromAspect(aspect);
       localRelationshipUpdates = allRelationships.stream()
           .filter(relationships -> !relationships.isEmpty()) // ensure at least 1 relationship in sublist to avoid index out of bounds
-          .map(relationships -> new BaseLocalRelationshipBuilder.LocalRelationshipUpdates(
-              relationships, relationships.get(0).getClass(), BaseGraphWriterDAO.RemovalOption.REMOVE_NONE))
+          .map(relationships -> {
+            for (RELATIONSHIP relationship : relationships) {
+              validateRelationshipSource(urn, relationship); // validate that all relationships' sources are equal to the given asset urn
+            }
+            return new BaseLocalRelationshipBuilder.LocalRelationshipUpdates(
+              relationships, relationships.get(0).getClass(), BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE);
+          })
           .collect(Collectors.toList());
     } else if (_relationshipSource == RelationshipSource.RELATIONSHIP_BUILDERS) {
       if (_localRelationshipBuilderRegistry != null && _localRelationshipBuilderRegistry.isRegistered(aspectClass)) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -8,7 +8,6 @@ import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.UnionTemplate;
-import com.linkedin.metadata.dao.builder.BaseLocalRelationshipBuilder;
 import com.linkedin.metadata.dao.builder.BaseLocalRelationshipBuilder.LocalRelationshipUpdates;
 import com.linkedin.metadata.dao.builder.LocalRelationshipBuilderRegistry;
 import com.linkedin.metadata.dao.exception.ModelConversionException;
@@ -18,10 +17,10 @@ import com.linkedin.metadata.dao.producer.BaseMetadataEventProducer;
 import com.linkedin.metadata.dao.producer.BaseTrackingMetadataEventProducer;
 import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
-import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
-import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.storage.LocalDAOStorageConfig;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
+import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
+import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
 import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.dao.utils.QueryUtils;
@@ -896,13 +895,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       List<List<RELATIONSHIP>> allRelationships = EBeanDAOUtils.extractRelationshipsFromAspect(aspect);
       localRelationshipUpdates = allRelationships.stream()
           .filter(relationships -> !relationships.isEmpty()) // ensure at least 1 relationship in sublist to avoid index out of bounds
-          .map(relationships -> {
-            for (RELATIONSHIP relationship : relationships) {
-              validateRelationshipSource(urn, relationship); // validate that all relationships' sources are equal to the given asset urn
-            }
-            return new BaseLocalRelationshipBuilder.LocalRelationshipUpdates(
-              relationships, relationships.get(0).getClass(), BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE);
-          })
+          .map(relationships -> new LocalRelationshipUpdates(
+            relationships, relationships.get(0).getClass(), BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE))
           .collect(Collectors.toList());
     } else if (_relationshipSource == RelationshipSource.RELATIONSHIP_BUILDERS) {
       if (_localRelationshipBuilderRegistry != null && _localRelationshipBuilderRegistry.isRegistered(aspectClass)) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -44,6 +44,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import static com.linkedin.metadata.annotations.GmaAnnotationParser.*;
+import static com.linkedin.metadata.dao.utils.ModelUtils.*;
 
 
 /**
@@ -373,6 +374,21 @@ public class EBeanDAOUtils {
         .setField(field)
         .setValue(localRelationshipValue)
         .setCondition(condition);
+  }
+
+  /**
+   * Validate that the source of a relationship matches the asset urn that the relationship was derived from. Relationships
+   * must be defined such that the source is always the asset urn of the aspect the relationship is included in.
+   * @param assetUrn urn of the asset to be ingested
+   * @param relationship relationship derived from the aspect to be ingested
+   * @throws IllegalArgumentException if the asset urn and the relationship source urn don't match
+   */
+  public static <URN, RELATIONSHIP extends RecordTemplate> void validateRelationshipSource(URN assetUrn, RELATIONSHIP relationship) {
+    Urn sourceUrn = getSourceUrnFromRelationship(relationship);
+    if (!sourceUrn.equals(assetUrn)) {
+      throw new IllegalArgumentException(String.format("The asset from which a relationship is derived from must be the source of the relationship. "
+          + "Relationship class: %s, Expected source urn: %s, Actual source urn: %s", relationship.getClass().getCanonicalName(), assetUrn, sourceUrn));
+    }
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -44,7 +44,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import static com.linkedin.metadata.annotations.GmaAnnotationParser.*;
-import static com.linkedin.metadata.dao.utils.ModelUtils.*;
 
 
 /**
@@ -374,21 +373,6 @@ public class EBeanDAOUtils {
         .setField(field)
         .setValue(localRelationshipValue)
         .setCondition(condition);
-  }
-
-  /**
-   * Validate that the source of a relationship matches the asset urn that the relationship was derived from. Relationships
-   * must be defined such that the source is always the asset urn of the aspect the relationship is included in.
-   * @param assetUrn urn of the asset to be ingested
-   * @param relationship relationship derived from the aspect to be ingested
-   * @throws IllegalArgumentException if the asset urn and the relationship source urn don't match
-   */
-  public static <URN, RELATIONSHIP extends RecordTemplate> void validateRelationshipSource(URN assetUrn, RELATIONSHIP relationship) {
-    Urn sourceUrn = getSourceUrnFromRelationship(relationship);
-    if (!sourceUrn.equals(assetUrn)) {
-      throw new IllegalArgumentException(String.format("The asset from which a relationship is derived from must be the source of the relationship. "
-          + "Relationship class: %s, Expected source urn: %s, Actual source urn: %s", relationship.getClass().getCanonicalName(), assetUrn, sourceUrn));
-    }
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -42,8 +42,8 @@ public class EbeanLocalRelationshipWriterDAOTest {
 
   @Test
   public void testAddRelationshipWithRemoveAllEdgesToDestination() throws URISyntaxException {
-    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_belongsto", "urn:li:bar:000",
-        "bar", "urn:li:foo:123", "foo")));
+    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_belongsto", "urn:li:foo:123",
+        "foo", "urn:li:bar:000", "bar")));
 
     AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(
         BarUrn.createFromString("urn:li:bar:123"),
@@ -54,7 +54,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
         .buildRelationships(FooUrn.createFromString("urn:li:foo:123"), aspectFooBar);
 
     // Before processing
-    List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_belongsto where source='urn:li:bar:000'").findList();
+    List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_belongsto where destination='urn:li:bar:000'").findList();
     assertEquals(before.size(), 1);
 
     _localRelationshipWriterDAO.processLocalRelationshipUpdates(FooUrn.createFromString("urn:li:foo:123"), updates, false);
@@ -67,7 +67,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
     assertEquals(softDeleted.size(), 1); // 1 soft deleted edge
 
     List<SqlRow> newEdges = _server.createSqlQuery(
-        "select * from metadata_relationship_belongsto where destination='urn:li:foo:123' and deleted_ts IS NULL").findList();
+        "select * from metadata_relationship_belongsto where source='urn:li:foo:123' and deleted_ts IS NULL").findList();
 
     assertEquals(newEdges.size(), 3); // 3 new edges added.
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/builder/BelongsToLocalRelationshipBuilder.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/builder/BelongsToLocalRelationshipBuilder.java
@@ -21,12 +21,12 @@ public class BelongsToLocalRelationshipBuilder extends BaseLocalRelationshipBuil
       @Nonnull AspectFooBar aspectFooBar) {
     List<BelongsTo> belongsToRelationships = new ArrayList<>();
     for (Urn barUrn : aspectFooBar.getBars()) {
-      belongsToRelationships.add(new BelongsTo().setSource(barUrn).setDestination(urn));
+      belongsToRelationships.add(new BelongsTo().setSource(urn).setDestination(barUrn));
     }
 
     LocalRelationshipUpdates localRelationshipUpdates =
         new LocalRelationshipUpdates(belongsToRelationships, BelongsTo.class,
-            BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_TO_DESTINATION);
+            BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE);
 
     return Collections.singletonList(localRelationshipUpdates);
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -24,6 +24,8 @@ import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.AnnotatedAspectFooWithRelationshipField;
 import com.linkedin.testing.CommonAspect;
 import com.linkedin.testing.CommonAspectArray;
+import com.linkedin.testing.localrelationship.BelongsTo;
+import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
@@ -640,5 +642,24 @@ public class EBeanDAOUtilsTest {
     assertEquals(new AnnotatedRelationshipBar(), results.get(2).get(0));
   }
 
+  @Test
+  public void testValidateRelationshipSourceSuccess() throws URISyntaxException {
+    FooUrn assetUrn = FooUrn.createFromString("urn:li:foo:1");
+    BarUrn destUrn = BarUrn.createFromString("urn:li:bar:1");
+    BelongsTo belongsTo = new BelongsTo().setSource(assetUrn).setDestination(destUrn);
+    try {
+      EBeanDAOUtils.validateRelationshipSource(assetUrn, belongsTo);
+    } catch (IllegalArgumentException e) {
+      org.testng.Assert.fail("Test should not throw an exception", e);
+    }
+  }
 
+  @Test
+  public void testValidateRelationshipSourceFail() throws URISyntaxException {
+    FooUrn assetUrn = FooUrn.createFromString("urn:li:foo:1");
+    FooUrn sourceUrn = FooUrn.createFromString("urn:li:foo:2");
+    BarUrn destUrn = BarUrn.createFromString("urn:li:bar:1");
+    BelongsTo belongsTo = new BelongsTo().setSource(sourceUrn).setDestination(destUrn);
+    org.testng.Assert.assertThrows(() -> EBeanDAOUtils.validateRelationshipSource(assetUrn, belongsTo));
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -16,16 +16,14 @@ import com.linkedin.metadata.query.LocalRelationshipValue;
 import com.linkedin.metadata.query.RelationshipField;
 import com.linkedin.metadata.query.UrnField;
 import com.linkedin.testing.AnnotatedAspectBarWithRelationshipFields;
+import com.linkedin.testing.AnnotatedAspectFooWithRelationshipField;
 import com.linkedin.testing.AnnotatedRelationshipBar;
 import com.linkedin.testing.AnnotatedRelationshipBarArray;
 import com.linkedin.testing.AnnotatedRelationshipFoo;
 import com.linkedin.testing.AnnotatedRelationshipFooArray;
 import com.linkedin.testing.AspectFoo;
-import com.linkedin.testing.AnnotatedAspectFooWithRelationshipField;
 import com.linkedin.testing.CommonAspect;
 import com.linkedin.testing.CommonAspectArray;
-import com.linkedin.testing.localrelationship.BelongsTo;
-import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
@@ -640,26 +638,5 @@ public class EBeanDAOUtilsTest {
     assertEquals(new AnnotatedRelationshipFoo(), results.get(1).get(0));
     assertEquals(new AnnotatedRelationshipFoo(), results.get(1).get(1));
     assertEquals(new AnnotatedRelationshipBar(), results.get(2).get(0));
-  }
-
-  @Test
-  public void testValidateRelationshipSourceSuccess() throws URISyntaxException {
-    FooUrn assetUrn = FooUrn.createFromString("urn:li:foo:1");
-    BarUrn destUrn = BarUrn.createFromString("urn:li:bar:1");
-    BelongsTo belongsTo = new BelongsTo().setSource(assetUrn).setDestination(destUrn);
-    try {
-      EBeanDAOUtils.validateRelationshipSource(assetUrn, belongsTo);
-    } catch (IllegalArgumentException e) {
-      org.testng.Assert.fail("Test should not throw an exception", e);
-    }
-  }
-
-  @Test
-  public void testValidateRelationshipSourceFail() throws URISyntaxException {
-    FooUrn assetUrn = FooUrn.createFromString("urn:li:foo:1");
-    FooUrn sourceUrn = FooUrn.createFromString("urn:li:foo:2");
-    BarUrn destUrn = BarUrn.createFromString("urn:li:bar:1");
-    BelongsTo belongsTo = new BelongsTo().setSource(sourceUrn).setDestination(destUrn);
-    org.testng.Assert.assertThrows(() -> EBeanDAOUtils.validateRelationshipSource(assetUrn, belongsTo));
   }
 }


### PR DESCRIPTION

## Summary
In Model 1.0, when new relationships are ingested, existing relationships are handled (i.e. removed) according to user-defined removal options. There are 4 possible options:
1) REMOVE_NONE
2) REMOVE_ALL_EDGES_FROM_SOURCE
3) REMOVE_ALL_EDGES_TO_DESTINATION
4) REMOVE_EDGES_FROM_SOURCE_TO_DESTINATION

1. has no use cases and will no longer be supported.
2. will be the default
3. will no longer be supported. in 2.0, relationships must always be modeled such that the asset they are derived from is the source in the relationship.
4. has use cases in AIM but moving forward, it will be up to the user to replicate these now "non-default" behaviors via pre-ingestion lambdas. Essentially, whatever the user provides to us in the aspect model, we will ingest using REMOVE_ALL_EDGES_FROM_SOURCE behavior.

## Testing Done
adjusted some unit tests
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
