### PR TITLE
fix(aim): make an exception for checkSameSourceUrn for AIM case

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/GraphUtils.java
@@ -23,6 +23,12 @@ public class GraphUtils {
     if (relationships.isEmpty()) {
       return;
     }
+
+    // TODO: remove this temporary allow list after AIM no longer relies on ProducesLocalRelationshipBuilderFromFeatureDependencies
+    if (assetUrn != null && assetUrn.getEntityType().equals("mlFeatureVersion") && relationships.get(0).getClass().getSimpleName().equals("produces")) {
+      return;
+    }
+
     for (RecordTemplate relationship : relationships) {
       if (ModelUtils.isRelationshipInV2(relationship.schema())) {
         if (assetUrn == null) {


### PR DESCRIPTION
## Summary
AIM integration tests are failing because of this validation check. They have a special case where the urn from which the relationship is derived (MlTrainedModel) is the destination of the Produces relationship. Allow this use case temporarily while AIM redesigns their models.
## Testing Done
mint build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
