### PR TITLE
feat: add dual source mode for addRelationship processing

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -951,7 +951,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param updatesBuiltFromRelationshipBuilders LocalRelationshipUpdates built from relationship builders
    * @return true if there is no conflict, false otherwise
    */
-  private boolean areConsistentLocalRelationshipUpdates(List<LocalRelationshipUpdates> updatesExtractedFromAspect, List<LocalRelationshipUpdates> updatesBuiltFromRelationshipBuilders) {
+  private boolean areConsistentLocalRelationshipUpdates(List<LocalRelationshipUpdates> updatesExtractedFromAspect,
+      List<LocalRelationshipUpdates> updatesBuiltFromRelationshipBuilders) {
     if (updatesExtractedFromAspect.isEmpty() || updatesBuiltFromRelationshipBuilders.isEmpty()) {
       return true;
     }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -63,7 +63,6 @@ import com.linkedin.testing.EntityAspectUnion;
 import com.linkedin.testing.FooSnapshot;
 import com.linkedin.testing.MixedRecord;
 import com.linkedin.testing.localrelationship.AspectFooBar;
-import com.linkedin.testing.localrelationship.AspectFooBarBaz;
 import com.linkedin.testing.localrelationship.BelongsTo;
 import com.linkedin.testing.localrelationship.BelongsToV2;
 import com.linkedin.testing.localrelationship.BelongsToV2Array;

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -63,7 +63,6 @@ import com.linkedin.testing.EntityAspectUnion;
 import com.linkedin.testing.FooSnapshot;
 import com.linkedin.testing.MixedRecord;
 import com.linkedin.testing.localrelationship.AspectFooBar;
-import com.linkedin.testing.localrelationship.AspectFooBarBaz;
 import com.linkedin.testing.localrelationship.BelongsTo;
 import com.linkedin.testing.localrelationship.BelongsToV2;
 import com.linkedin.testing.localrelationship.BelongsToV2Array;
@@ -2567,13 +2566,6 @@ public class EbeanLocalDAOTest {
     barDao.add(barUrn1, new AspectFoo().setValue("1"), auditStamp);
     barDao.add(barUrn2, new AspectFoo().setValue("2"), auditStamp);
     barDao.add(barUrn3, new AspectFoo().setValue("3"), auditStamp);
-
-    // add another aspect (AspectFooBarBaz) which includes BelongsTo relationship(s)
-    BarUrn barUrn4 = BarUrn.createFromString("urn:li:bar:4");
-    BelongsToV2 belongsTo4 = new BelongsToV2().setSource(barUrn4).setDestination(fooUrn);
-    AspectFooBarBaz aspectFooBarBaz = new AspectFooBarBaz().setBars(new BarUrnArray(barUrn4)).setBelongsTos(new BelongsToV2Array(belongsTo4));
-    fooDao.add(fooUrn, aspectFooBarBaz, auditStamp);
-    barDao.add(barUrn4, new AspectFoo().setValue("4"), auditStamp);
 
     // Verify local relationships and entities are added.
     EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -64,7 +64,8 @@ import com.linkedin.testing.FooSnapshot;
 import com.linkedin.testing.MixedRecord;
 import com.linkedin.testing.localrelationship.AspectFooBar;
 import com.linkedin.testing.localrelationship.BelongsTo;
-import com.linkedin.testing.localrelationship.BelongsToArray;
+import com.linkedin.testing.localrelationship.BelongsToV2;
+import com.linkedin.testing.localrelationship.BelongsToV2Array;
 import com.linkedin.testing.localrelationship.ReportsTo;
 import com.linkedin.testing.localrelationship.ReportsToArray;
 import com.linkedin.testing.urn.BarUrn;
@@ -2548,12 +2549,13 @@ public class EbeanLocalDAOTest {
     // add an aspect (AspectFooBar) which includes BelongsTo relationships and ReportsTo relationships
     FooUrn fooUrn = makeFooUrn(1);
     BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
-    BelongsTo belongsTo1 = new BelongsTo().setSource(fooUrn).setDestination(barUrn1);
+
+    BelongsToV2 belongsTo1 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn1);
     BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
-    BelongsTo belongsTo2 = new BelongsTo().setSource(fooUrn).setDestination(barUrn2);
+    BelongsToV2 belongsTo2 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn2);
     BarUrn barUrn3 = BarUrn.createFromString("urn:li:bar:3");
-    BelongsTo belongsTo3 = new BelongsTo().setSource(fooUrn).setDestination(barUrn3);
-    BelongsToArray belongsToArray = new BelongsToArray(belongsTo1, belongsTo2, belongsTo3);
+    BelongsToV2 belongsTo3 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn3);
+    BelongsToV2Array belongsToArray = new BelongsToV2Array(belongsTo1, belongsTo2, belongsTo3);
     ReportsTo reportsTo = new ReportsTo().setSource(fooUrn).setDestination(barUrn1);
     ReportsToArray reportsToArray = new ReportsToArray(reportsTo);
     AspectFooBar aspectFooBar = new AspectFooBar()
@@ -2565,13 +2567,20 @@ public class EbeanLocalDAOTest {
     barDao.add(barUrn2, new AspectFoo().setValue("2"), auditStamp);
     barDao.add(barUrn3, new AspectFoo().setValue("3"), auditStamp);
 
+    // add another aspect (AspectFooBarBaz) which includes BelongsTo relationship(s)
+    BarUrn barUrn4 = BarUrn.createFromString("urn:li:bar:4");
+    BelongsToV2 belongsTo4 = new BelongsToV2().setSource(barUrn4).setDestination(fooUrn);
+    AspectFooBarBaz aspectFooBarBaz = new AspectFooBarBaz().setBars(new BarUrnArray(barUrn4)).setBelongsTos(new BelongsToV2Array(belongsTo4));
+    fooDao.add(fooUrn, aspectFooBarBaz, auditStamp);
+    barDao.add(barUrn4, new AspectFoo().setValue("4"), auditStamp);
+
     // Verify local relationships and entities are added.
     EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);
     ebeanLocalRelationshipQueryDAO.setSchemaConfig(_schemaConfig);
 
-    List<BelongsTo> resultBelongsTos =
+    List<BelongsToV2> resultBelongsTos =
         ebeanLocalRelationshipQueryDAO.findRelationships(FooSnapshot.class, EMPTY_FILTER, BarSnapshot.class,
-            EMPTY_FILTER, BelongsTo.class, OUTGOING_FILTER, 0, 10);
+            EMPTY_FILTER, BelongsToV2.class, OUTGOING_FILTER, 0, 10);
 
     assertEquals(resultBelongsTos.size(), 3);
 
@@ -2591,7 +2600,7 @@ public class EbeanLocalDAOTest {
 
     // check that the belongsTo relationships 1, 2, & 3 were soft deleted
     resultBelongsTos = ebeanLocalRelationshipQueryDAO.findRelationships(FooSnapshot.class, EMPTY_FILTER, BarSnapshot.class,
-            EMPTY_FILTER, BelongsTo.class, OUTGOING_FILTER, 0, 10);
+            EMPTY_FILTER, BelongsToV2.class, OUTGOING_FILTER, 0, 10);
 
     // check that the reportsTo relationship was soft deleted
     resultReportsTos =
@@ -3141,12 +3150,13 @@ public class EbeanLocalDAOTest {
 
     FooUrn fooUrn = makeFooUrn(1);
     BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
-    BelongsTo belongsTo1 = new BelongsTo().setSource(fooUrn).setDestination(barUrn1);
+
+    BelongsToV2 belongsTo1 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn1);
     BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
-    BelongsTo belongsTo2 = new BelongsTo().setSource(fooUrn).setDestination(barUrn2);
+    BelongsToV2 belongsTo2 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn2);
     BarUrn barUrn3 = BarUrn.createFromString("urn:li:bar:3");
-    BelongsTo belongsTo3 = new BelongsTo().setSource(fooUrn).setDestination(barUrn3);
-    BelongsToArray belongsToArray = new BelongsToArray(belongsTo1, belongsTo2, belongsTo3);
+    BelongsToV2 belongsTo3 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn3);
+    BelongsToV2Array belongsToArray = new BelongsToV2Array(belongsTo1, belongsTo2, belongsTo3);
     AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(barUrn1, barUrn2, barUrn3)).setBelongsTos(belongsToArray);
     AuditStamp auditStamp = makeAuditStamp("foo", System.currentTimeMillis());
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -63,6 +63,7 @@ import com.linkedin.testing.EntityAspectUnion;
 import com.linkedin.testing.FooSnapshot;
 import com.linkedin.testing.MixedRecord;
 import com.linkedin.testing.localrelationship.AspectFooBar;
+import com.linkedin.testing.localrelationship.AspectFooBarBaz;
 import com.linkedin.testing.localrelationship.BelongsTo;
 import com.linkedin.testing.localrelationship.BelongsToV2;
 import com.linkedin.testing.localrelationship.BelongsToV2Array;
@@ -3150,7 +3151,6 @@ public class EbeanLocalDAOTest {
 
     FooUrn fooUrn = makeFooUrn(1);
     BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
-
     BelongsToV2 belongsTo1 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn1);
     BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
     BelongsToV2 belongsTo2 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn2);
@@ -3170,7 +3170,7 @@ public class EbeanLocalDAOTest {
     ebeanLocalRelationshipQueryDAO.setSchemaConfig(_schemaConfig);
 
     List<BelongsToV2> relationships =
-        ebeanLocalRelationshipQueryDAO.findRelationships(BarSnapshot.class, EMPTY_FILTER, FooSnapshot.class,
+        ebeanLocalRelationshipQueryDAO.findRelationships(FooSnapshot.class, EMPTY_FILTER, BarSnapshot.class,
             EMPTY_FILTER, BelongsToV2.class, OUTGOING_FILTER, 0, 10);
 
     AspectKey<FooUrn, AspectFooBar> key = new AspectKey<>(AspectFooBar.class, fooUrn, 0L);
@@ -3191,11 +3191,11 @@ public class EbeanLocalDAOTest {
 
     FooUrn fooUrn = makeFooUrn(1);
     BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
-    BelongsToV2 belongsTo1 = new BelongsToV2().setSource(barUrn1).setDestination(fooUrn);
+    BelongsToV2 belongsTo1 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn1);
     BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
-    BelongsToV2 belongsTo2 = new BelongsToV2().setSource(barUrn2).setDestination(fooUrn);
+    BelongsToV2 belongsTo2 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn2);
     BarUrn barUrn3 = BarUrn.createFromString("urn:li:bar:3");
-    BelongsToV2 belongsTo3 = new BelongsToV2().setSource(barUrn3).setDestination(fooUrn);
+    BelongsToV2 belongsTo3 = new BelongsToV2().setSource(fooUrn).setDestination(barUrn3);
     BelongsToV2Array belongsToArray = new BelongsToV2Array(belongsTo1, belongsTo2, belongsTo3);
 
     AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(barUrn1, barUrn2, barUrn3)).setBelongsTos(belongsToArray);
@@ -3223,7 +3223,7 @@ public class EbeanLocalDAOTest {
 
     // verify 3 BelongsToV2
     List<BelongsToV2> relationshipsV2 =
-        ebeanLocalRelationshipQueryDAO.findRelationships(BarSnapshot.class, EMPTY_FILTER, FooSnapshot.class,
+        ebeanLocalRelationshipQueryDAO.findRelationships(FooSnapshot.class, EMPTY_FILTER, BarSnapshot.class,
             EMPTY_FILTER, BelongsToV2.class, OUTGOING_FILTER, 0, 10);
 
     assertEquals(relationshipsV2.size(), 3);

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS metadata_aspect;
 DROP TABLE IF EXISTS metadata_id;
 DROP TABLE IF EXISTS metadata_index;
 DROP TABLE IF EXISTS metadata_relationship_belongsto;
+DROP TABLE IF EXISTS metadata_relationship_belongstov2;
 
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (
@@ -44,6 +45,19 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata LONGTEXT NOT NULL,
     source VARCHAR(1000) NOT NULL,

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS metadata_aspect;
 DROP TABLE IF EXISTS metadata_id;
 DROP TABLE IF EXISTS metadata_index;
 DROP TABLE IF EXISTS metadata_relationship_belongsto;
+DROP TABLE IF EXISTS metadata_relationship_belongstov2;
 
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (
@@ -44,6 +45,19 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
 );
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata LONGTEXT NOT NULL,
     source VARCHAR(1000) NOT NULL,

--- a/dao-impl/ebean-dao/src/test/resources/gma-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/gma-create-all.sql
@@ -44,6 +44,19 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     PRIMARY KEY (id)
 );
 
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(500) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(500) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon DATETIME(6) NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
 CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata JSON NOT NULL,

--- a/dao-impl/ebean-dao/src/test/resources/gma-drop-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/gma-drop-all.sql
@@ -6,4 +6,6 @@ drop table if exists metadata_index;
 
 drop table if exists metadata_relationship_belongsto;
 
+drop table if exists metadata_relationship_belongstov2;
+
 drop table if exists metadata_relationship_reportsto;

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AspectFooBar.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AspectFooBar.pdl
@@ -5,6 +5,6 @@ import com.linkedin.testing.BarUrn
 @gma.aspect.column.name = "aspectfoobar"
 record AspectFooBar {
   bars: array[BarUrn]
-  belongsTos: optional array[BelongsTo]
+  belongsTos: optional array[BelongsToV2]
   reportsTos: optional array[ReportsTo]
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AspectFooBarBaz.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AspectFooBarBaz.pdl
@@ -5,5 +5,5 @@ import com.linkedin.testing.BarUrn
 @gma.aspect.column.name = "aspectfoobarbaz"
 record AspectFooBarBaz {
   bars: array[BarUrn]
-  belongsTos: optional array[BelongsTo]
+  belongsTos: optional array[BelongsToV2]
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/BelongsToV2.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/BelongsToV2.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.testing.localrelationship
+
+@pairings = [ {
+  "destination": "com.linkedin.testing.urn.FooUrn",
+  "source": "com.linkedin.testing.urn.BarUrn"
+} ]
+@gma.model = "RELATIONSHIP"
+record BelongsToV2 includes BaseRelationship {
+}


### PR DESCRIPTION
## Summary
This PR will enable the EBeanLocalDAO to process extract relationships from both aspect and local relationship builder. The assumption is the aspect will have V2 relationships and local relationship builder will have V2 relationships, but the source/destination pairing value should be the same. Then the relationships will be written to both V1 and V2 tables.

I.e., during V1 -> V2 transition, the relationships will be extracted from both sources and be written to v1 and v2 tables separately.

also refactored old unit tests to have aspect use v2 relationships.

## Testing Done
./gradlew build
unit tests

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
