### PR TITLE
fix(relationship 2.0): handle the case where aspects can have multiple fields with the same relationship type

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -410,7 +410,7 @@ public class EBeanDAOUtils {
         if (modelType == ModelType.RELATIONSHIP) {
           log.debug("Found {} relationships of type {} for field {} of aspect class {}.",
               relationshipsList.size(), relationshipsList.get(0).getClass(), fieldName, clazz.getName());
-          relationshipMap.computeIfAbsent(obj.getClass(), k -> new HashSet<>()).addAll((List<RELATIONSHIP>) relationshipsList);
+          relationshipMap.computeIfAbsent(relationshipsList.get(0).getClass(), k -> new HashSet<>()).addAll((List<RELATIONSHIP>) relationshipsList);
         }
       } catch (ReflectiveOperationException e) {
         throw new RuntimeException(e);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -381,45 +381,12 @@ public class EBeanDAOUtils {
   /**
    * Extract the non-null values from all top-level relationship fields of an aspect.
    * @param aspect aspect (possibly with relationships) to be ingested
-   * @return a list of relationship arrays, with each array representing the relationship(s) present in each top-level relationship
-   *     field in the aspect. An empty list means that there is no non-null relationship metadata attached to the given aspect.
+   * @return a map of relationship class to relationship sets, with each set representing the relationship(s) of a particular type present in
+   *     all the top-level relationship fields in the aspect. An empty map means that there is no non-null relationship metadata attached to the given aspect.
    */
-//  @Nonnull
-//  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate> List<List<RELATIONSHIP>> extractRelationshipsFromAspect(ASPECT aspect) {
-//    return aspect.schema().getFields().stream().filter(field -> !field.getType().isPrimitive()).map(field -> {
-//      String fieldName = field.getName();
-//      Class<RecordTemplate> clazz = (Class<RecordTemplate>) aspect.getClass();
-//      try {
-//        Method getMethod = clazz.getMethod("get" + StringUtils.capitalize(fieldName)); // getFieldName
-//        Object obj = getMethod.invoke(aspect); // invoke getFieldName
-//        // all relationship fields will be represented as either singleton fields or Arrays so filter out any non-RecordTemplates,
-//        // empty lists, and lists that don't contain RecordTemplates
-//        if (obj instanceof RecordTemplate) {
-//          ModelType modelType = parseModelTypeFromGmaAnnotation((RecordTemplate) obj);
-//          if (modelType == ModelType.RELATIONSHIP) {
-//            log.debug("Found {} relationship(s) of type {} for field {} of aspect class {}.",
-//                1, obj.getClass(), fieldName, clazz.getName());
-//            return Collections.singletonList((RELATIONSHIP) obj);
-//          }
-//        } else if (!(obj instanceof List) || ((List) obj).isEmpty() || !(((List) obj).get(0) instanceof RecordTemplate)) {
-//          return null;
-//        }
-//        List<RecordTemplate> relationshipsList = (List<RecordTemplate>) obj;
-//        ModelType modelType = parseModelTypeFromGmaAnnotation(relationshipsList.get(0));
-//        if (modelType == ModelType.RELATIONSHIP) {
-//          log.debug("Found {} relationships of type {} for field {} of aspect class {}.",
-//              relationshipsList.size(), relationshipsList.get(0).getClass(), fieldName, clazz.getName());
-//          return (List<RELATIONSHIP>) relationshipsList;
-//        }
-//      } catch (ReflectiveOperationException e) {
-//        throw new RuntimeException(e);
-//      }
-//      return null;
-//    }).filter(Objects::nonNull).collect(Collectors.toList());
-//  }
-
   @Nonnull
-  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate> Map<Class<?>, Set<RELATIONSHIP>> extractRelationshipsFromAspect(ASPECT aspect) {
+  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate>Map<Class<?>, Set<RELATIONSHIP>>
+  extractRelationshipsFromAspect(ASPECT aspect) {
     Map<Class<?>, Set<RELATIONSHIP>> relationshipMap = new HashMap<>();
     aspect.schema().getFields().stream().filter(field -> !field.getType().isPrimitive()).forEach(field -> {
       String fieldName = field.getName();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -30,10 +30,13 @@ import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -381,9 +384,44 @@ public class EBeanDAOUtils {
    * @return a list of relationship arrays, with each array representing the relationship(s) present in each top-level relationship
    *     field in the aspect. An empty list means that there is no non-null relationship metadata attached to the given aspect.
    */
+//  @Nonnull
+//  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate> List<List<RELATIONSHIP>> extractRelationshipsFromAspect(ASPECT aspect) {
+//    return aspect.schema().getFields().stream().filter(field -> !field.getType().isPrimitive()).map(field -> {
+//      String fieldName = field.getName();
+//      Class<RecordTemplate> clazz = (Class<RecordTemplate>) aspect.getClass();
+//      try {
+//        Method getMethod = clazz.getMethod("get" + StringUtils.capitalize(fieldName)); // getFieldName
+//        Object obj = getMethod.invoke(aspect); // invoke getFieldName
+//        // all relationship fields will be represented as either singleton fields or Arrays so filter out any non-RecordTemplates,
+//        // empty lists, and lists that don't contain RecordTemplates
+//        if (obj instanceof RecordTemplate) {
+//          ModelType modelType = parseModelTypeFromGmaAnnotation((RecordTemplate) obj);
+//          if (modelType == ModelType.RELATIONSHIP) {
+//            log.debug("Found {} relationship(s) of type {} for field {} of aspect class {}.",
+//                1, obj.getClass(), fieldName, clazz.getName());
+//            return Collections.singletonList((RELATIONSHIP) obj);
+//          }
+//        } else if (!(obj instanceof List) || ((List) obj).isEmpty() || !(((List) obj).get(0) instanceof RecordTemplate)) {
+//          return null;
+//        }
+//        List<RecordTemplate> relationshipsList = (List<RecordTemplate>) obj;
+//        ModelType modelType = parseModelTypeFromGmaAnnotation(relationshipsList.get(0));
+//        if (modelType == ModelType.RELATIONSHIP) {
+//          log.debug("Found {} relationships of type {} for field {} of aspect class {}.",
+//              relationshipsList.size(), relationshipsList.get(0).getClass(), fieldName, clazz.getName());
+//          return (List<RELATIONSHIP>) relationshipsList;
+//        }
+//      } catch (ReflectiveOperationException e) {
+//        throw new RuntimeException(e);
+//      }
+//      return null;
+//    }).filter(Objects::nonNull).collect(Collectors.toList());
+//  }
+
   @Nonnull
-  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate> List<List<RELATIONSHIP>> extractRelationshipsFromAspect(ASPECT aspect) {
-    return aspect.schema().getFields().stream().filter(field -> !field.getType().isPrimitive()).map(field -> {
+  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate> Map<Class<?>, Set<RELATIONSHIP>> extractRelationshipsFromAspect(ASPECT aspect) {
+    Map<Class<?>, Set<RELATIONSHIP>> relationshipMap = new HashMap<>();
+    aspect.schema().getFields().stream().filter(field -> !field.getType().isPrimitive()).forEach(field -> {
       String fieldName = field.getName();
       Class<RecordTemplate> clazz = (Class<RecordTemplate>) aspect.getClass();
       try {
@@ -396,23 +434,24 @@ public class EBeanDAOUtils {
           if (modelType == ModelType.RELATIONSHIP) {
             log.debug("Found {} relationship(s) of type {} for field {} of aspect class {}.",
                 1, obj.getClass(), fieldName, clazz.getName());
-            return Collections.singletonList((RELATIONSHIP) obj);
+            relationshipMap.computeIfAbsent(obj.getClass(), k -> new HashSet<>()).add((RELATIONSHIP) obj);
+            return;
           }
         } else if (!(obj instanceof List) || ((List) obj).isEmpty() || !(((List) obj).get(0) instanceof RecordTemplate)) {
-          return null;
+          return;
         }
         List<RecordTemplate> relationshipsList = (List<RecordTemplate>) obj;
         ModelType modelType = parseModelTypeFromGmaAnnotation(relationshipsList.get(0));
         if (modelType == ModelType.RELATIONSHIP) {
           log.debug("Found {} relationships of type {} for field {} of aspect class {}.",
               relationshipsList.size(), relationshipsList.get(0).getClass(), fieldName, clazz.getName());
-          return (List<RELATIONSHIP>) relationshipsList;
+          relationshipMap.computeIfAbsent(obj.getClass(), k -> new HashSet<>()).addAll((List<RELATIONSHIP>) relationshipsList);
         }
       } catch (ReflectiveOperationException e) {
         throw new RuntimeException(e);
       }
-      return null;
-    }).filter(Objects::nonNull).collect(Collectors.toList());
+    });
+    return relationshipMap;
   }
 
   // Using the GmaAnnotationParser, extract the model type from the @gma.model annotation on any models.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -29,12 +29,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -385,7 +383,7 @@ public class EBeanDAOUtils {
    *     all the top-level relationship fields in the aspect. An empty map means that there is no non-null relationship metadata attached to the given aspect.
    */
   @Nonnull
-  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate>Map<Class<?>, Set<RELATIONSHIP>>
+  public static <RELATIONSHIP extends RecordTemplate, ASPECT extends RecordTemplate> Map<Class<?>, Set<RELATIONSHIP>>
   extractRelationshipsFromAspect(ASPECT aspect) {
     Map<Class<?>, Set<RELATIONSHIP>> relationshipMap = new HashMap<>();
     aspect.schema().getFields().stream().filter(field -> !field.getType().isPrimitive()).forEach(field -> {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -658,7 +658,7 @@ public class EBeanDAOUtilsTest {
         .setRelationshipBars(relationshipBars); // don't set moreRelationshipFoos field
 
     results = EBeanDAOUtils.extractRelationshipsFromAspect(barWithRelationshipFields);
-    assertEquals(3, results.size());
+    assertEquals(2, results.size());
     assertEquals(3, results.get(AnnotatedRelationshipFoo.class).size()); // relationshipFoo1 (1) + relationshipFoos (2)
     assertEquals(1, results.get(AnnotatedRelationshipBar.class).size()); // relationshipBars
     assertTrue(results.get(AnnotatedRelationshipFoo.class).contains(test1));


### PR DESCRIPTION
## Summary
Currently, these is a "bug" where aspects that have multiple relationship fields of the same relationship type will not have all of them persisted properly in the DB. This is because the current logic for extracting relationships from aspect fields keeps all the extracted relationships separate by the field it was derived from. Then, the relationships are ingested sequentially by each field name group. Relationships in 2.0 are ingested using REMOVE_ALL_EDGES_FROM_SOURCE so any earlier relationships will get overwritten by later relationships if the later ones are of the same type as the earlier ones. 

The new logic will group them by relationship class. Each relationship class will be processed sequentially. This way, there is never any overlap of types between different relationship groups. So any deletions will only occur on previously existing relationships, not relationships added earlier in the current ingestion.
## Testing Done
Updated unit tests
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
