### PR TITLE
Handling urn creation in create sql

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -196,11 +196,18 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
     // Create insert statement with variable number of aspect columns
     // For example: INSERT INTO <table_name> (<columns>)
-    StringBuilder insertIntoSql = new StringBuilder(SQL_INSERT_INTO_ASPECT_WITH_URN);
-
+    StringBuilder insertIntoSql = new StringBuilder();
     // Create part of insert statement with variable number of aspect values
     // For example: VALUES (<values>);
-    StringBuilder insertSqlValues = new StringBuilder(SQL_INSERT_ASPECT_VALUES_WITH_URN);
+    StringBuilder insertSqlValues = new StringBuilder();
+
+    if (urnExtraction) {
+      insertIntoSql.append(SQL_INSERT_INTO_ASSET_WITH_URN);
+      insertSqlValues.append(SQL_INSERT_ASSET_VALUES_WITH_URN);
+    } else {
+      insertIntoSql.append(SQL_INSERT_INTO_ASSET);
+      insertSqlValues.append(SQL_INSERT_ASSET_VALUES);
+    }
 
     for (int i = 0; i < classNames.size(); i++) {
       insertIntoSql.append(getAspectColumnName(urn.getEntityType(), classNames.get(i)));

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -64,9 +64,13 @@ public class SQLStatementUtils {
           + "ON DUPLICATE KEY UPDATE %s = :metadata, lastmodifiedon = :lastmodifiedon, a_urn = :a_urn;";
 
   // INSERT prefix of the sql statement for inserting into metadata_aspect table with multiple aspects which will be combined with the VALUES suffix
-  public static final String SQL_INSERT_INTO_ASPECT_WITH_URN = "INSERT INTO %s (urn, a_urn, lastmodifiedon, lastmodifiedby,";
+  public static final String SQL_INSERT_INTO_ASSET_WITH_URN = "INSERT INTO %s (urn, a_urn, lastmodifiedon, lastmodifiedby,";
   // VALUES suffix of the sql statement for inserting into metadata_aspect table with multiple aspects which will be combined with the INSERT prefix
-  public static final String SQL_INSERT_ASPECT_VALUES_WITH_URN = "VALUES (:urn, :a_urn, :lastmodifiedon, :lastmodifiedby,";
+  public static final String SQL_INSERT_ASSET_VALUES_WITH_URN = "VALUES (:urn, :a_urn, :lastmodifiedon, :lastmodifiedby,";
+  // INSERT prefix of the sql statement for inserting into metadata_aspect table with multiple aspects which will be combined with the VALUES suffix
+  public static final String SQL_INSERT_INTO_ASSET = "INSERT INTO %s (urn, lastmodifiedon, lastmodifiedby,";
+  // VALUES suffix of the sql statement for inserting into metadata_aspect table with multiple aspects which will be combined with the INSERT prefix
+  public static final String SQL_INSERT_ASSET_VALUES = "VALUES (:urn, :lastmodifiedon, :lastmodifiedby,";
   // closing bracket for the sql statement INSERT prefix
   // e.g. INSERT INTO metadata_aspect (urn, a_urn, lastmodifiedon, lastmodifiedby)
   public static final String CLOSING_BRACKET = ") ";

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -54,6 +54,21 @@ public class SQLStatementUtilsTest {
   }
 
   @Test
+  public void testCreateInsertAspectSql() {
+    String expectedSql = "INSERT INTO %s (urn, a_urn, lastmodifiedon, lastmodifiedby,";
+    assertEquals(expectedSql, SQLStatementUtils.SQL_INSERT_INTO_ASSET_WITH_URN);
+
+    expectedSql = "VALUES (:urn, :a_urn, :lastmodifiedon, :lastmodifiedby,";
+    assertEquals(expectedSql, SQLStatementUtils.SQL_INSERT_ASSET_VALUES_WITH_URN);
+
+    expectedSql = "INSERT INTO %s (urn, lastmodifiedon, lastmodifiedby,";
+    assertEquals(expectedSql, SQLStatementUtils.SQL_INSERT_INTO_ASSET);
+
+    expectedSql = "VALUES (:urn, :lastmodifiedon, :lastmodifiedby,";
+    assertEquals(expectedSql, SQLStatementUtils.SQL_INSERT_ASSET_VALUES);
+  }
+
+  @Test
   public void testCreateAspectReadSql() {
     FooUrn fooUrn1 = makeFooUrn(1);
     FooUrn fooUrn2 = makeFooUrn(2);


### PR DESCRIPTION
## Summary

- Updating the  sql statement for creating assets when `urnExtraction=true`. 
- `urnExtraction=true` is applicable when schema was updated to add a new column and this column needs to be populated on insert/update.
- Existing sql statement always contained the a_urn whereas the parameter was added only if urnExtraction=true causing parameter mismatch error:
```
java.sql.exception: No value set for parameter 4
```
- The `a_urn` substring should be added to sql formatting string only if `urnExtraction=true`

Previous SQL: (missing value for a_urn)
```
INSERT INTO <table_name> (urn, a_urn, a_aspect_0, a_aspect_1, lastmodifiedon, lastmodifiedby)VALUES (urn_value, a_aspect_0_value, a_aspect_1_value, lastmodifiedon_value, lastmodifiedby_value)
```

Fixed SQL: (urnExtraction=false)
```
INSERT INTO <table_name> (urn, a_aspect_0, a_aspect_1, lastmodifiedon, lastmodifiedby)VALUES (urn_value, a_aspect_0_value, a_aspect_1_value, lastmodifiedon_value, lastmodifiedby_value)
```



## Testing Done
Added unit tests

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
