### PR TITLE
cleanup: Add no-internalModels-flag variants to methods used by GMS's

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -1076,11 +1076,44 @@ public abstract class BaseEntityResource<
   }
 
   /**
+   * Same as the above but doesn't require the callee to provide the 'isInternalModelsEnabled' flag.
+   *
+   * @param urns collection of urns
+   * @param aspectClasses set of aspect classes
+   * @return All {@link VALUE} objects keyed by {@link URN} obtained from DB
+   */
+  @Nonnull
+  protected Map<URN, VALUE> getInternal(@Nonnull Collection<URN> urns,
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses) {
+    final boolean isInternalModelsEnabled = getResourceLix().testGetAll(_urnClass.getSimpleName());
+    return getUrnAspectMap(urns, aspectClasses, isInternalModelsEnabled).entrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey,
+            e -> isInternalModelsEnabled ? toInternalValue(newInternalSnapshot(e.getKey(), e.getValue()))
+                : toValue(newSnapshot(e.getKey(), e.getValue()))));
+  }
+
+  /**
    * Similar to {@link #getInternal(Collection, Set, boolean)}  but filter out {@link URN}s which are not in the DB.
    */
   @Nonnull
   protected Map<URN, VALUE> getInternalNonEmpty(@Nonnull Collection<URN> urns,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, boolean isInternalModelsEnabled) {
+    return getUrnAspectMap(urns, aspectClasses, isInternalModelsEnabled).entrySet()
+        .stream()
+        .filter(e -> !e.getValue().isEmpty())
+        .collect(Collectors.toMap(Map.Entry::getKey,
+            e -> isInternalModelsEnabled ? toInternalValue(newInternalSnapshot(e.getKey(), e.getValue()))
+                : toValue(newSnapshot(e.getKey(), e.getValue()))));
+  }
+
+  /**
+   * Same as the above but doesn't require the callee to provide the 'isInternalModelsEnabled' flag.
+   */
+  @Nonnull
+  protected Map<URN, VALUE> getInternalNonEmpty(@Nonnull Collection<URN> urns,
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses) {
+    final boolean isInternalModelsEnabled = getResourceLix().testGetAll(_urnClass.getSimpleName());
     return getUrnAspectMap(urns, aspectClasses, isInternalModelsEnabled).entrySet()
         .stream()
         .filter(e -> !e.getValue().isEmpty())

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
@@ -225,6 +225,18 @@ public abstract class BaseSearchableEntityResource<
     );
   }
 
+  /**
+   * Same as the above but doesn't require the callee to provide the 'isInternalModelsEnabled' flag.
+   * @param searchResult Search result returned from search infra, such as Elasticsearch.
+   * @param aspectNames List of aspect names that need to be returned.
+   * @return CollectionResult which contains: 1. aspect values fetched from MySQL DB, 2. Total count 3. Search result metadata.
+   */
+  @Nonnull
+  public CollectionResult<VALUE, SearchResultMetadata> getSearchQueryCollectionResult(@Nonnull SearchResult<DOCUMENT> searchResult,
+      @Nullable String[] aspectNames) {
+    return getSearchQueryCollectionResult(searchResult, aspectNames, getResourceLix().testSearch(_urnClass.getSimpleName()));
+  }
+
   private URN toEntitySpecificUrn(Urn urn) {
      try {
        return (URN) (_urnClass.getMethod("createFromUrn", Urn.class).invoke(null, urn));


### PR DESCRIPTION
## Summary

Add no-flag variants to methods so that consumer GMS's don't need to call "lix logic", which is confusing since there is no Lix active any more.

Non-TMS Codesearch: https://jarvis.corp.linkedin.com/codesearch/results/?query=mp%3A*-gms%20getResourceLix

TMS Codesearch: https://jarvis.corp.linkedin.com/codesearch/results?query=mp%3Ametadata-store+getResourceLix&current=1&nresults=10

## Testing Done

n/a

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
