### PR TITLE
Update workflows to explicitly use ubuntu-22.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
           dpkg --add-architecture i386 && apt update
           sudo apt-get update
       - name: Install lib
-        run: sudo apt-get install libncurses5 libncurses5:i386
+        run: sudo apt-get install libncurses6 libncurses6:i386
 
       - name: Gradle build (and test)
         run: ./gradlew build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,12 +24,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Update package list
-        run: |
-          dpkg --add-architecture i386 && apt update
-          sudo apt-get update
       - name: Install lib
-        run: sudo apt-get install libncurses6 libncurses6:i386
+        run: sudo apt-get install libncurses6
 
       - name: Gradle build (and test)
         run: ./gradlew build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -25,7 +25,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Install lib
-        run: sudo apt-get install libncurses6
+        run: sudo apt-get install libncurses5
 
       - name: Gradle build (and test)
         run: ./gradlew build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           java-version: 1.8
       - name: Add to source list
-        run: echo "deb http://security.ubuntu.com/ubuntu focal-security main universe" > /etc/apt/sources.list.d/ubuntu-focal-sources.list
+        run: |
+          chmod +777 /etc/apt/sources.list.d/ubuntu-focal-sources.list
+          echo "deb http://security.ubuntu.com/ubuntu focal-security main universe" > /etc/apt/sources.list.d/ubuntu-focal-sources.list
       - name: Update package list
         run: sudo apt-get update
       - name: Install lib

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Add i386 architecture
-        run: sudo dpkg --add-architecture i386
+      - name: Add to source list
+        run: echo "deb http://security.ubuntu.com/ubuntu focal-security main universe" > /etc/apt/sources.list.d/ubuntu-focal-sources.list
       - name: Update package list
         run: sudo apt-get update
       - name: Install lib

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      
+      - name: Add i386 architecture
+        run: sudo dpkg --add-architecture i386
       - name: Update package list
         run: sudo apt-get update
       - name: Install lib

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,14 +24,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Add to source list
-        run: |
-          chmod +777 /etc/apt/sources.list.d/ubuntu-focal-sources.list
-          echo "deb http://security.ubuntu.com/ubuntu focal-security main universe" > /etc/apt/sources.list.d/ubuntu-focal-sources.list
       - name: Update package list
         run: sudo apt-get update
       - name: Install lib
-        run: sudo apt-get install libncurses5 libncurses5:i386
+        run: sudo apt-get install libncurses5
 
       - name: Gradle build (and test)
         run: ./gradlew build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      
+      - name: Update package list
+        run: sudo apt-get update
       - name: Install lib
         run: sudo apt-get install libncurses5 libncurses5:i386
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Install lib
-        run: sudo apt-get install libncurses5
+        run: sudo apt-get install libncurses5 libncurses5:i386
 
       - name: Gradle build (and test)
         run: ./gradlew build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,9 +25,11 @@ jobs:
         with:
           java-version: 1.8
       - name: Update package list
-        run: sudo apt-get update
+        run: |
+          dpkg --add-architecture i386 && apt update
+          sudo apt-get update
       - name: Install lib
-        run: sudo apt-get install libncurses5
+        run: sudo apt-get install libncurses5 libncurses5:i386
 
       - name: Gradle build (and test)
         run: ./gradlew build

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install lib
-        run: sudo apt-get install libncurses5
+        run: sudo apt-get install libncurses6
 
       - name: Release
         uses: ./.github/actions/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install lib
-        run: sudo apt-get install libncurses6
+        run: sudo apt-get install libncurses5
 
       - name: Release
         uses: ./.github/actions/release


### PR DESCRIPTION
## Summary
Build and release on GH actions is failing consistently with

```
Run sudo apt-get install libncurses5
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libncurses5
Error: Process completed with exit code 100.
```

This may be due to the recent Ubuntu 24.04 migration that GH is performing which affects all workflows using `ubuntu-latest`. Ref: https://github.com/actions/runner-images/issues/10636. The article recommends to downgrade to ubuntu 22.04 explicitly if running into issues.
## Testing Done
build action on gh (which uses build-and-test.yml) succeeds
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
