### PR TITLE
throw 404 exception when get non-existing asset

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -528,6 +528,11 @@ public abstract class BaseEntityResource<
 
     return RestliUtils.toTask(() -> {
       final URN urn = parseUrnParam(urnString);
+
+      if (!getLocalDAO().exists(urn)) {
+        throw RestliUtils.resourceNotFoundException();
+      }
+
       final Set<AspectKey<URN, ? extends RecordTemplate>> keys = parseAspectsParam(aspectNames, true).stream()
           .map(aspectClass -> new AspectKey<>(aspectClass, urn, LATEST_VERSION))
           .collect(Collectors.toSet());

--- a/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/restli-resources/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -1448,6 +1448,8 @@ public class BaseEntityResourceTest extends BaseEngineTest {
         ImmutableMap.of(fooKey, Optional.of(foo), fooEvolvedKey, Optional.of(fooEvolved), barKey, Optional.of(bar),
             fooBarKey, Optional.of(fooBar), attKey, Optional.of(attributes)));
 
+    when(_mockLocalDAO.exists(urn)).thenReturn(true);
+
     EntityAsset asset = runAndWait(_resource.getAsset(urn.toString(), null));
 
     assertEquals(asset.getUrn(), urn);
@@ -1457,6 +1459,19 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     assertEquals(asset.getBar(), bar);
     assertEquals(asset.getAspectFooBar(), fooBar);
     assertEquals(asset.getAspectAttributes(), attributes);
+  }
+
+  @Test
+  public void testGetNonExistAsset() {
+    // Test get non existing assets
+    FooUrn nonExist = makeFooUrn(2);
+    when(_mockLocalDAO.exists(nonExist)).thenReturn(false);
+    try {
+      runAndWait(_resource.getAsset(nonExist.toString(), null));
+      fail("get non-exist asset should fail");
+    } catch (RestLiServiceException restLiServiceException) {
+      // expected failure
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

When ./getAsset on non-existing asset, it should throw 404 exception 

## Testing Done

unit test

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
