### PR TITLE
fix: getAspectClassNames to handle union alias

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
@@ -929,7 +929,9 @@ public class ModelUtils {
     try {
       final UnionTemplate unionTemplate = unionClass.newInstance();
       final UnionDataSchema unionDataSchema = (UnionDataSchema) unionTemplate.schema();
-      return unionDataSchema.getMembers().stream().map(UnionDataSchema.Member::getUnionMemberKey).collect(Collectors.toList());
+      return unionDataSchema.getMembers().stream().map(
+          member -> member.hasAlias() ? member.getType().getUnionMemberKey() : member.getUnionMemberKey()
+      ).collect(Collectors.toList());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -602,6 +602,13 @@ public class ModelUtilsTest {
   }
 
   @Test
+  public void testGetAspectClassNamesWithAlias() {
+    List<String> classNames = ModelUtils.getAspectClassNames(EntityUnionAlias.class);
+    assertEquals(classNames.get(0), "com.linkedin.testing.EntityFoo");
+    assertEquals(classNames.get(1), "com.linkedin.testing.EntityBar");
+  }
+
+  @Test
   public void testGetUnionClassFromSnapshot() {
     Class<UnionTemplate> unionTemplate = ModelUtils.getUnionClassFromSnapshot(EntitySnapshot.class);
     assertEquals(unionTemplate.getCanonicalName(), "com.linkedin.testing.EntityAspectUnion");


### PR DESCRIPTION
## Summary
Small fix of getAspectClassNames to handle union alias, to unblock EbeanLocalRelationshipQueryDAO.findEntities. (related to recent change in #436 

The buggy behavior was that when aliases exists in the union type, this function will return the alias instead of the canonical name.

For example:
```
typeref EntityUnionAlias = union[
  foo: EntityFoo,
  bar: EntityBar
]
```
old code will return foo when we actually expects `com.linkedin.testing.EntityFoo`

## Testing Done
added unit test
./graldew build

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
