### PR TITLE
feat: add dual source mode for addRelationship processing

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
@@ -74,7 +74,7 @@ public class GraphUtils {
     checkSameUrn(relationships, removalOption, sourceField, destinationField, null);
   }
 
-  private static void checkSameUrn(@Nonnull List<? extends RecordTemplate> records, @Nonnull String field,
+  public static void checkSameUrn(@Nonnull List<? extends RecordTemplate> records, @Nonnull String field,
       @Nonnull Urn compare) {
     for (RecordTemplate relation : records) {
       if (ModelUtils.isRelationshipInV2(relation.schema()) && field.equals(SOURCE)) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -2549,11 +2549,11 @@ public class EbeanLocalDAOTest {
     // add an aspect (AspectFooBar) which includes BelongsTo relationships and ReportsTo relationships
     FooUrn fooUrn = makeFooUrn(1);
     BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
-    BelongsToV2 belongsTo1 = new BelongsToV2().setDestination(BelongsToV2.Destination.create(barUrn1.toString()));
+    BelongsToV2 belongsTo1 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn1));
     BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
-    BelongsToV2 belongsTo2 = new BelongsToV2().setDestination(BelongsToV2.Destination.create(barUrn2.toString()));
+    BelongsToV2 belongsTo2 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn2));
     BarUrn barUrn3 = BarUrn.createFromString("urn:li:bar:3");
-    BelongsToV2 belongsTo3 = new BelongsToV2().setDestination(BelongsToV2.Destination.create(barUrn3.toString()));
+    BelongsToV2 belongsTo3 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn3));
     BelongsToV2Array belongsToArray = new BelongsToV2Array(belongsTo1, belongsTo2, belongsTo3);
     ReportsTo reportsTo = new ReportsTo().setSource(fooUrn).setDestination(barUrn1);
     ReportsToArray reportsToArray = new ReportsToArray(reportsTo);
@@ -3142,11 +3142,11 @@ public class EbeanLocalDAOTest {
 
     FooUrn fooUrn = makeFooUrn(1);
     BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
-    BelongsToV2 belongsTo1 = new BelongsToV2().setDestination(BelongsToV2.Destination.create(barUrn1.toString()));
+    BelongsToV2 belongsTo1 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn1));
     BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
-    BelongsToV2 belongsTo2 = new BelongsToV2().setDestination(BelongsToV2.Destination.create(barUrn2.toString()));
+    BelongsToV2 belongsTo2 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn2));
     BarUrn barUrn3 = BarUrn.createFromString("urn:li:bar:3");
-    BelongsToV2 belongsTo3 = new BelongsToV2().setDestination(BelongsToV2.Destination.create(barUrn3.toString()));
+    BelongsToV2 belongsTo3 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn3));
     BelongsToV2Array belongsToArray = new BelongsToV2Array(belongsTo1, belongsTo2, belongsTo3);
     AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(barUrn1, barUrn2, barUrn3)).setBelongsTos(belongsToArray);
     AuditStamp auditStamp = makeAuditStamp("foo", System.currentTimeMillis());
@@ -3169,6 +3169,80 @@ public class EbeanLocalDAOTest {
 
     assertEquals(relationships.size(), 3);
     assertEquals(aspects.size(), 1);
+  }
+
+  @Test
+  public void testAddRelationshipsFromDualSource() throws URISyntaxException {
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> fooDao = createDao(FooUrn.class);
+    EbeanLocalDAO<EntityAspectUnion, BarUrn> barDao = createDao(BarUrn.class);
+    fooDao.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
+    barDao.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
+
+    fooDao.setRelationshipSource(EbeanLocalDAO.RelationshipSource.DUAL_SOURCE);
+
+    FooUrn fooUrn = makeFooUrn(1);
+    BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
+    BelongsToV2 belongsTo1 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn1));
+    BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
+    BelongsToV2 belongsTo2 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn2));
+    BarUrn barUrn3 = BarUrn.createFromString("urn:li:bar:3");
+    BelongsToV2 belongsTo3 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn3));
+    BelongsToV2Array belongsToArray = new BelongsToV2Array(belongsTo1, belongsTo2, belongsTo3);
+
+    AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(barUrn1, barUrn2, barUrn3)).setBelongsTos(belongsToArray);
+    AuditStamp auditStamp = makeAuditStamp("foo", System.currentTimeMillis());
+
+    fooDao.add(fooUrn, aspectFooBar, auditStamp);
+    barDao.add(barUrn1, new AspectFoo().setValue("1"), auditStamp);
+    barDao.add(barUrn2, new AspectFoo().setValue("2"), auditStamp);
+    barDao.add(barUrn3, new AspectFoo().setValue("3"), auditStamp);
+
+    // Verify local relationships and entity are added.
+    EbeanLocalRelationshipQueryDAO ebeanLocalRelationshipQueryDAO = new EbeanLocalRelationshipQueryDAO(_server);
+    ebeanLocalRelationshipQueryDAO.setSchemaConfig(_schemaConfig);
+
+    // verify 3 BelongsTo (V1)
+    List<BelongsTo> relationships =
+        ebeanLocalRelationshipQueryDAO.findRelationships(FooSnapshot.class, EMPTY_FILTER, BarSnapshot.class,
+            EMPTY_FILTER, BelongsTo.class, OUTGOING_FILTER, 0, 10);
+
+    AspectKey<FooUrn, AspectFooBar> key = new AspectKey<>(AspectFooBar.class, fooUrn, 0L);
+    List<EbeanMetadataAspect> aspects = fooDao.batchGetHelper(Collections.singletonList(key), 1, 0);
+
+    assertEquals(relationships.size(), 3);
+    assertEquals(aspects.size(), 1);
+
+    // verify 3 BelongsToV2
+    List<BelongsToV2> relationshipsV2 =
+        ebeanLocalRelationshipQueryDAO.findRelationships(FooSnapshot.class, EMPTY_FILTER, BarSnapshot.class,
+            EMPTY_FILTER, BelongsToV2.class, OUTGOING_FILTER, 0, 10);
+
+    assertEquals(relationshipsV2.size(), 3);
+  }
+
+  @Test
+  public void testAddRelationshipsFromDualSourceWithInconsistentRelationships() throws URISyntaxException {
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> fooDao = createDao(FooUrn.class);
+    EbeanLocalDAO<EntityAspectUnion, BarUrn> barDao = createDao(BarUrn.class);
+    fooDao.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
+    barDao.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
+
+    fooDao.setRelationshipSource(EbeanLocalDAO.RelationshipSource.DUAL_SOURCE);
+
+    FooUrn fooUrn = makeFooUrn(1);
+    BarUrn barUrn1 = BarUrn.createFromString("urn:li:bar:1");
+
+    BarUrn barUrn2 = BarUrn.createFromString("urn:li:bar:2");
+    BelongsToV2 belongsTo2 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn2));
+    BarUrn barUrn3 = BarUrn.createFromString("urn:li:bar:3");
+    BelongsToV2 belongsTo3 = new BelongsToV2().setDestination(BelongsToV2.Destination.createWithDestinationBar(barUrn3));
+    BelongsToV2Array belongsToArray = new BelongsToV2Array(belongsTo2, belongsTo3);
+
+    // bars field and belongsTos field have different values (inconsistent relationships)
+    AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(barUrn1)).setBelongsTos(belongsToArray);
+    AuditStamp auditStamp = makeAuditStamp("foo", System.currentTimeMillis());
+
+    assertThrows(IllegalArgumentException.class, () -> fooDao.add(fooUrn, aspectFooBar, auditStamp));
   }
 
   @Test

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/BelongsToV2.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/BelongsToV2.pdl
@@ -1,8 +1,10 @@
 namespace com.linkedin.testing.localrelationship
 
+import com.linkedin.testing.BarUrn
+
 @gma.model = "RELATIONSHIP"
 record BelongsToV2 {
   destination: union [
-    string
+    destinationBar: BarUrn
   ]
 }


### PR DESCRIPTION
## Summary
#466 is broken up to #470 + this.

This PR will enable the EBeanLocalDAO to process extract relationships from both aspect and local relationship builder. The assumption is the aspect will have V2 relationships and local relationship builder will have V2 relationships, but the source/destination pairing value should be the same. Then the relationships will be written to both V1 and V2 tables.

I.e., during V1 -> V2 transition, the relationships will be extracted from both sources and be written to v1 and v2 tables separately.

## Testing Done
./gradlew build

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
