### PR TITLE
Change the API we use to fill in the default value

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -16,8 +16,6 @@ import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.exception.ModelConversionException;
 import com.linkedin.metadata.validator.InvalidSchemaException;
 import com.linkedin.metadata.validator.ValidationUtils;
-import com.linkedin.restli.internal.server.response.ResponseUtils;
-import com.linkedin.restli.server.RestLiServiceException;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -74,9 +72,8 @@ public class RecordUtils {
   @Nonnull
   public static String toJsonString(@Nonnull RecordTemplate recordTemplate) {
     try {
-      DataMap dataWithDefaultValue = (DataMap) ResponseUtils.fillInDataDefault(recordTemplate.schema(), recordTemplate.data());
-      return DATA_TEMPLATE_CODEC.mapToString(dataWithDefaultValue);
-    } catch (RestLiServiceException | IOException e) {
+      return DATA_TEMPLATE_CODEC.mapToString(recordTemplate.data());
+    } catch (IOException e) {
       throw new ModelConversionException("Failed to serialize RecordTemplate: " + recordTemplate.toString(), e);
     }
   }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -5,6 +5,7 @@ import com.linkedin.data.schema.PathSpec;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.dao.BaseLocalDAO;
 import com.linkedin.metadata.dao.exception.ModelConversionException;
 import com.linkedin.metadata.validator.InvalidSchemaException;
 import com.linkedin.metadata.validator.ValidationUtils;
@@ -62,7 +63,7 @@ public class RecordUtilsTest {
     AspectWithDefaultValue defaultValueAspect = new AspectWithDefaultValue().setNestedValueWithDefault(new MapValueRecord());
     String expected =
         loadJsonFromResource("defaultValueAspect.json").replaceAll("\\s+", "").replaceAll("\\n", "").replaceAll("\\r", "");
-
+    BaseLocalDAO.validateAgainstSchemaAndFillinDefault(defaultValueAspect);
     String actual = RecordUtils.toJsonString(defaultValueAspect);
 
     assertEquals(actual, expected);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -504,7 +504,7 @@ public class EBeanDAOUtilsTest {
 
     Method extractAspectJsonString = EBeanDAOUtils.class.getDeclaredMethod("extractAspectJsonString", String.class);
     extractAspectJsonString.setAccessible(true);
-    assertEquals("{\"lastmodifiedon\":\"1\",\"lastmodifiedby\":\"0\",\"aspect\":{\"value\":\"test\"}}", toJson);
+    assertEquals("{\"lastmodifiedon\":\"1\",\"aspect\":{\"value\":\"test\"},\"lastmodifiedby\":\"0\"}", toJson);
     assertNotNull(RecordUtils.toRecordTemplate(AspectFoo.class, (String) extractAspectJsonString.invoke(EBeanDAOUtils.class, toJson)));
   }
 


### PR DESCRIPTION
## Summary
Change the API we use to fill in the default value
The original way of fill in default value will fill in all the field with default value even they are not required. which means as long as the field is optional, we will fill in the default value for it. The  behavior is conflict with the way we do compare using DataTemplateUtil.areEqual(), which only fill in the default value for required field. We do compare using DataTemplateUtil.areEqual() to compare the existing value and new value to avoid duplicate write to database, so the original approach will make us to write to db for every request even it's essentially the same. 

In the new approach, we will use ValidateDataAgainstSchema.validate(model, new ValidationOptions(RequiredMode.FIXUP_ABSENT_WITH_DEFAULT, CoercionMode.NORMAL,
            UnrecognizedFieldMode.DISALLOW)); to do the default fill in, which is the same API they use in DataTemplateUtil.areEqual(). 
This approach will make sure 
1. We don't write the same data to db multiple times.
2. We only fill in default value when it's a required field, which save some space on db as well
3. We leverage the existing check, so no much overhead will be added there

Along with the change, I also remove _modelValidationOnWrite and force it to always do the default value fill in. I have verified that no one is calling enableModelValidationOnWrite, so the behavior should remain unchanged. 
## Testing Done
Unit test. 
Deploy to local and verify it works
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
