### PR TITLE
Remove duplicate code in RecordUtilsTest.java

### DIFF
--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -542,17 +542,6 @@ public class RecordUtilsTest {
     assertEquals(destinationFieldName, "destinationBar");
   }
 
-  private AspectBaz loadAspectBaz(String resourceName) throws IOException {
-    return RecordUtils.toRecordTemplate(AspectBaz.class,
-        IOUtils.toString(ClassLoader.getSystemResourceAsStream(resourceName), StandardCharsets.UTF_8));
-  }
-
-  private RelationshipV2Bar mockRelationshipV2Bar(BarUrn barUrn) {
-    RelationshipV2Bar.Destination destination = new RelationshipV2Bar.Destination();
-    destination.setDestinationBar(barUrn);
-    return new RelationshipV2Bar().setDestination(destination);
-  }
-
   @Test
   public void testExtractFieldValueFromUnionField() {
     BarUrn barUrn = makeBarUrn(1);


### PR DESCRIPTION
## Summary
In the previous PR, pushed in duplicate code in [RecordUtilsTest.java](https://github.com/linkedin/datahub-gma/blob/master/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java#L545) and caused build error https://github.com/linkedin/datahub-gma/actions/runs/11691202669/job/32557830316

This PR is to remove the duplicate `loadAspectBaz` and `mockRelationshipV2Bar`, and to fix the build issue.

## Testing Done
```
./gradlew build
...

BUILD SUCCESSFUL in 1m 24s
245 actionable tasks: 25 executed, 220 up-to-date
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
