### PR TITLE
feat(SMO relationship onboarding: Hack week): Add a getter method for mgEntityTypeNameSet

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -251,11 +251,8 @@ public class EbeanLocalRelationshipQueryDAO {
       // there's no concept of MG entity or non-entity in old schema mode. always return false.
       return false;
     }
-    // there is some race condition, the local relationship db might not be ready when EbeanLocalRelationshipQueryDAO inits.
-    // so we can't init the _mgEntityTypeNameSet in constructor.
-    if (_mgEntityTypeNameSet == null) {
-      initMgEntityTypeNameSet();
-    }
+
+    initMgEntityTypeNameSet();
 
     return _mgEntityTypeNameSet.contains(StringUtils.lowerCase(entityType));
   }
@@ -483,6 +480,8 @@ public class EbeanLocalRelationshipQueryDAO {
    * Creates and return a set of MG entity type names by querying the database.
    */
   public Set<String> initMgEntityTypeNameSet() {
+    // there is some race condition, the local relationship db might not be ready when EbeanLocalRelationshipQueryDAO inits.
+    // so we can't init the _mgEntityTypeNameSet in constructor.
     if (_mgEntityTypeNameSet == null) {
       final String sql = "SELECT table_name FROM information_schema.tables"
           + " WHERE table_type = 'BASE TABLE' AND TABLE_SCHEMA=DATABASE() AND table_name LIKE 'metadata_entity_%'";

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -73,13 +73,6 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Get the set of MG entity type names.
-   */
-  public Set<String> getMgEntityTypeNameSet() {
-    return _mgEntityTypeNameSet;
-  }
-
-  /**
    * Finds a list of entities of a specific type based on the given filter on the entity.
    * The SNAPSHOT class must be defined within com.linkedin.metadata.snapshot package in metadata-models.
    * This method is not supported in OLD_SCHEMA_ONLY mode.
@@ -487,13 +480,18 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Creates a set of MG entity type names by querying the database.
+   * Creates and return a set of MG entity type names by querying the database.
    */
-  public void initMgEntityTypeNameSet() {
-    final String sql = "SELECT table_name FROM information_schema.tables"
-        + " WHERE table_type = 'BASE TABLE' AND TABLE_SCHEMA=DATABASE() AND table_name LIKE 'metadata_entity_%'";
-    _mgEntityTypeNameSet = _server.createSqlQuery(sql).findList().stream()
-        .map(row -> row.getString("table_name").replace("metadata_entity_", ""))
-        .collect(Collectors.toSet());
+  public Set<String> initMgEntityTypeNameSet() {
+    if (_mgEntityTypeNameSet == null) {
+      final String sql = "SELECT table_name FROM information_schema.tables"
+          + " WHERE table_type = 'BASE TABLE' AND TABLE_SCHEMA=DATABASE() AND table_name LIKE 'metadata_entity_%'";
+      _mgEntityTypeNameSet = _server.createSqlQuery(sql)
+          .findList()
+          .stream()
+          .map(row -> row.getString("table_name").replace("metadata_entity_", ""))
+          .collect(Collectors.toSet());
+    }
+    return _mgEntityTypeNameSet;
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -73,6 +73,13 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
+   * Get the set of MG entity type names.
+   */
+  public Set<String> getMgEntityTypeNameSet() {
+    return _mgEntityTypeNameSet;
+  }
+
+  /**
    * Finds a list of entities of a specific type based on the given filter on the entity.
    * The SNAPSHOT class must be defined within com.linkedin.metadata.snapshot package in metadata-models.
    * This method is not supported in OLD_SCHEMA_ONLY mode.


### PR DESCRIPTION
## Summary
To access the _mgEntityTypeNameSet after calling initMgEntityTypeNameSet(), we need to add a public getter method in the EbeanLocalRelationshipQueryDAO class

## Testing Done

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
