### PR TITLE
translate ModelValidationException to 4XX

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/exception/ModelValidationException.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/exception/ModelValidationException.java
@@ -1,5 +1,9 @@
 package com.linkedin.metadata.dao.exception;
 
+/**
+ * Exception thrown when the requested aspect is not defined in the asset model / there is invalid aspect present
+ * in the database that is not defined in the asset model.
+ */
 public class ModelValidationException extends RuntimeException {
 
   public ModelValidationException(String message) {


### PR DESCRIPTION
## Summary
we had large amount of exceptions like this
```
com.linkedin.metadata.dao.exception.ModelValidationException: failed to get aspect alias for: com.linkedin.dataset.DatasetProperties from asset: class pegasus.com.linkedin.metadata.asset.GrpcMethodAsset:
    at com.linkedin.metadata.dao.utils.SQLSchemaUtils.getColumnName(SQLSchemaUtils.java:225)
    at com.linkedin.metadata.dao.utils.SQLSchemaUtils.getAspectColumnName(SQLSchemaUtils.java:131)
    at com.linkedin.metadata.dao.utils.SQLSchemaUtils.getAspectColumnName(SQLSchemaUtils.java:151)
    at com.linkedin.metadata.dao.EbeanLocalAccess.batchGetUnion(EbeanLocalAccess.java:179)
    at com.linkedin.metadata.dao.EbeanLocalDAO.batchGetHelper(EbeanLocalDAO.java:1148)
    at com.linkedin.metadata.dao.EbeanLocalDAO.batchGet(EbeanLocalDAO.java:1078)
    at com.linkedin.metadata.dao.EbeanLocalDAO.get(EbeanLocalDAO.java:975)
    at com.linkedin.metadata.restli.BaseAspectRoutingResource.getInternalAspectsFromLocalDao(BaseAspectRoutingResource.java:548)
    at com.linkedin.metadata.restli.BaseAspectRoutingResource.lambda$getSnapshot$2(BaseAspectRoutingResource.java:160)
    at com.linkedin.metadata.restli.RestliUtils.toTask(RestliUtils.java:35)
    at com.linkedin.metadata.restli.BaseAspectRoutingResource.getSnapshot(BaseAspectRoutingResource.java:157)
    at com.linkedin.metadata.restli.BaseAspectRoutingResource.getSnapshot(BaseAspectRoutingResource.java:146)
    at com.linkedin.service.rest.resources.grpcmethod.GrpcMethods.getSnapshot(GrpcMethods.java:243)
    at jdk.internal.reflect.GeneratedMethodAccessor236.invoke
```
this pr translates this type of exception to to a 4XX restli service exception

## Testing Done
./gradlew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
