### PR TITLE
add support for recursively set default value in test mode

### DIFF
--- a/dao-api/build.gradle
+++ b/dao-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   compile externalDependency.reflections
   compile externalDependency.commonsLang
   implementation 'com.google.protobuf:protobuf-java:3.21.1'
+  implementation spec.product.pegasus.restliServer
   dataModel project(':core-models')
   dataModel project(':validators')
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -81,7 +81,7 @@ public class RecordUtils {
 
   /**
    * Serializes a {@link RecordTemplate} to JSON string.
-   *Also take test mode as input to control the default value fill in strategy
+   * Also take test mode as input to control the default value fill in strategy
    * @param recordTemplate the record template to serialize
    * @return the JSON string serialized using {@link JacksonDataTemplateCodec}.
    */

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -13,6 +13,7 @@ import com.linkedin.testing.AspectBaz;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.AspectBarArray;
 import com.linkedin.testing.AspectFooArray;
+import com.linkedin.testing.AspectWithDefaultValue;
 import com.linkedin.testing.EntityAspectUnion;
 import com.linkedin.testing.EntityAspectUnionAlias;
 import com.linkedin.testing.EntityAspectUnionComplex;
@@ -49,6 +50,17 @@ public class RecordUtilsTest {
         loadJsonFromResource("foo.json").replaceAll("\\s+", "").replaceAll("\\n", "").replaceAll("\\r", "");
 
     String actual = RecordUtils.toJsonString(foo);
+
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void testToJsonStringWithDefault() throws IOException {
+    AspectWithDefaultValue defaultValueAspect = new AspectWithDefaultValue();
+    String expected =
+        loadJsonFromResource("defaultValueAspect.json").replaceAll("\\s+", "").replaceAll("\\n", "").replaceAll("\\r", "");
+
+    String actual = RecordUtils.toJsonString(defaultValueAspect, true);
 
     assertEquals(actual, expected);
   }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -23,6 +23,7 @@ import com.linkedin.testing.MixedRecord;
 import com.linkedin.testing.PizzaInfo;
 import com.linkedin.testing.StringUnion;
 import com.linkedin.testing.StringUnionArray;
+import com.linkedin.testing.MapValueRecord;
 import com.linkedin.testing.singleaspectentity.EntityValue;
 import com.linkedin.testing.urn.FooUrn;
 import java.io.IOException;
@@ -56,7 +57,7 @@ public class RecordUtilsTest {
 
   @Test
   public void testToJsonStringWithDefault() throws IOException {
-    AspectWithDefaultValue defaultValueAspect = new AspectWithDefaultValue();
+    AspectWithDefaultValue defaultValueAspect = new AspectWithDefaultValue().setNestedValueWithDefault(new MapValueRecord());
     String expected =
         loadJsonFromResource("defaultValueAspect.json").replaceAll("\\s+", "").replaceAll("\\n", "").replaceAll("\\r", "");
 

--- a/dao-api/src/test/resources/defaultValueAspect.json
+++ b/dao-api/src/test/resources/defaultValueAspect.json
@@ -1,3 +1,6 @@
 {
+  "nestedValueWithDefault":{
+    "mapValueWithDefaultmap":{}
+  },
   "valueWithDefault": ""
 }

--- a/dao-api/src/test/resources/defaultValueAspect.json
+++ b/dao-api/src/test/resources/defaultValueAspect.json
@@ -1,0 +1,3 @@
+{
+  "valueWithDefault": ""
+}

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -138,7 +138,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     }
 
     AuditedAspect auditedAspect = new AuditedAspect()
-        .setAspect(RecordUtils.toJsonString(newValue))
+        .setAspect(RecordUtils.toJsonString(newValue, isTestMode))
         .setCanonicalName(aspectClass.getCanonicalName())
         .setLastmodifiedby(actor)
         .setLastmodifiedon(new Timestamp(timestamp).toString())

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectWithDefaultValue.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectWithDefaultValue.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.testing
+
+record AspectWithDefaultValue {
+
+  /**
+   * For unit tests
+   */
+  valueWithDefault: string = ""
+}

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectWithDefaultValue.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/AspectWithDefaultValue.pdl
@@ -6,4 +6,5 @@ record AspectWithDefaultValue {
    * For unit tests
    */
   valueWithDefault: string = ""
+  nestedValueWithDefault: record MapValueRecord {mapValueWithDefaultmap: map[string, string] = { }}
 }


### PR DESCRIPTION
## Summary
Add support for recursively set default value in test mode
## Testing Done
Add unit test
Also this only change the behavior for test mode, will not affect the prod behavior at all
snapshot the version and deploy to local to make sure it works, but it won't change the data for things that already set to empty. 
## Checklist

- [X ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
