### PR TITLE
Enable default value fill in for all update behavior

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -818,8 +818,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
             maxTransactionRetry);
 
     // skip MAE producing and post update hook in test mode or if the result is null (no actual update with addCommon)
-    return updateLambda.getIngestionParams().isTestMode() ? result.newValue
-        : result == null ? null : unwrapAddResult(urn, result, auditStamp, trackingContext);
+    return result == null ? null : (updateLambda.getIngestionParams().isTestMode() ? result.newValue
+        : unwrapAddResult(urn, result, auditStamp, trackingContext));
   }
 
   /**

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -74,30 +74,10 @@ public class RecordUtils {
   @Nonnull
   public static String toJsonString(@Nonnull RecordTemplate recordTemplate) {
     try {
-      return DATA_TEMPLATE_CODEC.mapToString(recordTemplate.data());
-    } catch (IOException e) {
-      throw new ModelConversionException("Failed to serialize RecordTemplate: " + recordTemplate.toString());
-    }
-  }
-
-  /**
-   * Serializes a {@link RecordTemplate} to JSON string.
-   * Also take test mode as input to control the default value fill in strategy
-   * @param recordTemplate the record template to serialize
-   * @return the JSON string serialized using {@link JacksonDataTemplateCodec}.
-   */
-  //Todo: we will remove this method once we verify it works and does not bring too much degrade in test mode.
-  @Nonnull
-  public static String toJsonString(@Nonnull RecordTemplate recordTemplate, boolean isTestMode) {
-    if (isTestMode) {
-      try {
-        DataMap dataWithDefaultValue = (DataMap) ResponseUtils.fillInDataDefault(recordTemplate.schema(), recordTemplate.data());
-        return DATA_TEMPLATE_CODEC.mapToString(dataWithDefaultValue);
-      } catch (RestLiServiceException | IOException e) {
-        throw new ModelConversionException("Failed to serialize RecordTemplate: " + recordTemplate.toString(), e);
-      }
-    } else {
-      return toJsonString(recordTemplate);
+      DataMap dataWithDefaultValue = (DataMap) ResponseUtils.fillInDataDefault(recordTemplate.schema(), recordTemplate.data());
+      return DATA_TEMPLATE_CODEC.mapToString(dataWithDefaultValue);
+    } catch (RestLiServiceException | IOException e) {
+      throw new ModelConversionException("Failed to serialize RecordTemplate: " + recordTemplate.toString(), e);
     }
   }
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -63,7 +63,7 @@ public class RecordUtilsTest {
     String expected =
         loadJsonFromResource("defaultValueAspect.json").replaceAll("\\s+", "").replaceAll("\\n", "").replaceAll("\\r", "");
 
-    String actual = RecordUtils.toJsonString(defaultValueAspect, true);
+    String actual = RecordUtils.toJsonString(defaultValueAspect);
 
     assertEquals(actual, expected);
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -138,7 +138,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     }
 
     AuditedAspect auditedAspect = new AuditedAspect()
-        .setAspect(RecordUtils.toJsonString(newValue, isTestMode))
+        .setAspect(RecordUtils.toJsonString(newValue))
         .setCanonicalName(aspectClass.getCanonicalName())
         .setLastmodifiedby(actor)
         .setLastmodifiedon(new Timestamp(timestamp).toString())

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -504,7 +504,7 @@ public class EBeanDAOUtilsTest {
 
     Method extractAspectJsonString = EBeanDAOUtils.class.getDeclaredMethod("extractAspectJsonString", String.class);
     extractAspectJsonString.setAccessible(true);
-    assertEquals("{\"lastmodifiedon\":\"1\",\"aspect\":{\"value\":\"test\"},\"lastmodifiedby\":\"0\"}", toJson);
+    assertEquals("{\"lastmodifiedon\":\"1\",\"lastmodifiedby\":\"0\",\"aspect\":{\"value\":\"test\"}}", toJson);
     assertNotNull(RecordUtils.toRecordTemplate(AspectFoo.class, (String) extractAspectJsonString.invoke(EBeanDAOUtils.class, toJson)));
   }
 


### PR DESCRIPTION
## Summary
Enable default value fill in for all update behavior
## Testing Done
We already did the test in test mode, verified that in dural write mode, it does not introduce too much latency, 2ms in general
## Checklist

- [ X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
