### PR TITLE
[Bug Fix] Added null check for extracted aspect value

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -374,9 +374,12 @@ public class EbeanLocalRelationshipQueryDAO {
       String auditedAspectStr = sqlRow.getString(colName);
 
       if (auditedAspectStr != null) {
-        RecordTemplate aspect = RecordUtils.toRecordTemplate(ClassUtils.loadClass(aspectCanonicalName),
-            EBeanDAOUtils.extractAspectJsonString(auditedAspectStr));
-        aspects.add(ModelUtils.newAspectUnion(ModelUtils.getUnionClassFromSnapshot(snapshotClass), aspect));
+        String extractedAspectStr = EBeanDAOUtils.extractAspectJsonString(auditedAspectStr);
+        if (extractedAspectStr != null) {
+          RecordTemplate aspect = RecordUtils.toRecordTemplate(ClassUtils.loadClass(aspectCanonicalName),
+              extractedAspectStr);
+          aspects.add(ModelUtils.newAspectUnion(ModelUtils.getUnionClassFromSnapshot(snapshotClass), aspect));
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
Added null check for extracted aspect value.

For Graph queries, we are getting this Null Pointer Exception and analyzing the stack trace we found this could be a potential gap.

```
Error message:
NullPointerException: Cannot invoke "String.length()" because "content" is null,

Root cause:
java.lang.NullPointerException: Cannot invoke "String.length()" because "content" is null
	at com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:1336)
	at com.linkedin.data.codec.JacksonDataCodec.stringToMap(JacksonDataCodec.java:136)
	at com.linkedin.metadata.dao.utils.RecordUtils.toRecordTemplate(RecordUtils.java:93)
	at com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO.constructSnapshot(EbeanLocalRelationshipQueryDAO.java:377)
	at com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO.lambda$findEntities$0(EbeanLocalRelationshipQueryDAO.java:106)
```
## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
