### PR TITLE
fix(relationship 2.0): add aspect column to relationship tables and fix soft deletion

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
@@ -47,6 +47,7 @@ public class GraphUtils {
    * @param urn The source asset urn. Optional for V1. Must for V2. Exception will be thrown if urn is not provided for V2.
    * @return The source asset urn.
    */
+  @Nonnull
   public static <RELATIONSHIP extends RecordTemplate> Urn getSourceUrnBasedOnRelationshipVersion(
       @Nonnull RELATIONSHIP relationship, @Nullable Urn urn) {
     Urn sourceUrn;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
@@ -874,7 +874,7 @@ public class ModelUtils {
    * @param relationship must be a valid relationship model defined in com.linkedin.metadata.relationship
    * @return boolean. True if the relationship is in MG model V2.
    */
-  public static <RELATIONSHIP extends RecordTemplate> boolean isRelationshipInV2(Class<? extends RecordTemplate> relationship) {
+  public static boolean isRelationshipInV2(Class<? extends RecordTemplate> relationship) {
     final RecordDataSchema schema = ValidationUtils.getRecordSchema(relationship);
     return isRelationshipInV2(schema);
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -629,7 +629,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
 
     // This method will handle relationship ingestions and soft-deletions
-    addRelationshipsIfAny(urn, newValue, oldValue, aspectClass, isTestMode);
+    handleRelationshipIngestion(urn, newValue, oldValue, aspectClass, isTestMode);
 
     return largestVersion;
   }
@@ -662,7 +662,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       }
       Optional<ASPECT> aspect = toRecordTemplate(aspectClass, results.get(0));
       if (aspect.isPresent()) {
-        return addRelationshipsIfAny(urn, aspect.get(), null, aspectClass, false);
+        return handleRelationshipIngestion(urn, aspect.get(), null, aspectClass, false);
       }
       return Collections.emptyList();
     }, 1);
@@ -862,7 +862,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param isTestMode Whether the test mode is enabled or not
    * @return List of LocalRelationshipUpdates that were executed
    */
-  public <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<LocalRelationshipUpdates> addRelationshipsIfAny(
+  public <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<LocalRelationshipUpdates> handleRelationshipIngestion(
       @Nonnull URN urn, @Nullable ASPECT newValue, @Nullable ASPECT oldValue, @Nonnull Class<ASPECT> aspectClass, boolean isTestMode) {
     // Check if we're soft deleting newValue, which means we need to remove any relationships derived from oldValue
     boolean isSoftDeletion = false;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -87,8 +87,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   private IEbeanLocalAccess<URN> _localAccess;
   private EbeanLocalRelationshipWriterDAO _localRelationshipWriterDAO;
   private LocalRelationshipBuilderRegistry _localRelationshipBuilderRegistry = null;
-
-  private RelationshipSource _relationshipSource = RelationshipSource.RELATIONSHIP_BUILDERS;
   private SchemaConfig _schemaConfig = SchemaConfig.OLD_SCHEMA_ONLY;
   private final EBeanDAOConfig _eBeanDAOConfig = new EBeanDAOConfig();
 
@@ -98,14 +96,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     DUAL_SCHEMA // Write to both the old and new tables and perform a comparison between values when reading
   }
 
-  /**
-   * Where to look for the relationship(s) for ingestion. Either extract the relationships from the aspect metadata or
-   * from the local relationship registry (legacy), which uses relationship builders.
-   */
-  public enum RelationshipSource {
-    ASPECT_METADATA, // Look at the aspect model and extract any relationship from its fields
-    RELATIONSHIP_BUILDERS // Use the relationship registry, which relies on relationship builders
-  }
+  private boolean _useAspectColumnForRelationshipRemoval = false;
 
   // Which approach to be used for record retrieval when inserting a new record
   // See GCN-38382
@@ -136,13 +127,12 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Set where the relationships should be derived from during ingestion. Either from aspect models or from relationship
-   * builders. The default is relationship builders. This should only be used during DAO instantiation i.e. in the DAO factory.
-   * One limitation when setting this is that all aspects for a particular entity type must use the same relationship source config.
-   * @param relationshipSource {@link RelationshipSource ASPECT_METADATA or RELATIONSHIP_BUILDERS}
+   * Set a flag to indicate whether to use the aspect column for relationship removal. If set to true, only relationships from
+   * the same aspect class will be removed during ingestion or soft-deletion.
    */
-  public void setRelationshipSource(RelationshipSource relationshipSource) {
-    _relationshipSource = relationshipSource;
+  public void setUseAspectColumnForRelationshipRemoval(boolean useAspectColumnForRelationshipRemoval) {
+    _useAspectColumnForRelationshipRemoval = useAspectColumnForRelationshipRemoval;
+    _localRelationshipWriterDAO.setUseAspectColumnForRelationshipRemoval(useAspectColumnForRelationshipRemoval);
   }
 
   public void setOverwriteLatestVersionEnabled(boolean overwriteLatestVersionEnabled) {
@@ -600,16 +590,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       @Nullable ASPECT oldValue, @Nullable AuditStamp oldAuditStamp, @Nullable ASPECT newValue,
       @Nonnull AuditStamp newAuditStamp, boolean isSoftDeleted, @Nullable IngestionTrackingContext trackingContext,
       boolean isTestMode) {
-    // First, check that if the aspect is going to be soft-deleted that it does not have any relationships derived from it.
-    // We currently don't support soft-deleting aspects from which local relationships are derived via relationship builders.
-    if (newValue == null && _relationshipSource == RelationshipSource.RELATIONSHIP_BUILDERS
-          && _localRelationshipBuilderRegistry != null
-          && _localRelationshipBuilderRegistry.isRegistered(aspectClass)) {
-      throw new UnsupportedOperationException(
-          String.format("Aspect %s cannot be soft-deleted because it has a local relationship builder registered.",
-              aspectClass.getCanonicalName()));
-    }
-
     // Save oldValue as the largest version + 1
     long largestVersion = 0;
     if ((isSoftDeleted || oldValue != null) && oldAuditStamp != null && _changeLogEnabled) {
@@ -648,17 +628,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       insert(urn, newValue, aspectClass, newAuditStamp, LATEST_VERSION, trackingContext, isTestMode);
     }
 
-    // If the aspect is to be soft deleted and we are deriving relationships from aspect metadata, remove any relationships
-    // associated with the previous aspect value.
-    if (newValue == null && _relationshipSource == RelationshipSource.ASPECT_METADATA && oldValue != null) {
-      List<RecordTemplate> relationships = extractRelationshipsFromAspect(oldValue).values().stream()
-          .flatMap(Set::stream)
-          .collect(Collectors.toList());
-      _localRelationshipWriterDAO.removeRelationshipsV2(relationships, urn);
-    // Otherwise, add any local relationships that are derived from the aspect.
-    } else {
-      addRelationshipsIfAny(urn, newValue, aspectClass, isTestMode);
-    }
+    // This method will handle relationship ingestions and soft-deletions
+    addRelationshipsIfAny(urn, newValue, oldValue, aspectClass, isTestMode);
 
     return largestVersion;
   }
@@ -691,7 +662,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       }
       Optional<ASPECT> aspect = toRecordTemplate(aspectClass, results.get(0));
       if (aspect.isPresent()) {
-        return addRelationshipsIfAny(urn, aspect.get(), aspectClass, false);
+        return addRelationshipsIfAny(urn, aspect.get(), null, aspectClass, false);
       }
       return Collections.emptyList();
     }, 1);
@@ -880,19 +851,30 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   /**
    * If the aspect is associated with at least one relationship, upsert the relationship into the corresponding local
    * relationship table. Associated means that the aspect has a registered relationship build or it includes a relationship field.
+   * If the new value is null and the old value exists, the aspect is being soft-deleted so remove any existing relationships
+   * associated with that aspect.
    * It will first try to find a registered relationship builder; if one doesn't exist or returns no relationship updates,
    * try to find relationships from the aspect itself.
    * @param urn Urn of the metadata update
-   * @param aspect Aspect of the metadata update
+   * @param newValue new value of the aspect
+   * @param oldValue previous value of the aspect
    * @param aspectClass Aspect class of the metadata update
    * @param isTestMode Whether the test mode is enabled or not
    * @return List of LocalRelationshipUpdates that were executed
    */
   public <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<LocalRelationshipUpdates> addRelationshipsIfAny(
-      @Nonnull URN urn, @Nullable ASPECT aspect, @Nonnull Class<ASPECT> aspectClass, boolean isTestMode) {
-    if (aspect == null) {
-      return Collections.emptyList();
+      @Nonnull URN urn, @Nullable ASPECT newValue, @Nullable ASPECT oldValue, @Nonnull Class<ASPECT> aspectClass, boolean isTestMode) {
+    // Check if we're soft deleting newValue, which means we need to remove any relationships derived from oldValue
+    boolean isSoftDeletion = false;
+    if (newValue == null) {
+      if (oldValue == null) {
+        return Collections.emptyList();
+      }
+      isSoftDeletion = true;
     }
+
+    // Get the relationships associated with the aspect. from newValue if inserting, from oldValue if soft-deleting.
+    ASPECT aspect = isSoftDeletion ? oldValue : newValue;
     List<LocalRelationshipUpdates> localRelationshipUpdates = Collections.emptyList();
     // Try to get relationships using relationship builders first. If there is not a relationship builder registered
     // for the aspect class, try to get relationships from the aspect metadata instead. After most relationship models
@@ -913,7 +895,15 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
               Arrays.asList(entry.getValue().toArray()), entry.getKey(), BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE))
           .collect(Collectors.toList());
     }
-    _localRelationshipWriterDAO.processLocalRelationshipUpdates(urn, localRelationshipUpdates, isTestMode);
+    // process relationship soft-deletion if applicable
+    if (isSoftDeletion) {
+      List<RELATIONSHIP> relationships = new ArrayList<>();
+      localRelationshipUpdates.forEach(localRelationshipUpdate -> relationships.addAll(localRelationshipUpdate.getRelationships()));
+      _localRelationshipWriterDAO.removeRelationships(urn, aspectClass, relationships);
+      return Collections.emptyList();
+    }
+    // process relationship ingestion
+    _localRelationshipWriterDAO.processLocalRelationshipUpdates(urn, aspectClass, localRelationshipUpdates, isTestMode);
     return localRelationshipUpdates;
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -861,7 +861,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param oldValue previous value of the aspect
    * @param aspectClass Aspect class of the metadata update
    * @param isTestMode Whether the test mode is enabled or not
-   * @return List of LocalRelationshipUpdates that were executed
+   * @return List of LocalRelationshipUpdates that were executed, or an empty list if soft-deleting relationships only
    */
   public <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<LocalRelationshipUpdates> handleRelationshipIngestion(
       @Nonnull URN urn, @Nullable ASPECT newValue, @Nullable ASPECT oldValue, @Nonnull Class<ASPECT> aspectClass, boolean isTestMode) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -96,6 +96,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     DUAL_SCHEMA // Write to both the old and new tables and perform a comparison between values when reading
   }
 
+  // TODO: clean up once AIM is no longer using existing local relationships - they should make new relationship tables with the aspect column
   private boolean _useAspectColumnForRelationshipRemoval = false;
 
   // Which approach to be used for record retrieval when inserting a new record

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -91,7 +91,6 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     RelationshipValidator.validateRelationshipSchema(relationshipClass, isRelationshipInV2(relationshipClass));
     removeRelationshipsBySource(urn, aspectClass, isTestMode ? SQLSchemaUtils.getTestRelationshipTableName(relationshipClass)
         : SQLSchemaUtils.getRelationshipTableName(relationshipClass));
-
   }
 
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -106,9 +106,8 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
   @Override
   public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
       @Nonnull RemovalOption removalOption, boolean isTestMode) {
-    throw new UnsupportedOperationException("addRelationships(List<RELATIONSHIP>, RemovalOption, boolean) "
-        + "is not supported in EbeanLocalRelationshipWriterDAO. Please use addRelationships(@Nullable Urn urn, "
-        + "Class<ASPECT>, List<RELATIONSHIP>, boolean)");
+    throw new UnsupportedOperationException("addRelationships(List<RELATIONSHIP>, RemovalOption, boolean) is not supported "
+        + "in EbeanLocalRelationshipWriterDAO. Please use addRelationships(Urn, Class<ASPECT>, List<RELATIONSHIP>, boolean)");
   }
 
   @Override

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -25,9 +25,11 @@ import static com.linkedin.metadata.dao.utils.ModelUtils.*;
 public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
   private static final String DEFAULT_ACTOR = "urn:li:principal:UNKNOWN";
   private final EbeanServer _server;
+  private boolean _useAspectColumnForRelationshipRemoval = false;
 
   // Common column names shared by all local relationship tables.
   private static class CommonColumnName {
+    private static final String ASPECT = "aspect";
     private static final String SOURCE = "source";
     private static final String DESTINATION = "destination";
     private static final String SOURCE_TYPE = "source_type";
@@ -42,19 +44,27 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
   }
 
   /**
+   * Set a flag to indicate whether to use the aspect column for relationship removal. If set to true, only relationships from
+   * the same aspect class will be removed during ingestion or soft-deletion.
+   */
+  public void setUseAspectColumnForRelationshipRemoval(boolean useAspectColumnForRelationshipRemoval) {
+    _useAspectColumnForRelationshipRemoval = useAspectColumnForRelationshipRemoval;
+  }
+
+  /**
    * Process the local relationship updates with transaction guarantee.
    * @param urn Urn of the entity to update relationships.
    * @param relationshipUpdates Updates to local relationship tables.
    * @param isTestMode whether to use test schema
    */
   @Transactional
-  public void processLocalRelationshipUpdates(@Nonnull Urn urn,
+  public <ASPECT extends RecordTemplate> void processLocalRelationshipUpdates(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull List<LocalRelationshipUpdates> relationshipUpdates, boolean isTestMode) {
     for (LocalRelationshipUpdates relationshipUpdate : relationshipUpdates) {
       if (relationshipUpdate.getRelationships().isEmpty()) {
-        clearRelationshipsByEntity(urn, relationshipUpdate.getRelationshipClass(), isTestMode);
+        clearRelationshipsByEntity(urn, aspectClass, relationshipUpdate.getRelationshipClass(), isTestMode);
       } else {
-        addRelationships(relationshipUpdate.getRelationships(), isTestMode, urn);
+        addRelationships(urn, aspectClass, relationshipUpdate.getRelationships(), isTestMode);
       }
     }
   }
@@ -65,26 +75,24 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
    * @param relationshipClass relationship that needs to be cleared
    * @param isTestMode whether to use test schema
    */
-  public void clearRelationshipsByEntity(@Nonnull Urn urn,
+  public <ASPECT extends RecordTemplate> void clearRelationshipsByEntity(@Nonnull Urn urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull Class<? extends RecordTemplate> relationshipClass, boolean isTestMode) {
     RelationshipValidator.validateRelationshipSchema(relationshipClass, isRelationshipInV2(relationshipClass));
-    SqlUpdate deletionSQL = _server.createSqlUpdate(SQLStatementUtils.deleteLocalRelationshipSQL(
-        isTestMode ? SQLSchemaUtils.getTestRelationshipTableName(relationshipClass)
-            : SQLSchemaUtils.getRelationshipTableName(relationshipClass), RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE));
-    deletionSQL.setParameter(CommonColumnName.SOURCE, urn.toString());
-    deletionSQL.execute();
+    removeRelationshipsBySource(urn, aspectClass, isTestMode ? SQLSchemaUtils.getTestRelationshipTableName(relationshipClass)
+        : SQLSchemaUtils.getRelationshipTableName(relationshipClass));
   }
 
   /**
    * Persist the given list of relationships to the local relationship using REMOVE_ALL_EDGES_FROM_SOURCE.
-   * @param relationships the list of relationships to be persisted
-   * @param isTestMode whether to use test schema
    * @param urn Urn of the entity to update relationships.
    *            For Relationship V1: Optional, can be source or destination urn.
    *            For Relationship V2: Required, is the source urn.
+   * @param aspectClass class of the aspect from which these relationships are extracted from
+   * @param relationships the list of relationships to be persisted
+   * @param isTestMode whether to use test schema
    */
-  public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
-      boolean isTestMode, @Nullable Urn urn) {
+  public <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> void addRelationships(@Nullable Urn urn,
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull List<RELATIONSHIP> relationships, boolean isTestMode) {
     // split relationships by relationship type
     Map<String, List<RELATIONSHIP>> relationshipGroupMap = relationships.stream()
         .collect(Collectors.groupingBy(relationship -> relationship.getClass().getCanonicalName()));
@@ -92,31 +100,43 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     // validate if all relationship groups have valid urns
     relationshipGroupMap.values().forEach(relationshipGroup -> GraphUtils.checkSameSourceUrn(relationshipGroup, urn));
 
-    relationshipGroupMap.values().forEach(relationshipGroup -> {
-      addRelationshipGroup(relationshipGroup, isTestMode, urn);
-    });
+    relationshipGroupMap.values().forEach(relationshipGroup -> addRelationshipGroup(urn, aspectClass, relationshipGroup, isTestMode));
   }
 
-  // This method only supports Relationship 1.0 (i.e. source present in model) ingestion using graph builders.
   @Override
   public <RELATIONSHIP extends RecordTemplate> void addRelationships(@Nonnull List<RELATIONSHIP> relationships,
       @Nonnull RemovalOption removalOption, boolean isTestMode) {
-    addRelationships(relationships, isTestMode, null);
+    throw new UnsupportedOperationException("addRelationships(List<RELATIONSHIP>, RemovalOption, boolean) "
+        + "is not supported in EbeanLocalRelationshipWriterDAO. Please use addRelationships(@Nullable Urn urn, "
+        + "Class<ASPECT>, List<RELATIONSHIP>, boolean)");
   }
 
   @Override
   public <RELATIONSHIP extends RecordTemplate> void removeRelationships(@Nonnull List<RELATIONSHIP> relationships) {
-    removeRelationshipsV2(relationships, null);
+    throw new UnsupportedOperationException("removeRelationships(List<RELATIONSHIP>) is not supported in EbeanLocalRelationshipWriterDAO. "
+        + "Please use removeRelationships(Urn, Class<ASPECT>, List<RELATIONSHIP>)");
   }
 
-  public <RELATIONSHIP extends RecordTemplate> void removeRelationshipsV2(@Nonnull List<RELATIONSHIP> relationships, @Nullable Urn sourceUrn) {
-    for (RELATIONSHIP relationship : relationships) {
-      _server.createSqlUpdate(SQLStatementUtils.deleteLocalRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(relationship),
-              RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION))
-          .setParameter(CommonColumnName.SOURCE, GraphUtils.getSourceUrnBasedOnRelationshipVersion(relationship, sourceUrn).toString())
-          .setParameter(CommonColumnName.DESTINATION, getDestinationUrnFromRelationship(relationship).toString())
-          .execute();
+  /**
+   * Remove relationships based on source and aspect class.
+   * @param sourceUrn asset urn
+   * @param aspectClass class of the aspect from which the relationships are derived from
+   * @param relationships list of relationships to remove
+   */
+  public <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> void removeRelationships(@Nonnull Urn sourceUrn,
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull List<RELATIONSHIP> relationships) {
+    if (relationships.isEmpty()) {
+      return;
     }
+    GraphUtils.checkSameSourceUrn(relationships, sourceUrn);
+    Map<String, List<RELATIONSHIP>> relationshipGroupMap = relationships.stream()
+        .collect(Collectors.groupingBy(relationship -> relationship.getClass().getCanonicalName()));
+    relationshipGroupMap.values()
+        .forEach(relationshipList -> {
+          Class<RELATIONSHIP> relationshipClass = (Class<RELATIONSHIP>) relationshipList.get(0).getClass();
+          RelationshipValidator.validateRelationshipSchema(relationshipClass, isRelationshipInV2(relationshipClass));
+          removeRelationshipsBySource(sourceUrn, aspectClass, SQLSchemaUtils.getRelationshipTableName(relationshipClass));
+        });
   }
 
   @Override
@@ -131,13 +151,14 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
 
   /**
    * Add the given list of relationships to the local relationship tables.
-   * @param relationshipGroup the list of relationships to be persisted
-   * @param isTestMode  whether to use test schema
    * @param urn the source urn to be used for the relationships. Optional for Relationship V1.
    *            Needed for Relationship V2 because source is not included in the relationshipV2 metadata.
+   * @param aspectClass class of the aspect from which these relationships are extracted from
+   * @param relationshipGroup the list of relationships to be persisted
+   * @param isTestMode  whether to use test schema
    */
-  private <RELATIONSHIP extends RecordTemplate> void addRelationshipGroup(@Nonnull final List<RELATIONSHIP> relationshipGroup,
-      boolean isTestMode, @Nullable Urn urn) {
+  private <ASPECT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> void addRelationshipGroup(@Nullable Urn urn,
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull final List<RELATIONSHIP> relationshipGroup, boolean isTestMode) {
     if (relationshipGroup.size() == 0) {
       return;
     }
@@ -146,8 +167,9 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     RelationshipValidator.validateRelationshipSchema(firstRelationship.getClass(), isRelationshipInV2(firstRelationship.getClass()));
 
     // Remove some local relationships if needed before adding new relationships using REMOVE_ALL_EDGES_FROM_SOURCE.
-    removeRelationshipsBySource(isTestMode ? SQLSchemaUtils.getTestRelationshipTableName(firstRelationship)
-        : SQLSchemaUtils.getRelationshipTableName(firstRelationship), firstRelationship, urn);
+    Urn sourceUrn = GraphUtils.getSourceUrnBasedOnRelationshipVersion(firstRelationship, urn);
+    removeRelationshipsBySource(sourceUrn, aspectClass, isTestMode ? SQLSchemaUtils.getTestRelationshipTableName(firstRelationship)
+        : SQLSchemaUtils.getRelationshipTableName(firstRelationship));
 
     long now = Instant.now().toEpochMilli();
 
@@ -158,32 +180,35 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
       Urn source = GraphUtils.getSourceUrnBasedOnRelationshipVersion(relationship, urn);
       Urn destination = getDestinationUrnFromRelationship(relationship);
 
-      _server.createSqlUpdate(SQLStatementUtils.insertLocalRelationshipSQL(
+      SqlUpdate sqlUpdate = _server.createSqlUpdate(SQLStatementUtils.insertLocalRelationshipSQL(
               isTestMode ? SQLSchemaUtils.getTestRelationshipTableName(relationship)
-                  : SQLSchemaUtils.getRelationshipTableName(relationship)))
+                  : SQLSchemaUtils.getRelationshipTableName(relationship), _useAspectColumnForRelationshipRemoval))
           .setParameter(CommonColumnName.METADATA, RecordUtils.toJsonString(relationship))
           .setParameter(CommonColumnName.SOURCE_TYPE, source.getEntityType())
           .setParameter(CommonColumnName.DESTINATION_TYPE, destination.getEntityType())
           .setParameter(CommonColumnName.SOURCE, source.toString())
           .setParameter(CommonColumnName.DESTINATION, destination.toString())
           .setParameter(CommonColumnName.LAST_MODIFIED_ON, new Timestamp(now))
-          .setParameter(CommonColumnName.LAST_MODIFIED_BY, DEFAULT_ACTOR)
-          .execute();
+          .setParameter(CommonColumnName.LAST_MODIFIED_BY, DEFAULT_ACTOR);
+      if (_useAspectColumnForRelationshipRemoval) {
+        sqlUpdate.setParameter(CommonColumnName.ASPECT, aspectClass.getCanonicalName());
+      }
+      sqlUpdate.execute();
     }
   }
 
   /**
    * Process the relationship removal in the DB tableName based on the removal option.
+   * @param source the source urn to be used for the relationships
    * @param tableName the table name of the relationship
-   * @param relationship the relationship to be removed
-   * @param urn the source urn to be used for the relationships. Optional for Relationship V1.
-   *            Needed for Relationship V2 because source is not included in the relationshipV2 metadata.
    */
-  private <RELATIONSHIP extends RecordTemplate> void removeRelationshipsBySource(@Nonnull String tableName,
-      @Nonnull RELATIONSHIP relationship, @Nullable Urn urn) {
-    SqlUpdate deletionSQL = _server.createSqlUpdate(SQLStatementUtils.deleteLocalRelationshipSQL(tableName, RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE));
-    Urn source = GraphUtils.getSourceUrnBasedOnRelationshipVersion(relationship, urn);
+  private <ASPECT extends RecordTemplate> void removeRelationshipsBySource(@Nonnull Urn source,
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull String tableName) {
+    SqlUpdate deletionSQL = _server.createSqlUpdate(SQLStatementUtils.deleteLocalRelationshipSQL(tableName, _useAspectColumnForRelationshipRemoval));
     deletionSQL.setParameter(CommonColumnName.SOURCE, source.toString());
+    if (_useAspectColumnForRelationshipRemoval) {
+      deletionSQL.setParameter(CommonColumnName.ASPECT, aspectClass.getCanonicalName());
+    }
     deletionSQL.execute();
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -4,7 +4,6 @@ import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
 import com.linkedin.metadata.query.AspectField;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.IndexFilter;
@@ -25,8 +24,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.javatuples.Pair;
 
-import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
 import static com.linkedin.metadata.dao.utils.SQLIndexFilterUtils.*;
+import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
 
 
 /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -102,12 +102,15 @@ public class SQLStatementUtils {
       + "destination_type, lastmodifiedon, lastmodifiedby) VALUE (:metadata, :source, :destination, :source_type,"
       + " :destination_type, :lastmodifiedon, :lastmodifiedby)";
 
-  private static final String DELETE_BY_SOURCE = "UPDATE %s SET deleted_ts=NOW() WHERE source = :source AND deleted_ts IS NULL";
+  private static final String INSERT_LOCAL_RELATIONSHIP_WITH_ASPECT = "INSERT INTO %s (metadata, source, destination, source_type, "
+      + "destination_type, lastmodifiedon, lastmodifiedby, aspect) VALUE (:metadata, :source, :destination, :source_type,"
+      + " :destination_type, :lastmodifiedon, :lastmodifiedby, :aspect)";
 
-  private static final String DELETE_BY_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination AND deleted_ts IS NULL";
+  private static final String DELETE_BY_SOURCE = "UPDATE %s SET deleted_ts=NOW() "
+      + "WHERE source = :source AND deleted_ts IS NULL";
 
-  private static final String DELETE_BY_SOURCE_AND_DESTINATION = "UPDATE %s SET deleted_ts=NOW() WHERE destination = :destination"
-      + " AND source = :source AND deleted_ts IS NULL";
+  private static final String DELETE_BY_SOURCE_AND_ASPECT = "UPDATE %s SET deleted_ts=NOW() "
+      + "WHERE source = :source AND aspect = :aspect AND deleted_ts IS NULL";
 
   /**
    *  Filter query has pagination params in the existing APIs. To accommodate this, we use subquery to include total result counts in the query response.
@@ -322,8 +325,8 @@ public class SQLStatementUtils {
    * @param tableName Name of the table where the local relation metadata will be inserted.
    * @return SQL statement for inserting local relation.
    */
-  public static String insertLocalRelationshipSQL(String tableName) {
-    return String.format(INSERT_LOCAL_RELATIONSHIP, tableName);
+  public static String insertLocalRelationshipSQL(String tableName, boolean useAspectColumn) {
+    return useAspectColumn ? String.format(INSERT_LOCAL_RELATIONSHIP_WITH_ASPECT, tableName) : String.format(INSERT_LOCAL_RELATIONSHIP, tableName);
   }
 
   /**
@@ -337,15 +340,8 @@ public class SQLStatementUtils {
 
   @Nonnull
   @ParametersAreNonnullByDefault
-  public static String deleteLocalRelationshipSQL(final String tableName, final BaseGraphWriterDAO.RemovalOption removalOption) {
-    if (removalOption == BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE) {
-      return String.format(DELETE_BY_SOURCE, tableName);
-    } else if (removalOption == BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION) {
-      return String.format(DELETE_BY_SOURCE_AND_DESTINATION, tableName);
-    }
-    throw new IllegalArgumentException(String.format("Relationships can only be removed using either REMOVE_ALL_EDGES_FROM_SOURCE "
-        + "when inserting new relationships or REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION when soft deleting an aspect "
-        + "from which relationships are derived from. Table name: %s, removal option: %s", tableName, removalOption));
+  public static String deleteLocalRelationshipSQL(final String tableName, boolean useAspectColumn) {
+    return useAspectColumn ? String.format(DELETE_BY_SOURCE_AND_ASPECT, tableName) : String.format(DELETE_BY_SOURCE, tableName);
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -3092,7 +3092,7 @@ public class EbeanLocalDAOTest {
     fooDao.setLocalRelationshipBuilderRegistry(new SampleLocalRelationshipRegistryImpl());
 
     // Add only the local relationships
-    fooDao.addRelationshipsIfAny(fooUrn, aspectFooBar, null, AspectFooBar.class, false);
+    fooDao.handleRelationshipIngestion(fooUrn, aspectFooBar, null, AspectFooBar.class, false);
 
     // Verify that the local relationships were added
     relationships = ebeanLocalRelationshipQueryDAO.findRelationships(
@@ -3133,7 +3133,7 @@ public class EbeanLocalDAOTest {
     fooDao.setUseAspectColumnForRelationshipRemoval(true);
 
     // Add only the local relationships
-    fooDao.addRelationshipsIfAny(fooUrn, aspectFooBar, null, AspectFooBar.class, false);
+    fooDao.handleRelationshipIngestion(fooUrn, aspectFooBar, null, AspectFooBar.class, false);
 
     // Verify that the local relationships were added
     relationships = ebeanLocalRelationshipQueryDAO.findRelationships(

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -13,7 +13,6 @@ import com.linkedin.metadata.dao.EbeanLocalDAO;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipWriterDAO;
 import com.linkedin.metadata.dao.IEbeanLocalAccess;
-import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
 import com.linkedin.metadata.dao.utils.EmbeddedMariaInstance;
@@ -49,6 +48,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -185,11 +185,11 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Add Bob reports-to ALice relationship
     ReportsTo bobReportsToAlice = new ReportsTo().setSource(bob).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(bobReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(bob, AspectFoo.class, Collections.singletonList(bobReportsToAlice), false);
 
     // Add Jack reports-to ALice relationship
     ReportsTo jackReportsToAlice = new ReportsTo().setSource(jack).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(jackReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(jack, AspectFoo.class, Collections.singletonList(jackReportsToAlice), false);
 
     // Find all reports-to relationship for Alice.
     LocalRelationshipFilter filter;
@@ -220,8 +220,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Soft (set delete_ts = now()) Delete Jack reports-to ALice relationship
     SqlUpdate deletionSQL = _server.createSqlUpdate(
-        SQLStatementUtils.deleteLocalRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice),
-            BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE));
+        SQLStatementUtils.deleteLocalRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice), false));
     deletionSQL.setParameter("source", jack.toString());
     deletionSQL.execute();
 
@@ -264,13 +263,13 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Add Spark consume-from hdfs relationship
     ConsumeFrom sparkConsumeFromHdfs = new ConsumeFrom().setSource(spark).setDestination(hdfs).setEnvironment(EnvorinmentType.OFFLINE);
-    _localRelationshipWriterDAO.addRelationship(sparkConsumeFromHdfs, false);
+    _localRelationshipWriterDAO.addRelationships(spark, AspectFoo.class, Collections.singletonList(sparkConsumeFromHdfs), false);
 
     // Add Samza consume-from kafka and Samza consume-from restli relationships
     ConsumeFrom samzaConsumeFromKafka = new ConsumeFrom().setSource(samza).setDestination(kafka).setEnvironment(EnvorinmentType.NEARLINE);
     ConsumeFrom samzaConsumeFromRestli = new ConsumeFrom().setSource(samza).setDestination(restli).setEnvironment(EnvorinmentType.ONLINE);
 
-    _localRelationshipWriterDAO.addRelationships(ImmutableList.of(samzaConsumeFromKafka, samzaConsumeFromRestli), false);
+    _localRelationshipWriterDAO.addRelationships(samza, AspectFoo.class, ImmutableList.of(samzaConsumeFromKafka, samzaConsumeFromRestli), false);
 
     // Find all consume-from relationship for Samza.
     LocalRelationshipCriterion filterUrnCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
@@ -331,11 +330,11 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Add Bob reports-to ALice relationship
     ReportsTo bobReportsToAlice = new ReportsTo().setSource(bob).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(bobReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(bob, AspectFoo.class, Collections.singletonList(bobReportsToAlice), false);
 
     // Add Jack reports-to ALice relationship
     ReportsTo jackReportsToAlice = new ReportsTo().setSource(jack).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(jackReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(jack, AspectFoo.class, Collections.singletonList(jackReportsToAlice), false);
 
     // Find all reports-to relationship for Alice.
     LocalRelationshipFilter destFilter;
@@ -367,8 +366,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Soft (set delete_ts = now()) Delete Jack reports-to ALice relationship
     SqlUpdate deletionSQL = _server.createSqlUpdate(
-        SQLStatementUtils.deleteLocalRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice),
-            BaseGraphWriterDAO.RemovalOption.REMOVE_ALL_EDGES_FROM_SOURCE));
+        SQLStatementUtils.deleteLocalRelationshipSQL(SQLSchemaUtils.getRelationshipTableName(jackReportsToAlice), false));
     deletionSQL.setParameter("source", jack.toString());
     deletionSQL.execute();
 
@@ -411,13 +409,13 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Add Spark consume-from hdfs relationship
     ConsumeFrom sparkConsumeFromHdfs = new ConsumeFrom().setSource(spark).setDestination(hdfs).setEnvironment(EnvorinmentType.OFFLINE);
-    _localRelationshipWriterDAO.addRelationship(sparkConsumeFromHdfs, false);
+    _localRelationshipWriterDAO.addRelationships(spark, AspectFoo.class, Collections.singletonList(sparkConsumeFromHdfs), false);
 
     // Add Samza consume-from kafka and Samza consume-from restli relationships
     ConsumeFrom samzaConsumeFromKafka = new ConsumeFrom().setSource(samza).setDestination(kafka).setEnvironment(EnvorinmentType.NEARLINE);
     ConsumeFrom samzaConsumeFromRestli = new ConsumeFrom().setSource(samza).setDestination(restli).setEnvironment(EnvorinmentType.ONLINE);
 
-    _localRelationshipWriterDAO.addRelationships(ImmutableList.of(samzaConsumeFromRestli, samzaConsumeFromKafka), false);
+    _localRelationshipWriterDAO.addRelationships(samza, AspectFoo.class, ImmutableList.of(samzaConsumeFromRestli, samzaConsumeFromKafka), false);
 
     // Find all consume-from relationship for Samza.
     LocalRelationshipCriterion filterUrnCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
@@ -481,23 +479,23 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // add kafka owned by crew1
     OwnedBy kafkaOwnedByCrew1 = new OwnedBy().setSource(kafka).setDestination(crew1);
-    _localRelationshipWriterDAO.addRelationship(kafkaOwnedByCrew1, false);
+    _localRelationshipWriterDAO.addRelationships(kafka, AspectFoo.class, Collections.singletonList(kafkaOwnedByCrew1), false);
 
     // add hdfs owned by crew1
     OwnedBy hdfsOwnedByCrew1 = new OwnedBy().setSource(hdfs).setDestination(crew1);
-    _localRelationshipWriterDAO.addRelationship(hdfsOwnedByCrew1, false);
+    _localRelationshipWriterDAO.addRelationships(hdfs, AspectFoo.class, Collections.singletonList(hdfsOwnedByCrew1), false);
 
     // add restli owned by crew1
     OwnedBy restliOwnedByCrew1 = new OwnedBy().setSource(restli).setDestination(crew1);
-    _localRelationshipWriterDAO.addRelationship(restliOwnedByCrew1, false);
+    _localRelationshipWriterDAO.addRelationships(restli, AspectFoo.class, Collections.singletonList(restliOwnedByCrew1), false);
 
     // add spark owned by crew2
     OwnedBy sparkOwnedByCrew2 = new OwnedBy().setSource(spark).setDestination(crew2);
-    _localRelationshipWriterDAO.addRelationship(sparkOwnedByCrew2, false);
+    _localRelationshipWriterDAO.addRelationships(spark, AspectFoo.class, Collections.singletonList(sparkOwnedByCrew2), false);
 
     // add samza owned by crew2
     OwnedBy samzaOwnedByCrew2 = new OwnedBy().setSource(samza).setDestination(crew2);
-    _localRelationshipWriterDAO.addRelationship(samzaOwnedByCrew2, false);
+    _localRelationshipWriterDAO.addRelationships(samza, AspectFoo.class, Collections.singletonList(samzaOwnedByCrew2), false);
 
     // Find all owned-by relationship for crew1.
     LocalRelationshipCriterion filterUrnCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
@@ -551,15 +549,15 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // add kafka owned by crew
     OwnedBy kafkaOwnedByCrew = new OwnedBy().setSource(kafka).setDestination(crew);
-    _localRelationshipWriterDAO.addRelationship(kafkaOwnedByCrew, false);
+    _localRelationshipWriterDAO.addRelationships(kafka, AspectFoo.class, Collections.singletonList(kafkaOwnedByCrew), false);
 
     // add hdfs owned by crew
     OwnedBy hdfsOwnedByCrew = new OwnedBy().setSource(hdfs).setDestination(crew);
-    _localRelationshipWriterDAO.addRelationship(hdfsOwnedByCrew, false);
+    _localRelationshipWriterDAO.addRelationships(hdfs, AspectFoo.class, Collections.singletonList(hdfsOwnedByCrew), false);
 
     // add restli owned by crew
     OwnedBy restliOwnedByCrew = new OwnedBy().setSource(restli).setDestination(crew);
-    _localRelationshipWriterDAO.addRelationship(restliOwnedByCrew, false);
+    _localRelationshipWriterDAO.addRelationships(restli, AspectFoo.class, Collections.singletonList(restliOwnedByCrew), false);
 
     // Find all owned-by relationship for crew.
     LocalRelationshipCriterion filterUrnCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
@@ -630,23 +628,23 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Add Bob reports-to ALice relationship
     ReportsTo bobReportsToAlice = new ReportsTo().setSource(bob).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(bobReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(bob, AspectFoo.class, Collections.singletonList(bobReportsToAlice), false);
 
     // Add Jack reports-to ALice relationship
     ReportsTo jackReportsToAlice = new ReportsTo().setSource(jack).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(jackReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(jack, AspectFoo.class, Collections.singletonList(jackReportsToAlice), false);
 
     // Add Lisa reports-to ALice relationship
     ReportsTo lisaReportsToAlice = new ReportsTo().setSource(lisa).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(lisaReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(lisa, AspectFoo.class, Collections.singletonList(lisaReportsToAlice), false);
 
     // Add Rose reports-to ALice relationship
     ReportsTo roseReportsToAlice = new ReportsTo().setSource(rose).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(roseReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(rose, AspectFoo.class, Collections.singletonList(roseReportsToAlice), false);
 
     // Add Jenny reports-to ALice relationship
     ReportsTo jennyReportsToAlice = new ReportsTo().setSource(jenny).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(jennyReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(jenny, AspectFoo.class, Collections.singletonList(jennyReportsToAlice), false);
 
     // Find all reports-to relationship for Alice.
     LocalRelationshipFilter filter;
@@ -720,13 +718,13 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _fooUrnEBeanLocalAccess.add(bob, new AspectFoo().setValue("Bob"), AspectFoo.class, new AuditStamp(), null, false);
     _fooUrnEBeanLocalAccess.add(jack, new AspectFoo().setValue("Jack"), AspectFoo.class, new AuditStamp(), null, false);
 
-    // Add Bob reports-to ALice relationship
+    // Add Bob reports-to Alice relationship
     ReportsTo bobReportsToAlice = new ReportsTo().setSource(bob).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(bobReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(bob, AspectFoo.class, Collections.singletonList(bobReportsToAlice), false);
 
-    // Add Jack reports-to ALice relationship
+    // Add Jack reports-to Alice relationship
     ReportsTo jackReportsToAlice = new ReportsTo().setSource(jack).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(jackReportsToAlice, false);
+    _localRelationshipWriterDAO.addRelationships(jack, AspectFoo.class, Collections.singletonList(jackReportsToAlice), false);
 
     // Find all Alice's direct reports.
     LocalRelationshipCriterion filterCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create("Alice"),
@@ -774,11 +772,11 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // Add Alice belongs to MIT and Stanford.
     BelongsTo aliceBelongsToMit = new BelongsTo().setSource(alice).setDestination(mit);
     BelongsTo aliceBelongsToStanford = new BelongsTo().setSource(alice).setDestination(stanford);
-    _localRelationshipWriterDAO.addRelationships(ImmutableList.of(aliceBelongsToStanford, aliceBelongsToMit), false);
+    _localRelationshipWriterDAO.addRelationships(alice, AspectFoo.class, ImmutableList.of(aliceBelongsToStanford, aliceBelongsToMit), false);
 
     // Add Bob belongs to Stanford.
     BelongsTo bobBelongsToStandford = new BelongsTo().setSource(bob).setDestination(stanford);
-    _localRelationshipWriterDAO.addRelationship(bobBelongsToStandford, false);
+    _localRelationshipWriterDAO.addRelationships(bob, AspectFoo.class, Collections.singletonList(bobBelongsToStandford), false);
 
     // Alice filter
     LocalRelationshipCriterion filterCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create("Alice"),
@@ -833,15 +831,15 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Add Alice pair-with Jack relationships. Alice --> Jack.
     PairsWith alicePairsWithJack = new PairsWith().setSource(alice).setDestination(jack);
-    _localRelationshipWriterDAO.addRelationship(alicePairsWithJack, false);
+    _localRelationshipWriterDAO.addRelationships(alice, AspectFoo.class, Collections.singletonList(alicePairsWithJack), false);
 
     // Add Bob pair-with Alice relationships. Bob --> Alice.
     PairsWith bobPairsWithAlice = new PairsWith().setSource(bob).setDestination(alice);
-    _localRelationshipWriterDAO.addRelationship(bobPairsWithAlice, false);
+    _localRelationshipWriterDAO.addRelationships(bob, AspectFoo.class, Collections.singletonList(bobPairsWithAlice), false);
 
     // Add Alice pair-with John relationships. Alice --> John.
     PairsWith alicePairsWithJohn = new PairsWith().setSource(alice).setDestination(john);
-    _localRelationshipWriterDAO.addRelationship(alicePairsWithJohn, false);
+    _localRelationshipWriterDAO.addRelationships(alice, AspectFoo.class, Collections.singletonList(alicePairsWithJohn), false);
 
     // Alice filter
     LocalRelationshipCriterion filterCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create("Alice"),

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -248,7 +248,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
     List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
     assertEquals(before.size(), 10001);
 
-    _localRelationshipWriterDAO.clearRelationshipsByEntity(barUrn, PairsWith.class, false);
+    _localRelationshipWriterDAO.clearRelationshipsByEntity(barUrn, AspectFoo.class, PairsWith.class, false);
 
     // After processing verification
     List<SqlRow> all = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -320,7 +320,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
 
   private String insertRelationships(String table, String sourceUrn, String sourceType, String destinationUrn, String destinationType, String aspect) {
     String insertWithAspectTemplate = "INSERT INTO %s (metadata, source, source_type, destination, destination_type, lastmodifiedon, lastmodifiedby, aspect)"
-        + " VALUES ('{\"metadata\": true}', '%s', '%s', '%s', '%s', '1970-01-01 00:00:01', 'unknown', '%s')";
+        + " VALUES ('{\"metadata\": true}', '%s', '%s', '%s', '%s', CURRENT_TIMESTAMP, 'unknown', '%s')";
     String insertTemplate = "INSERT INTO %s (metadata, source, source_type, destination, destination_type, lastmodifiedon, lastmodifiedby)"
         + " VALUES ('{\"metadata\": true}', '%s', '%s', '%s', '%s', CURRENT_TIMESTAMP, 'unknown')";
     if (_useAspectColumnForRelationshipRemoval) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -4,10 +4,9 @@ import com.google.common.io.Resources;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipWriterDAO;
 import com.linkedin.metadata.dao.builder.BaseLocalRelationshipBuilder.LocalRelationshipUpdates;
 import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
-import com.linkedin.metadata.dao.localrelationship.builder.PairsWithLocalRelationshipBuilder;
-import com.linkedin.metadata.dao.localrelationship.builder.ReportsToLocalRelationshipBuilder;
 import com.linkedin.metadata.dao.localrelationship.builder.VersionOfLocalRelationshipBuilder;
 import com.linkedin.metadata.dao.utils.EmbeddedMariaInstance;
+import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.BarUrnArray;
 import com.linkedin.testing.RelationshipV2Bar;
 import com.linkedin.testing.localrelationship.AspectFooBar;
@@ -24,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -32,7 +33,20 @@ import static org.testng.Assert.*;
 public class EbeanLocalRelationshipWriterDAOTest {
   private EbeanServer _server;
   private EbeanLocalRelationshipWriterDAO _localRelationshipWriterDAO;
+  private boolean _useAspectColumnForRelationshipRemoval;
 
+  @Factory(dataProvider = "inputList")
+  public EbeanLocalRelationshipWriterDAOTest(boolean useAspectColumnForRelationshipRemoval) {
+    _useAspectColumnForRelationshipRemoval = useAspectColumnForRelationshipRemoval;
+  }
+
+  @DataProvider
+  public static Object[][] inputList() {
+    return new Object[][]{
+        {true},
+        {false}
+    };
+  }
   @BeforeClass
   public void init() throws IOException {
     _server = EmbeddedMariaInstance.getServer(EbeanLocalRelationshipWriterDAOTest.class.getSimpleName());
@@ -42,56 +56,21 @@ public class EbeanLocalRelationshipWriterDAOTest {
   }
 
   @Test
-  public void testAddRelationshipWithRemoveNone() throws URISyntaxException {
-    // All relationship ingestion should default to REMOVE_ALL_EDGES_FROM_SOURCE. REMOVE_NONE is no longer supported.
-    AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(
-        BarUrn.createFromString("urn:li:bar:123"),
-        BarUrn.createFromString("urn:li:bar:456"),
-        BarUrn.createFromString("urn:li:bar:789")));
-
-    List<LocalRelationshipUpdates> updates = new ReportsToLocalRelationshipBuilder(AspectFooBar.class)
-        .buildRelationships(FooUrn.createFromString("urn:li:foo:123"), aspectFooBar);
-
-    try {
-      _localRelationshipWriterDAO.processLocalRelationshipUpdates(FooUrn.createFromString("urn:li:foo:123"), updates, false);
-      fail("This test should throw an exception since only REMOVE_ALL_EDGES_FROM_SOURCE is supported");
-    } catch (IllegalArgumentException e) {
-      // do nothing
-    }
-  }
-
-  @Test
-  public void testAddRelationshipWithRemoveAllEdgesFromSourceToDestination() throws URISyntaxException {
-    // All relationship ingestion should default to REMOVE_ALL_EDGES_FROM_SOURCE. REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION is no longer supported.
-    AspectFooBar aspectFooBar = new AspectFooBar().setBars(new BarUrnArray(BarUrn.createFromString("urn:li:bar:123")));
-
-    List<LocalRelationshipUpdates> updates = new PairsWithLocalRelationshipBuilder(AspectFooBar.class)
-        .buildRelationships(FooUrn.createFromString("urn:li:foo:123"), aspectFooBar);
-
-    try {
-      _localRelationshipWriterDAO.processLocalRelationshipUpdates(FooUrn.createFromString("urn:li:foo:123"), updates,
-          false);
-      fail("This test should throw an exception since only REMOVE_ALL_EDGES_FROM_SOURCE is supported");
-    } catch (IllegalArgumentException e) {
-      // do nothing
-    }
-  }
-
-  @Test
   public void testAddRelationshipWithRemoveAllEdgesFromSource() throws URISyntaxException {
+    _localRelationshipWriterDAO.setUseAspectColumnForRelationshipRemoval(_useAspectColumnForRelationshipRemoval);
     // Test cases for Relationship Model V1
     // set 3 existing relationships
     // 1) "urn:li:bar:123" -> "urn:li:foo:123"
     // 2) "urn:li:bar:123" -> "urn:li:foo:000"
     // 3) "urn:li:bar:000" -> "urn:li:foo:123"
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_versionof", "urn:li:bar:123",
-        "bar", "urn:li:foo:123", "foo")));
+        "bar", "urn:li:foo:123", "foo", AspectFooBar.class.getCanonicalName())));
 
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_versionof", "urn:li:bar:123",
-        "bar", "urn:li:foo:000", "foo")));
+        "bar", "urn:li:foo:000", "foo", AspectFooBar.class.getCanonicalName())));
 
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_versionof", "urn:li:bar:000",
-        "bar", "urn:li:foo:123", "foo")));
+        "bar", "urn:li:foo:123", "foo", AspectFooBar.class.getCanonicalName())));
 
     // mock a new relationship update
     // 1) "urn:li:bar:123" -> "urn:li:foo:123"
@@ -104,7 +83,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
     List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_versionof").findList();
     assertEquals(before.size(), 3);
 
-    _localRelationshipWriterDAO.processLocalRelationshipUpdates(BarUrn.createFromString("urn:li:bar:123"), updates, false);
+    _localRelationshipWriterDAO.processLocalRelationshipUpdates(BarUrn.createFromString("urn:li:bar:123"), AspectFooBar.class, updates, false);
 
     // After processing verification
     // now the relationship table should have the following relationships:
@@ -136,15 +115,15 @@ public class EbeanLocalRelationshipWriterDAOTest {
     // 3) "urn:li:foo:2" -> "urn:li:bar:2"
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_relationshipv2bar",
         "urn:li:foo:1", "foo",
-        "urn:li:bar:1", "bar")));
+        "urn:li:bar:1", "bar", AspectFooBar.class.getCanonicalName())));
 
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_relationshipv2bar",
         "urn:li:foo:1", "foo",
-        "urn:li:bar:2", "bar")));
+        "urn:li:bar:2", "bar", AspectFooBar.class.getCanonicalName())));
 
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_relationshipv2bar",
         "urn:li:foo:2", "foo",
-        "urn:li:bar:2", "bar")));
+        "urn:li:bar:2", "bar", AspectFooBar.class.getCanonicalName())));
 
     // mock 3 new relationships
     // 1) "urn:li:foo:1" -> "urn:li:bar:1"
@@ -180,7 +159,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
     // 4) "urn:li:foo:1" -> "urn:li:bar:1" (newly inserted)
     // 5) "urn:li:foo:1" -> "urn:li:bar:22" (newly inserted)
     // 6) "urn:li:foo:1" -> "urn:li:bar:23" (newly inserted)
-    _localRelationshipWriterDAO.processLocalRelationshipUpdates(FooUrn.createFromString("urn:li:foo:1"), updates2, false);
+    _localRelationshipWriterDAO.processLocalRelationshipUpdates(FooUrn.createFromString("urn:li:foo:1"), AspectFooBar.class, updates2, false);
 
     // After processing verification
     List<SqlRow> all2 = _server.createSqlQuery("select * from metadata_relationship_relationshipv2bar").findList();
@@ -203,21 +182,22 @@ public class EbeanLocalRelationshipWriterDAOTest {
 
 
   @Test
-  public void testClearRelationshipsByEntityUrn() throws URISyntaxException {
-    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", "urn:li:bar:123",
-        "bar", "urn:li:foo:123", "foo")));
+  public void testClearRelationshipsByEntityUrnSameAspect() throws URISyntaxException {
+    _localRelationshipWriterDAO.setUseAspectColumnForRelationshipRemoval(_useAspectColumnForRelationshipRemoval);
 
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", "urn:li:bar:123",
-        "bar", "urn:li:foo:456", "foo")));
+        "bar", "urn:li:foo:123", "foo", AspectFooBar.class.getCanonicalName())));
+
+    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", "urn:li:bar:123",
+        "bar", "urn:li:foo:456", "foo", AspectFooBar.class.getCanonicalName())));
 
     BarUrn barUrn = BarUrn.createFromString("urn:li:bar:123");
-    FooUrn fooUrn = FooUrn.createFromString("urn:li:foo:123");
 
     // Before processing
     List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
     assertEquals(before.size(), 2);
 
-    _localRelationshipWriterDAO.clearRelationshipsByEntity(barUrn, PairsWith.class, false);
+    _localRelationshipWriterDAO.clearRelationshipsByEntity(barUrn, AspectFooBar.class, PairsWith.class, false);
 
     // After processing verification
     List<SqlRow> all = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
@@ -228,33 +208,103 @@ public class EbeanLocalRelationshipWriterDAOTest {
   }
 
   @Test
-  public void testRemoveRelationships() throws URISyntaxException {
+  public void testClearRelationshipsByEntityUrnDifferentAspect() throws URISyntaxException {
+    if (!_useAspectColumnForRelationshipRemoval) {
+      return; // this test doesn't apply to this case
+    }
+    _localRelationshipWriterDAO.setUseAspectColumnForRelationshipRemoval(_useAspectColumnForRelationshipRemoval);
+
+    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", "urn:li:bar:123",
+        "bar", "urn:li:foo:123", "foo", AspectFooBar.class.getCanonicalName())));
+
+    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", "urn:li:bar:123",
+        "bar", "urn:li:foo:456", "foo", AspectFoo.class.getCanonicalName())));
+
+    BarUrn barUrn = BarUrn.createFromString("urn:li:bar:123");
+
+    // Before processing
+    List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
+    assertEquals(before.size(), 2);
+
+    _localRelationshipWriterDAO.clearRelationshipsByEntity(barUrn, AspectFooBar.class, PairsWith.class, false);
+
+    // After processing verification - only the first relationship with foo123 should have been deleted
+    List<SqlRow> all = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
+    assertEquals(all.size(), 1); // Total number of edges is 1
+
+    // Clean up
+    _server.execute(Ebean.createSqlUpdate("truncate metadata_relationship_pairswith"));
+  }
+
+  @Test
+  public void testRemoveRelationshipsSameAspect() throws URISyntaxException {
+    _localRelationshipWriterDAO.setUseAspectColumnForRelationshipRemoval(_useAspectColumnForRelationshipRemoval);
+
     BarUrn barUrn = BarUrn.createFromString("urn:li:bar:123");
     FooUrn fooUrn123 = FooUrn.createFromString("urn:li:foo:123");
     FooUrn fooUrn456 = FooUrn.createFromString("urn:li:foo:456");
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", barUrn.toString(),
-        "bar", fooUrn123.toString(), "foo")));
+        "bar", fooUrn123.toString(), "foo", AspectFooBar.class.getCanonicalName())));
 
     _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", barUrn.toString(),
-        "bar", fooUrn456.toString(), "foo")));
+        "bar", fooUrn456.toString(), "foo", AspectFooBar.class.getCanonicalName())));
 
     // Before processing
     List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
     assertEquals(before.size(), 2);
 
     PairsWith pairsWith = new PairsWith().setSource(barUrn).setDestination(fooUrn123);
-    _localRelationshipWriterDAO.removeRelationships(Collections.singletonList(pairsWith));
+    _localRelationshipWriterDAO.removeRelationships(barUrn, AspectFooBar.class, Collections.singletonList(pairsWith));
 
     // After processing verification
+    List<SqlRow> all = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
+    assertEquals(all.size(), 0); // Total number of edges is 0
+
+    // Clean up
+    _server.execute(Ebean.createSqlUpdate("truncate metadata_relationship_pairswith"));
+  }
+
+  @Test
+  public void testRemoveRelationshipsDifferentAspect() throws URISyntaxException {
+    if (!_useAspectColumnForRelationshipRemoval) {
+      return; // this test doesn't apply to this case
+    }
+    _localRelationshipWriterDAO.setUseAspectColumnForRelationshipRemoval(_useAspectColumnForRelationshipRemoval);
+
+    BarUrn barUrn = BarUrn.createFromString("urn:li:bar:123");
+    FooUrn fooUrn123 = FooUrn.createFromString("urn:li:foo:123");
+    FooUrn fooUrn456 = FooUrn.createFromString("urn:li:foo:456");
+    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", barUrn.toString(),
+        "bar", fooUrn123.toString(), "foo", AspectFooBar.class.getCanonicalName())));
+
+    _server.execute(Ebean.createSqlUpdate(insertRelationships("metadata_relationship_pairswith", barUrn.toString(),
+        "bar", fooUrn456.toString(), "foo", AspectFoo.class.getCanonicalName())));
+
+    // Before processing
+    List<SqlRow> before = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
+    assertEquals(before.size(), 2);
+
+    PairsWith pairsWith = new PairsWith().setSource(barUrn).setDestination(fooUrn123);
+    _localRelationshipWriterDAO.removeRelationships(barUrn, AspectFooBar.class, Collections.singletonList(pairsWith));
+
+    // After processing verification - only the first relationship with foo123 should have been deleted.
     List<SqlRow> all = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
     assertEquals(all.size(), 1); // Total number of edges is 1
     assertEquals(all.get(0).getString("source"), barUrn.toString());
     assertEquals(all.get(0).getString("destination"), fooUrn456.toString());
+
+    // Clean up
+    _server.execute(Ebean.createSqlUpdate("truncate metadata_relationship_pairswith"));
   }
 
-  private String insertRelationships(String table, String sourceUrn, String sourceType, String destinationUrn, String destinationType) {
+  private String insertRelationships(String table, String sourceUrn, String sourceType, String destinationUrn, String destinationType, String aspect) {
+    String insertWithAspectTemplate = "INSERT INTO %s (metadata, source, source_type, destination, destination_type, lastmodifiedon, lastmodifiedby, aspect)"
+        + " VALUES ('{\"metadata\": true}', '%s', '%s', '%s', '%s', '1970-01-01 00:00:01', 'unknown', '%s')";
     String insertTemplate = "INSERT INTO %s (metadata, source, source_type, destination, destination_type, lastmodifiedon, lastmodifiedby)"
         + " VALUES ('{\"metadata\": true}', '%s', '%s', '%s', '%s', '1970-01-01 00:00:01', 'unknown')";
+    if (_useAspectColumnForRelationshipRemoval) {
+      return String.format(insertWithAspectTemplate, table, sourceUrn, sourceType, destinationUrn, destinationType, aspect);
+    }
     return String.format(insertTemplate, table, sourceUrn, sourceType, destinationUrn, destinationType);
   }
 }

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all-with-non-dollar-virtual-column-names.sql
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     lastmodifiedon DATETIME(6) NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all.sql
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     lastmodifiedon DATETIME(6) NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -67,6 +68,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -80,6 +82,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -67,6 +68,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -80,6 +82,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
@@ -9,96 +9,102 @@ DROP TABLE IF EXISTS metadata_entity_foo;
 DROP TABLE IF EXISTS metadata_entity_bar;
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata LONGTEXT NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
-    );
+);
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata JSON NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
-    );
+);
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_ownedby (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata JSON NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
-    );
+);
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_pairswith (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata JSON NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
-    );
+);
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_versionof (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata JSON NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
-    );
+);
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_consumefrom (
-                                                                 id BIGINT NOT NULL AUTO_INCREMENT,
-                                                                 metadata JSON NOT NULL,
-                                                                 source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata JSON NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
-    );
+);
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_relationshipv2bar (
-                                                               id BIGINT NOT NULL AUTO_INCREMENT,
-                                                               metadata LONGTEXT NOT NULL,
-                                                               source VARCHAR(1000) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
     source_type VARCHAR(100) NOT NULL,
     destination VARCHAR(1000) NOT NULL,
     destination_type VARCHAR(100) NOT NULL,
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
-    );
-
+);
 
 -- initialize foo entity table
 CREATE TABLE IF NOT EXISTS metadata_entity_foo (

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -31,6 +32,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -45,6 +47,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto_test (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
     );
 
@@ -58,6 +61,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_ownedby (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -71,6 +75,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_pairswith (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -84,6 +89,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_versionof (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -97,6 +103,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_consumefrom (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -110,6 +117,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_relationshipv2bar (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 

--- a/dao-impl/ebean-dao/src/test/resources/gma-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/gma-create-all.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
     lastmodifiedon DATETIME(6) NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -54,6 +55,7 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
     lastmodifiedon DATETIME(6) NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );
 
@@ -67,5 +69,6 @@ CREATE TABLE IF NOT EXISTS metadata_relationship_reportsto (
     lastmodifiedon DATETIME(6) NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
     PRIMARY KEY (id)
 );


### PR DESCRIPTION
## Summary
Add `aspect` column to relationship tables so that during relationship deletion, only the relationships derived from the same aspect that is being ingested can be deleted. This is to prevent accidental deletion of relationships which can be derived from multiple aspects.

Added a flag `useAspectColumnForRelationshipRemoval` which defaults to false to be backwards compatible.

Updated relationship soft deletion so it always works now whenever an aspect is soft-deleted.

Did some code cleanup of the RelationshipSource enum which is no longer needed since it will always try to get relationships from relationship builders first before looking in the aspect.

## Testing Done
add unit tests

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
