### PR TITLE
Refactor deletion

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -872,7 +872,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     // entire delete operation should be atomic
     final Collection<RecordTemplate> results = runInTransactionWithRetry(() -> aspectClasses.stream()
-        .map(x -> deleteWithReturn(urn, x, auditStamp, maxTransactionRetry, trackingContext))
+        .map(x -> delete(urn, x, auditStamp, maxTransactionRetry, trackingContext))
         .collect(Collectors.toList()), maxTransactionRetry);
 
     // package into ASPECT_UNION, this is logic performed in unwrapAddResultToUnion()
@@ -884,42 +884,35 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * Deletes the latest version of aspect for an entity.
+   * Deletes the latest version of an aspect for an entity and returns the ***old value***.
    *
    * <p>The new aspect will have an automatically assigned version number, which is guaranteed to be positive and
    * monotonically increasing. Older versions of aspect will be purged automatically based on the retention setting.
    *
-   * <p>Note that we do not support Post-update hooks while soft deleting an aspect
+   * <p>Note that we do not currently support pre- or post- update hooks while soft deleting an aspect.
+   *
+   * <p>Note that if the aspect is already null or deleted, the return value will be null. Mechanistically, upon a normal
+   * "LIVE" ingestion, the deletion operation is skipped altogether.
    *
    * @param urn urn the URN for the entity the aspect is attached to
    * @param aspectClass aspectClass of the aspect being saved
    * @param auditStamp the audit stamp of the previous latest aspect, null if new value is the first version
    * @param maxTransactionRetry maximum number of transaction retries before throwing an exception
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}
+   * @return the content of the aspect before deletion
    */
-  public <ASPECT extends RecordTemplate> void delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  @Nullable
+  public <ASPECT extends RecordTemplate> ASPECT delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp, int maxTransactionRetry) {
-    delete(urn, aspectClass, auditStamp, maxTransactionRetry, null);
+    return delete(urn, aspectClass, auditStamp, maxTransactionRetry, null);
   }
 
   /**
    * Same as above {@link #delete(Urn, Class, AuditStamp, int)} but with tracking context.
    */
-  public <ASPECT extends RecordTemplate> void delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
-      @Nonnull AuditStamp auditStamp, int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext) {
-    deleteWithReturn(urn, aspectClass, auditStamp, maxTransactionRetry, trackingContext);
-  }
-
-  /**
-   * Deletes the latest version of an aspect for an entity and returns the ***old value***.
-   *
-   * <p>Note that if the aspect is already null or deleted, the return value will be null. Mechanistically, upon a normal
-   * "LIVE" ingestion, the deletion operation is skipped altogether.
-   */
   @Nullable
-  public <ASPECT extends RecordTemplate> ASPECT deleteWithReturn(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  public <ASPECT extends RecordTemplate> ASPECT delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp, int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext) {
-
     checkValidAspect(aspectClass);
 
     final AddResult<ASPECT> result = runInTransactionWithRetry(() -> {
@@ -1012,19 +1005,19 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * Similar to {@link #delete(Urn, Class, AuditStamp, int)} but uses the default maximum transaction retry.
    */
-  @Nonnull
-  public <ASPECT extends RecordTemplate> void delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  @Nullable
+  public <ASPECT extends RecordTemplate> ASPECT delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp) {
-    delete(urn, aspectClass, auditStamp, null);
+    return delete(urn, aspectClass, auditStamp, null);
   }
 
   /**
    * Same as above {@link #delete(Urn, Class, AuditStamp)} but with tracking context.
    */
-  @Nonnull
-  public <ASPECT extends RecordTemplate> void delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
+  @Nullable
+  public <ASPECT extends RecordTemplate> ASPECT delete(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext) {
-    delete(urn, aspectClass, auditStamp, DEFAULT_MAX_TRANSACTION_RETRY, trackingContext);
+    return delete(urn, aspectClass, auditStamp, DEFAULT_MAX_TRANSACTION_RETRY, trackingContext);
   }
 
   private <ASPECT extends RecordTemplate> void applyRetention(@Nonnull URN urn, @Nonnull Class<ASPECT> aspectClass,

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -2735,7 +2735,7 @@ public class EbeanLocalDAOTest {
     EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
     FooUrn urn = makeFooUrn(1);
 
-    AspectFoo foo = dao.deleteWithReturn(urn, AspectFoo.class, _dummyAuditStamp, 3, null);
+    AspectFoo foo = dao.delete(urn, AspectFoo.class, _dummyAuditStamp, 3, null);
     assertNull(foo);
   }
 
@@ -2749,7 +2749,7 @@ public class EbeanLocalDAOTest {
     dao.add(urn, v0, _dummyAuditStamp);
 
     // attempt to delete an aspect that doesn't exist
-    AspectBar foo = dao.deleteWithReturn(urn, AspectBar.class, _dummyAuditStamp, 3, null);
+    AspectBar foo = dao.delete(urn, AspectBar.class, _dummyAuditStamp, 3, null);
     assertNull(foo);
   }
 
@@ -2759,13 +2759,13 @@ public class EbeanLocalDAOTest {
     FooUrn urn = makeFooUrn(1);
     AspectFoo v0 = new AspectFoo().setValue("foo");
     dao.add(urn, v0, _dummyAuditStamp);
-    AspectFoo foo = dao.deleteWithReturn(urn, AspectFoo.class, _dummyAuditStamp, 3, null);
+    AspectFoo foo = dao.delete(urn, AspectFoo.class, _dummyAuditStamp, 3, null);
 
     // make sure that the content matches the original
     assertEquals(foo, v0);
 
     // attempt to delete an aspect that has already been deleted
-    AspectFoo fooAgain = dao.deleteWithReturn(urn, AspectFoo.class, _dummyAuditStamp, 3, null);
+    AspectFoo fooAgain = dao.delete(urn, AspectFoo.class, _dummyAuditStamp, 3, null);
     assertNull(fooAgain);
   }
 


### PR DESCRIPTION
## Summary

Get rid of `deleteWithReturn()` and make returning something a part of the normal `delete()` call. This will eventually be propagated up to `metadata-graph-assets` so that a default-parameter-version of `delete()` can be used for simplicity.

## Testing Done

adjusted unit testing

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
