### PR TITLE
Add the process of Relationship V2 in EbeanLocalRelationshipWriterDAO

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
@@ -5,6 +5,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static com.linkedin.metadata.dao.utils.ModelUtils.*;
 
@@ -25,7 +26,7 @@ public class GraphUtils {
    */
   public static void checkSameUrn(@Nonnull final List<? extends RecordTemplate> relationships,
       @Nonnull final BaseGraphWriterDAO.RemovalOption removalOption, @Nonnull final String sourceField,
-      @Nonnull final String destinationField, Urn urn) {
+      @Nonnull final String destinationField, @Nullable Urn urn) {
 
     if (relationships.isEmpty()) {
       return;
@@ -51,7 +52,7 @@ public class GraphUtils {
    * @return The source asset urn.
    */
   public static <RELATIONSHIP extends RecordTemplate> Urn getSourceUrnBasedOnRelationshipVersion(
-      @Nonnull RELATIONSHIP relationship, Urn urn) {
+      @Nonnull RELATIONSHIP relationship, @Nullable Urn urn) {
     Urn sourceUrn;
     boolean isRelationshipInV2 = ModelUtils.isRelationshipInV2(relationship.schema());
     if (isRelationshipInV2 && urn != null) {
@@ -68,14 +69,15 @@ public class GraphUtils {
   }
 
   public static void checkSameUrn(@Nonnull final List<? extends RecordTemplate> relationships,
-      @Nonnull final BaseGraphWriterDAO.RemovalOption removalOption, final String sourceField, final String destinationField) {
+      @Nonnull final BaseGraphWriterDAO.RemovalOption removalOption, @Nonnull final String sourceField,
+      @Nonnull final String destinationField) {
     checkSameUrn(relationships, removalOption, sourceField, destinationField, null);
   }
 
   private static void checkSameUrn(@Nonnull List<? extends RecordTemplate> records, @Nonnull String field,
       @Nonnull Urn compare) {
     for (RecordTemplate relation : records) {
-      if (ModelUtils.isRelationshipInV2(relation.schema()) && field == SOURCE) {
+      if (ModelUtils.isRelationshipInV2(relation.schema()) && field.equals(SOURCE)) {
         // Skip source urn check for V2 relationships since they don't have source field
         // ToDo: enhance the source check for V2 relationships
         return;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
@@ -24,21 +24,14 @@ public class GraphUtils {
    * @param urn  source urn to compare. Optional for V1. Needed for V2.
    */
   public static void checkSameUrn(@Nonnull final List<? extends RecordTemplate> relationships,
-      @Nonnull final BaseGraphWriterDAO.RemovalOption removalOption, final String sourceField,
-      final String destinationField, Urn urn) {
+      @Nonnull final BaseGraphWriterDAO.RemovalOption removalOption, @Nonnull final String sourceField,
+      @Nonnull final String destinationField, Urn urn) {
 
     if (relationships.isEmpty()) {
       return;
     }
 
-    Urn sourceUrn = urn;
-    if (!ModelUtils.isRelationshipInV2(relationships.get(0).schema())) {
-      // get the sourceUrn from relationship, if relationship model in V1
-      sourceUrn = getSourceUrnFromRelationship(relationships.get(0));
-    }
-    if (sourceUrn == null) {
-      throw new IllegalArgumentException("Source urn is needed for Relationship V2");
-    }
+    final Urn sourceUrn = getSourceUrnBasedOnRelationshipVersion(relationships.get(0), urn);
     final Urn destinationUrn = getDestinationUrnFromRelationship(relationships.get(0));
 
     if (removalOption == BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE) {
@@ -49,6 +42,29 @@ public class GraphUtils {
       checkSameUrn(relationships, sourceField, sourceUrn);
       checkSameUrn(relationships, destinationField, destinationUrn);
     }
+  }
+
+  /**
+   * Get the source asset's urn for a given relationship.
+   * @param relationship Relationship. The relationship can be in model V1 or V2.
+   * @param urn The source asset urn. Optional for V1. Must for V2. Exception will be thrown if urn is not provided for V2.
+   * @return The source asset urn.
+   */
+  public static <RELATIONSHIP extends RecordTemplate> Urn getSourceUrnBasedOnRelationshipVersion(
+      @Nonnull RELATIONSHIP relationship, Urn urn) {
+    Urn sourceUrn;
+    boolean isRelationshipInV2 = ModelUtils.isRelationshipInV2(relationship.schema());
+    if (isRelationshipInV2 && urn != null) {
+      // if relationship model in V2 and urn is not null, get the sourceUrn from the input urn
+      sourceUrn = urn;
+    } else if (!isRelationshipInV2) {
+      // if relationship model in V1, get the sourceUrn from relationship
+      sourceUrn = getSourceUrnFromRelationship(relationship);
+    } else {
+      // throw exception if relationship in V2 but source urn not provided
+      throw new IllegalArgumentException("Source urn is needed for Relationship V2");
+    }
+    return sourceUrn;
   }
 
   public static void checkSameUrn(@Nonnull final List<? extends RecordTemplate> relationships,

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
@@ -874,7 +874,7 @@ public class ModelUtils {
    * @param relationship must be a valid relationship model defined in com.linkedin.metadata.relationship
    * @return boolean. True if the relationship is in MG model V2.
    */
-  static <RELATIONSHIP extends RecordTemplate> boolean isRelationshipInV2(Class<? extends RecordTemplate> relationship) {
+  public static <RELATIONSHIP extends RecordTemplate> boolean isRelationshipInV2(Class<? extends RecordTemplate> relationship) {
     final RecordDataSchema schema = ValidationUtils.getRecordSchema(relationship);
     return isRelationshipInV2(schema);
   }
@@ -887,7 +887,7 @@ public class ModelUtils {
    * @param schema schema of a valid relationship model defined in com.linkedin.metadata.relationship
    * @return boolean. True if the relationship is in MG model V2.
    */
-  static boolean isRelationshipInV2(@Nonnull RecordDataSchema schema) {
+  public static boolean isRelationshipInV2(@Nonnull RecordDataSchema schema) {
     // check the data type of the destination fields in schema and see if it's a union type
     return schema.getFields().stream().noneMatch(
         field -> field.getName().equals(SOURCE_FIELD))

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static com.linkedin.metadata.dao.utils.ModelUtils.*;
 
@@ -48,7 +49,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
    */
   @Transactional
   public void processLocalRelationshipUpdates(@Nonnull Urn urn,
-      @Nonnull List<LocalRelationshipUpdates> relationshipUpdates, boolean isTestMode) {
+      @Nonnull List<LocalRelationshipUpdates> relationshipUpdates, @Nonnull boolean isTestMode) {
     for (LocalRelationshipUpdates relationshipUpdate : relationshipUpdates) {
       if (relationshipUpdate.getRelationships().isEmpty()) {
         clearRelationshipsByEntity(urn, relationshipUpdate.getRelationshipClass(),
@@ -67,7 +68,8 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
    * @param isTestMode whether to use test schema
    */
   public void clearRelationshipsByEntity(@Nonnull Urn urn,
-      @Nonnull Class<? extends RecordTemplate> relationshipClass, @Nonnull RemovalOption removalOption, boolean isTestMode) {
+      @Nonnull Class<? extends RecordTemplate> relationshipClass, @Nonnull RemovalOption removalOption,
+      @Nonnull boolean isTestMode) {
     if (removalOption == RemovalOption.REMOVE_NONE
         || removalOption == RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION) {
       // this method is to handle the case of adding empty relationship list to clear relationships of an entity urn
@@ -96,7 +98,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
    *            For Relationship V2: Required, is the source urn.
    */
   public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
-      @Nonnull RemovalOption removalOption, boolean isTestMode, Urn urn) {
+      @Nonnull RemovalOption removalOption, @Nonnull boolean isTestMode, @Nullable Urn urn) {
     // split relationships by relationship type
     Map<String, List<RELATIONSHIP>> relationshipGroupMap = relationships.stream()
         .collect(Collectors.groupingBy(relationship -> relationship.getClass().getCanonicalName()));
@@ -109,9 +111,10 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
       addRelationshipGroup(relationshipGroup, removalOption, isTestMode, urn);
     });
   }
+
   @Override
   public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
-      @Nonnull RemovalOption removalOption, boolean isTestMode) {
+      @Nonnull RemovalOption removalOption, @Nonnull boolean isTestMode) {
     addRelationships(relationships, removalOption, isTestMode, null);
   }
 
@@ -145,7 +148,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
    *            Needed for Relationship V2 because source is not included in the relationshipV2 metadata.
    */
   private <RELATIONSHIP extends RecordTemplate> void addRelationshipGroup(@Nonnull final List<RELATIONSHIP> relationshipGroup,
-      @Nonnull RemovalOption removalOption, boolean isTestMode, Urn urn) {
+      @Nonnull RemovalOption removalOption, @Nonnull boolean isTestMode, @Nullable Urn urn) {
     if (relationshipGroup.size() == 0) {
       return;
     }
@@ -189,7 +192,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
    *            Needed for Relationship V2 because source is not included in the relationshipV2 metadata.
    */
   private <RELATIONSHIP extends RecordTemplate> void processRemovalOption(@Nonnull String tableName,
-      @Nonnull RELATIONSHIP relationship, @Nonnull RemovalOption removalOption, Urn urn) {
+      @Nonnull RELATIONSHIP relationship, @Nonnull RemovalOption removalOption, @Nullable Urn urn) {
 
     if (removalOption == RemovalOption.REMOVE_NONE) {
       return;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -5,7 +5,6 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.builder.BaseLocalRelationshipBuilder.LocalRelationshipUpdates;
 import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
 import com.linkedin.metadata.dao.utils.GraphUtils;
-import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.dao.utils.SQLSchemaUtils;
 import com.linkedin.metadata.dao.utils.SQLStatementUtils;
@@ -164,15 +163,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
       // Relationship model V2 doesn't include source urn, it needs to be passed in.
       // For relationship model V1, this given urn can be source urn or destination urn.
       // For relationship model V2, this given urn can only be source urn.
-      Urn source = urn;
-      if (!ModelUtils.isRelationshipInV2(relationship.schema())) {
-        // get source urn from relationship if V1
-        source = getSourceUrnFromRelationship(relationship);
-      }
-      if (source == null) {
-        throw new IllegalArgumentException("source urn is required for Relationship V2");
-      }
-
+      Urn source = GraphUtils.getSourceUrnBasedOnRelationshipVersion(relationship, urn);
       Urn destination = getDestinationUrnFromRelationship(relationship);
 
       _server.createSqlUpdate(SQLStatementUtils.insertLocalRelationshipSQL(
@@ -205,12 +196,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     }
 
     SqlUpdate deletionSQL = _server.createSqlUpdate(SQLStatementUtils.deleteLocalRelationshipSQL(tableName, removalOption));
-    Urn source = urn;
-    if (!ModelUtils.isRelationshipInV2(relationship.schema())) {
-      source = getSourceUrnFromRelationship(relationship);
-    } else if (source == null) {
-      throw new IllegalArgumentException("source urn is required for Relationship V2");
-    }
+    Urn source = GraphUtils.getSourceUrnBasedOnRelationshipVersion(relationship, urn);
     Urn destination = getDestinationUrnFromRelationship(relationship);
 
     if (removalOption == RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -5,6 +5,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.builder.BaseLocalRelationshipBuilder.LocalRelationshipUpdates;
 import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
 import com.linkedin.metadata.dao.utils.GraphUtils;
+import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.dao.utils.SQLSchemaUtils;
 import com.linkedin.metadata.dao.utils.SQLStatementUtils;
@@ -18,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.linkedin.metadata.dao.utils.ModelUtils.*;
 
@@ -35,8 +35,6 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     private static final String METADATA = "metadata";
     private static final String LAST_MODIFIED_ON = "lastmodifiedon";
     private static final String LAST_MODIFIED_BY = "lastmodifiedby";
-    private static final String DELETED_TS = "deleted_ts";
-    private static final String ASPECT = "aspect";
   }
 
   public EbeanLocalRelationshipWriterDAO(EbeanServer server) {
@@ -45,7 +43,9 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
 
   /**
    * Process the local relationship updates with transaction guarantee.
+   * @param urn Urn of the entity to update relationships.
    * @param relationshipUpdates Updates to local relationship tables.
+   * @param isTestMode whether to use test schema
    */
   @Transactional
   public void processLocalRelationshipUpdates(@Nonnull Urn urn,
@@ -55,7 +55,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
         clearRelationshipsByEntity(urn, relationshipUpdate.getRelationshipClass(),
             relationshipUpdate.getRemovalOption(), isTestMode);
       } else {
-        addRelationships(relationshipUpdate.getRelationships(), relationshipUpdate.getRemovalOption(), isTestMode);
+        addRelationships(relationshipUpdate.getRelationships(), relationshipUpdate.getRemovalOption(), isTestMode, urn);
       }
     }
   }
@@ -64,6 +64,8 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
    * This method is to serve for the purpose to clear all the relationships from a source entity urn.
    * @param urn entity urn could be either source or destination, depends on the RemovalOption
    * @param relationshipClass relationship that needs to be cleared
+   * @param removalOption removal option to specify which relationships to be removed
+   * @param isTestMode whether to use test schema
    */
   public void clearRelationshipsByEntity(@Nonnull Urn urn,
       @Nonnull Class<? extends RecordTemplate> relationshipClass, @Nonnull RemovalOption removalOption, boolean isTestMode) {
@@ -85,20 +87,33 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     deletionSQL.execute();
   }
 
-  @Override
+  /**
+   * Persist the given list of relationships to the local relationship tables.
+   * @param relationships the list of relationships to be persisted
+   * @param removalOption whether to remove existing relationship of the same type
+   * @param isTestMode whether to use test schema
+   * @param urn Urn of the entity to update relationships.
+   *            For Relationship V1: Optional, can be source or destination urn.
+   *            For Relationship V2: Required, is the source urn.
+   */
   public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
-      @Nonnull RemovalOption removalOption, boolean isTestMode) {
+      @Nonnull RemovalOption removalOption, boolean isTestMode, Urn urn) {
     // split relationships by relationship type
     Map<String, List<RELATIONSHIP>> relationshipGroupMap = relationships.stream()
         .collect(Collectors.groupingBy(relationship -> relationship.getClass().getCanonicalName()));
 
     // validate if all relationship groups have valid urns
     relationshipGroupMap.values().forEach(relationshipGroup
-        -> GraphUtils.checkSameUrn(relationshipGroup, removalOption, CommonColumnName.SOURCE, CommonColumnName.DESTINATION));
+        -> GraphUtils.checkSameUrn(relationshipGroup, removalOption, CommonColumnName.SOURCE, CommonColumnName.DESTINATION, urn));
 
     relationshipGroupMap.values().forEach(relationshipGroup -> {
-      addRelationshipGroup(relationshipGroup, removalOption, isTestMode);
+      addRelationshipGroup(relationshipGroup, removalOption, isTestMode, urn);
     });
+  }
+  @Override
+  public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
+      @Nonnull RemovalOption removalOption, boolean isTestMode) {
+    addRelationships(relationships, removalOption, isTestMode, null);
   }
 
   @Override
@@ -122,8 +137,16 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     throw new UnsupportedOperationException("Local relationship does not support removing entity. Please consider using metadata entity table.");
   }
 
+  /**
+   * Add the given list of relationships to the local relationship tables.
+   * @param relationshipGroup the list of relationships to be persisted
+   * @param removalOption whether to remove existing relationship of the same type
+   * @param isTestMode  whether to use test schema
+   * @param urn the source urn to be used for the relationships. Optional for Relationship V1.
+   *            Needed for Relationship V2 because source is not included in the relationshipV2 metadata.
+   */
   private <RELATIONSHIP extends RecordTemplate> void addRelationshipGroup(@Nonnull final List<RELATIONSHIP> relationshipGroup,
-      @Nonnull RemovalOption removalOption, boolean isTestMode) {
+      @Nonnull RemovalOption removalOption, boolean isTestMode, Urn urn) {
     if (relationshipGroup.size() == 0) {
       return;
     }
@@ -133,12 +156,23 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
 
     // Process remove option to delete some local relationships if needed before adding new relationships.
     processRemovalOption(isTestMode ? SQLSchemaUtils.getTestRelationshipTableName(firstRelationship)
-        : SQLSchemaUtils.getRelationshipTableName(firstRelationship), firstRelationship, removalOption);
+        : SQLSchemaUtils.getRelationshipTableName(firstRelationship), firstRelationship, removalOption, urn);
 
     long now = Instant.now().toEpochMilli();
 
     for (RELATIONSHIP relationship : relationshipGroup) {
-      Urn source = getSourceUrnFromRelationship(relationship);
+      // Relationship model V2 doesn't include source urn, it needs to be passed in.
+      // For relationship model V1, this given urn can be source urn or destination urn.
+      // For relationship model V2, this given urn can only be source urn.
+      Urn source = urn;
+      if (!ModelUtils.isRelationshipInV2(relationship.schema())) {
+        // get source urn from relationship if V1
+        source = getSourceUrnFromRelationship(relationship);
+      }
+      if (source == null) {
+        throw new IllegalArgumentException("source urn is required for Relationship V2");
+      }
+
       Urn destination = getDestinationUrnFromRelationship(relationship);
 
       _server.createSqlUpdate(SQLStatementUtils.insertLocalRelationshipSQL(
@@ -155,16 +189,28 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     }
   }
 
-  @ParametersAreNonnullByDefault
-  private <RELATIONSHIP extends RecordTemplate> void processRemovalOption(String tableName, RELATIONSHIP relationship,
-      RemovalOption removalOption) {
+  /**
+   * Process the relationship removal in the DB tableName based on the removal option.
+   * @param tableName the table name of the relationship
+   * @param relationship the relationship to be removed
+   * @param removalOption the removal option
+   * @param urn the source urn to be used for the relationships. Optional for Relationship V1.
+   *            Needed for Relationship V2 because source is not included in the relationshipV2 metadata.
+   */
+  private <RELATIONSHIP extends RecordTemplate> void processRemovalOption(@Nonnull String tableName,
+      @Nonnull RELATIONSHIP relationship, @Nonnull RemovalOption removalOption, Urn urn) {
 
     if (removalOption == RemovalOption.REMOVE_NONE) {
       return;
     }
 
     SqlUpdate deletionSQL = _server.createSqlUpdate(SQLStatementUtils.deleteLocalRelationshipSQL(tableName, removalOption));
-    Urn source = getSourceUrnFromRelationship(relationship);
+    Urn source = urn;
+    if (!ModelUtils.isRelationshipInV2(relationship.schema())) {
+      source = getSourceUrnFromRelationship(relationship);
+    } else if (source == null) {
+      throw new IllegalArgumentException("source urn is required for Relationship V2");
+    }
     Urn destination = getDestinationUrnFromRelationship(relationship);
 
     if (removalOption == RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION) {

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS metadata_relationship_ownedby;
 DROP TABLE IF EXISTS metadata_relationship_pairswith;
 DROP TABLE IF EXISTS metadata_relationship_versionof;
 DROP TABLE IF EXISTS metadata_relationship_consumefrom;
+DROP TABLE IF EXISTS metadata_relationship_relationshipv2bar;
 DROP TABLE IF EXISTS metadata_entity_foo;
 DROP TABLE IF EXISTS metadata_entity_bar;
 
@@ -84,6 +85,20 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_consumefrom (
     deleted_ts DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (id)
     );
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_relationshipv2bar (
+                                                               id BIGINT NOT NULL AUTO_INCREMENT,
+                                                               metadata LONGTEXT NOT NULL,
+                                                               source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
 
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS metadata_relationship_ownedby;
 DROP TABLE IF EXISTS metadata_relationship_pairswith;
 DROP TABLE IF EXISTS metadata_relationship_versionof;
 DROP TABLE IF EXISTS metadata_relationship_consumefrom;
+DROP TABLE IF EXISTS metadata_relationship_relationshipv2bar;
 DROP TABLE IF EXISTS metadata_entity_foo;
 DROP TABLE IF EXISTS metadata_entity_bar;
 
@@ -89,6 +90,19 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_versionof (
 CREATE TABLE IF NOT EXISTS metadata_relationship_consumefrom (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_relationshipv2bar (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
     source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,


### PR DESCRIPTION
## Summary
This PR is to support `processLocalRelationshipUpdates` for relationship model v2.

## Details
Changes include:
1. GraphUtils.java
- Pass source asset urn in the `checkSameUrn` method for model v2.
2. GraphUtilsTest.java
- Add test cases of model v2 into all scenarios
3. ModelUtils.java
- Make `isRelationshipInV2` methods public so they can be used in EbeanLocalRelationshipWriterDAO logic
4. EbeanLocalRelationshipWriterDAO.java
- Add new parameter source asset urn to methods `addRelationships`, `addRelationshipGroup`, and `processRemovalOption`. The logic for model v1 remains the same, but the logic changes to take the passed parameter for model v2.
- Update documents
- Remove unused constant strings
5. EbeanLocalRelationshipWriterDAOTest.java
- Add model v2 test cases to RemoveFromSource test cases, since that's the one to be supported for V2.
6. ebean-local-relationship-dao-create-all.sql
- Add new relationship table based on the V2 relationship
7. ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
- Add new relationship table based on the V2 relationship

## Testing Done
1. ./gradlew build
```

BUILD SUCCESSFUL in 58s
245 actionable tasks: 37 executed, 208 up-to-date
```
2. Add V2 test cases

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
