### PR TITLE
fix(relationship): fix ambiguous reference to deleted_ts column

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -257,7 +257,6 @@ public class EbeanLocalRelationshipQueryDAO {
     return _mgEntityTypeNameSet.contains(StringUtils.lowerCase(entityType));
   }
 
-
   /**
    * Extracts the table name from an entity urn for MG entities. If entityUrn is not for MG entity, return null.
    * @param entityType String representing the type of entity (e.g. "dataset")
@@ -437,7 +436,7 @@ public class EbeanLocalRelationshipQueryDAO {
         }
       }
 
-      sqlBuilder.append("WHERE deleted_ts is NULL");
+      sqlBuilder.append("WHERE rt.deleted_ts is NULL");
 
       filters.add(new Pair<>(relationshipFilter, "rt"));
 
@@ -449,7 +448,7 @@ public class EbeanLocalRelationshipQueryDAO {
         sqlBuilder.append(" AND ").append(whereClause);
       }
     } else if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
-      sqlBuilder.append("WHERE deleted_ts IS NULL");
+      sqlBuilder.append("WHERE rt.deleted_ts IS NULL");
       if (sourceEntityFilter != null) {
         validateEntityFilterOnlyOneUrn(sourceEntityFilter);
         if (sourceEntityFilter.hasCriteria() && sourceEntityFilter.getCriteria().size() > 0) {

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -127,6 +127,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts DATETIME(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
 );
 


### PR DESCRIPTION
## Summary
In the case where the entity table also has a column called `deleted_ts`, there will be a SQL exception when trying to call findRelationships.
## Testing Done
Added the column to an entity table used in unit tests. `./gradlew build` and verify that build passes
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
