### PR TITLE
catch duplicate entry errors and silently fail

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -858,6 +858,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         if (e.getMessage() != null && e.getMessage().contains("Duplicate entry")) {
           // silently fail and log the error
           log.warn("Insert to metadata_aspect failed due to duplicate entry exception. Exception: {}", e.toString());
+        } else {
+          throw e;
         }
       }
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -855,7 +855,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       try {
         _server.insert(aspect);
       } catch (Exception e) {
-        if (e.getMessage().contains("Duplicate entry")) {
+        if (e.getMessage() != null && e.getMessage().contains("Duplicate entry")) {
           // silently fail and log the error
           log.warn("Insert to metadata_aspect failed due to duplicate entry exception. Exception: {}", e.toString());
         }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -852,7 +852,14 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     //   2. if NOT in test mode
     //      -> which is ALWAYS a dual-write operation (meaning this insertion will already happen in the "other" write)
     if (_changeLogEnabled && !isTestMode) {
-      _server.insert(aspect);
+      try {
+        _server.insert(aspect);
+      } catch (Exception e) {
+        if (e.getMessage().contains("Duplicate entry")) {
+          // silently fail and log the error
+          log.warn("Insert to metadata_aspect failed due to duplicate entry exception. Exception: {}", e.toString());
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Catch duplicate entry exceptions during server.insert() due to race conditions.
Log at WARN level.

Exceptions from before:
```
Error[Duplicate entry 'urn:li:mlFeatureAnchor:(urn:li:mlFeatureVersion:(urn:li:mlFeatur' for key 'metadata_aspect.PRIMARY']
at io.ebean.config.dbplatform.SqlCodeTranslator.translate(SqlCodeTranslator.java:46)
at io.ebean.config.dbplatform.DatabasePlatform.translate(DatabasePlatform.java:223)
at io.ebeaninternal.server.persist.dml.DmlBeanPersister.execute(DmlBeanPersister.java:83)
at io.ebeaninternal.server.persist.dml.DmlBeanPersister.insert(DmlBeanPersister.java:49)
at io.ebeaninternal.server.core.PersistRequestBean.executeInsert(PersistRequestBean.java:1295)
at io.ebeaninternal.server.core.PersistRequestBean.executeNow(PersistRequestBean.java:797)
at io.ebeaninternal.server.core.PersistRequestBean.executeNoBatch(PersistRequestBean.java:852)
at io.ebeaninternal.server.core.PersistRequestBean.executeOrQueue(PersistRequestBean.java:843)
at io.ebeaninternal.server.persist.DefaultPersister.insert(DefaultPersister.java:525)
at io.ebeaninternal.server.persist.DefaultPersister.insert(DefaultPersister.java:471)
at io.ebeaninternal.server.core.DefaultServer.insert(DefaultServer.java:1773)
at io.ebeaninternal.server.core.DefaultServer.insert(DefaultServer.java:1765)
at com.linkedin.metadata.dao.EbeanLocalDAO.insert(EbeanLocalDAO.java:855)
at com.linkedin.metadata.dao.EbeanLocalDAO.saveLatest(EbeanLocalDAO.java:627)
at com.linkedin.metadata.dao.BaseLocalDAO.addCommon(BaseLocalDAO.java:523)
```
## Testing Done
N/A
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
