### PR TITLE
fix(relationship): fix bug in extractRelationshipFromAspect

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -405,7 +405,7 @@ public class EBeanDAOUtils {
         } else if (!(obj instanceof List) || ((List) obj).isEmpty() || !(((List) obj).get(0) instanceof RecordTemplate)) {
           return;
         }
-        // filter out all non-primitive, non-relationship fields
+        // filter out all non-primitive, non-relationship, non-list fields
         if (!(obj instanceof List)) {
           return;
         }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -405,7 +405,13 @@ public class EBeanDAOUtils {
         } else if (!(obj instanceof List) || ((List) obj).isEmpty() || !(((List) obj).get(0) instanceof RecordTemplate)) {
           return;
         }
-        List<RecordTemplate> relationshipsList = (List<RecordTemplate>) obj;
+        List<RecordTemplate> relationshipsList;
+        try {
+          relationshipsList = (List<RecordTemplate>) obj;
+        } catch (ClassCastException e) {
+          // if the field cannot be cast to a list, and it wasn't a RecordTemplate, skip since it cannot be a relationship
+          return;
+        }
         ModelType modelType = parseModelTypeFromGmaAnnotation(relationshipsList.get(0));
         if (modelType == ModelType.RELATIONSHIP) {
           log.debug("Found {} relationships of type {} for field {} of aspect class {}.",

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -405,13 +405,11 @@ public class EBeanDAOUtils {
         } else if (!(obj instanceof List) || ((List) obj).isEmpty() || !(((List) obj).get(0) instanceof RecordTemplate)) {
           return;
         }
-        List<RecordTemplate> relationshipsList;
-        try {
-          relationshipsList = (List<RecordTemplate>) obj;
-        } catch (ClassCastException e) {
-          // if the field cannot be cast to a list, and it wasn't a RecordTemplate, skip since it cannot be a relationship
+        // filter out all non-primitive, non-relationship fields
+        if (!(obj instanceof List)) {
           return;
         }
+        List<RecordTemplate> relationshipsList = (List<RecordTemplate>) obj;
         ModelType modelType = parseModelTypeFromGmaAnnotation(relationshipsList.get(0));
         if (modelType == ModelType.RELATIONSHIP) {
           log.debug("Found {} relationships of type {} for field {} of aspect class {}.",

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -28,6 +28,7 @@ import com.linkedin.testing.AspectWithDefaultValue;
 import com.linkedin.testing.CommonAspect;
 import com.linkedin.testing.CommonAspectArray;
 import com.linkedin.testing.MapValueRecord;
+import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
@@ -645,6 +646,7 @@ public class EBeanDAOUtilsTest {
     //     relationshipFoos -> [foo1, foo2]
     //     relationshipBars -> [bar1]
     //     moreRelationshipFoos -> not present
+    //     nonPrimitiveNonRelationshipField -> barUrn
     // }
     // expect:
     // [[foo1, foo2], [bar1]]
@@ -655,7 +657,8 @@ public class EBeanDAOUtilsTest {
         .setRelationshipFoo1(test3)
         // don't set relationshipFoo2 fields
         .setRelationshipFoos(relationshipFoos)
-        .setRelationshipBars(relationshipBars); // don't set moreRelationshipFoos field
+        .setRelationshipBars(relationshipBars) // don't set moreRelationshipFoos field
+        .setNonPrimitiveNonRelationshipField(BarUrn.createFromString("urn:li:bar:1"));
 
     results = EBeanDAOUtils.extractRelationshipsFromAspect(barWithRelationshipFields);
     assertEquals(2, results.size());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -28,7 +28,6 @@ import com.linkedin.testing.AspectWithDefaultValue;
 import com.linkedin.testing.CommonAspect;
 import com.linkedin.testing.CommonAspectArray;
 import com.linkedin.testing.MapValueRecord;
-import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -658,7 +658,7 @@ public class EBeanDAOUtilsTest {
         // don't set relationshipFoo2 fields
         .setRelationshipFoos(relationshipFoos)
         .setRelationshipBars(relationshipBars) // don't set moreRelationshipFoos field
-        .setNonPrimitiveNonRelationshipField(BarUrn.createFromString("urn:li:bar:1"));
+        .setNonPrimitiveNonRelationshipField(new CommonAspect());
 
     results = EBeanDAOUtils.extractRelationshipsFromAspect(barWithRelationshipFields);
     assertEquals(2, results.size());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -645,7 +645,7 @@ public class EBeanDAOUtilsTest {
     //     relationshipFoos -> [foo1, foo2]
     //     relationshipBars -> [bar1]
     //     moreRelationshipFoos -> not present
-    //     nonPrimitiveNonRelationshipField -> barUrn
+    //     nonPrimitiveNonRelationshipField -> commonAspect2
     // }
     // expect:
     // [[foo1, foo2], [bar1]]

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
@@ -51,4 +51,9 @@ record AnnotatedAspectBarWithRelationshipFields {
    * For unit tests
    */
   moreRelationshipFoos: optional array[AnnotatedRelationshipFoo]
+
+  /**
+   * For unit tests
+   */
+  nonPrimitiveNonRelationshipField = optional BarUrn
 }

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
@@ -55,5 +55,5 @@ record AnnotatedAspectBarWithRelationshipFields {
   /**
    * For unit tests
    */
-  nonPrimitiveNonRelationshipField = optional BarUrn
+  nonPrimitiveNonRelationshipField = optional CommonAspect
 }

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/AnnotatedAspectBarWithRelationshipFields.pdl
@@ -55,5 +55,5 @@ record AnnotatedAspectBarWithRelationshipFields {
   /**
    * For unit tests
    */
-  nonPrimitiveNonRelationshipField = optional CommonAspect
+  nonPrimitiveNonRelationshipField: optional CommonAspect
 }


### PR DESCRIPTION
## Summary
There is a bug in metadata-store integration tests:
```
com.linkedin.metadata.dao.RestliClientStatusException: com.linkedin.restli.client.RestLiResponseException: Response status 500, serviceErrorMessage: java.lang.ClassCastException: class com.linkedin.common.EntityComplianceAnnotation cannot be cast to class java.util.List (com.linkedin.common.EntityComplianceAnnotation is in unnamed module of loader 'app'; java.util.List is in module java.base of loader 'bootstrap')

```

This is because RecordTemplates are first checked to see if they are relationships. If not, the previous logic will assume that they are lists. But this is not the case if they are other structs. The fix is to add a check to see if it is a list. If it's not, just return.
## Testing Done
update unit test
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
