### PR TITLE
fix(backfill): update a_urn column during entity table backfill

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -58,6 +58,7 @@ public class SQLStatementUtils {
 
   // Note: include a_urn in the duplicate key update for backfilling the a_urn column in updateEntityTables() if the column was
   // added after data already exists in the entity table. Normally, a_urn never needs to get updated once it's set the first time.
+  // Note: this SQL should only be called if the urnExtraction flag is true (i.e. a_urn column exists)
   private static final String SQL_UPSERT_ASPECT_WITH_URN_TEMPLATE =
       "INSERT INTO %s (urn, a_urn, %s, lastmodifiedon, lastmodifiedby) VALUE (:urn, :a_urn, :metadata, :lastmodifiedon, :lastmodifiedby) "
           + "ON DUPLICATE KEY UPDATE %s = :metadata, lastmodifiedon = :lastmodifiedon, a_urn = :a_urn;";

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -56,9 +56,11 @@ public class SQLStatementUtils {
       "INSERT INTO %s (urn, %s, lastmodifiedon, lastmodifiedby) VALUE (:urn, :metadata, :lastmodifiedon, :lastmodifiedby) "
           + "ON DUPLICATE KEY UPDATE %s = :metadata, lastmodifiedon = :lastmodifiedon;";
 
+  // Note: include a_urn in the duplicate key update for backfilling the a_urn column in updateEntityTables() if the column was
+  // added after data already exists in the entity table. Normally, a_urn never needs to get updated once it's set the first time.
   private static final String SQL_UPSERT_ASPECT_WITH_URN_TEMPLATE =
       "INSERT INTO %s (urn, a_urn, %s, lastmodifiedon, lastmodifiedby) VALUE (:urn, :a_urn, :metadata, :lastmodifiedon, :lastmodifiedby) "
-          + "ON DUPLICATE KEY UPDATE %s = :metadata, lastmodifiedon = :lastmodifiedon;";
+          + "ON DUPLICATE KEY UPDATE %s = :metadata, lastmodifiedon = :lastmodifiedon, a_urn = :a_urn;";
 
   // "JSON_EXTRACT(%s, '$.gma_deleted') IS NOT NULL" is used to exclude soft-deleted entity which has no lastmodifiedon.
   // for details, see the known limitations on https://github.com/linkedin/datahub-gma/pull/311. Same reason for

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -43,7 +43,7 @@ public class SQLStatementUtilsTest {
     String expectedSql =
         "INSERT INTO metadata_entity_foo (urn, a_urn, a_aspectfoo, lastmodifiedon, lastmodifiedby) VALUE (:urn, "
             + ":a_urn, :metadata, :lastmodifiedon, :lastmodifiedby) ON DUPLICATE KEY UPDATE a_aspectfoo = :metadata,"
-            + " lastmodifiedon = :lastmodifiedon;";
+            + " lastmodifiedon = :lastmodifiedon, a_urn = :a_urn;";
     assertEquals(SQLStatementUtils.createAspectUpsertSql(fooUrn, AspectFoo.class, true, false), expectedSql);
 
     expectedSql =


### PR DESCRIPTION
## Summary
Currently, backfillEntityTables API does not backfill the a_urn column. This is an oversight since we never expected to need to backfill this column and it cannot be backfilled like other aspect columns. Thus, the solution is to add it to the upsert SQL which is called in EbeanLocalAccess::add. 
## Testing Done
./gradlew build


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
