### PR TITLE
[feat] add findRelationshipsV3 API (impl + unit tests)

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/RecordUtils.java
@@ -79,6 +79,23 @@ public class RecordUtils {
   }
 
   /**
+   * Creates a {@link DataMap} object from a serialized JSON string.
+   * @param jsonString the JSON string serialized using {@link JacksonDataTemplateCodec}
+   * @return the created {@link DataMap}
+   */
+  public static DataMap toDataMap(@Nonnull String jsonString) {
+    final DataMap dataMap;
+
+    try {
+      dataMap = DATA_TEMPLATE_CODEC.stringToMap(jsonString);
+    } catch (IOException e) {
+      throw new ModelConversionException("Failed to deserialize DataMap: " + jsonString);
+    }
+
+    return dataMap;
+  }
+
+  /**
    * Creates a {@link RecordTemplate} object from a serialized JSON string.
    *
    * @param type the type of {@link RecordTemplate} to create
@@ -88,14 +105,7 @@ public class RecordUtils {
    */
   @Nonnull
   public static <T extends RecordTemplate> T toRecordTemplate(@Nonnull Class<T> type, @Nonnull String jsonString) {
-    DataMap dataMap;
-    try {
-      dataMap = DATA_TEMPLATE_CODEC.stringToMap(jsonString);
-    } catch (IOException e) {
-      throw new ModelConversionException("Failed to deserialize DataMap: " + jsonString);
-    }
-
-    return toRecordTemplate(type, dataMap);
+    return toRecordTemplate(type, toDataMap(jsonString));
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -40,6 +40,8 @@ public class EbeanLocalRelationshipQueryDAO {
   public static final String RELATED_TO = "relatedTo";
   public static final String SOURCE = "source";
   public static final String METADATA = "metadata";
+  public static final String ASSET_RELATIONSHIP_TYPE = "asset.relationship.type";
+  public static final String MG_INTERNAL_ASSET_RELATIONSHIP_TYPE = "AssetRelationship.proto";
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -249,7 +251,7 @@ public class EbeanLocalRelationshipQueryDAO {
    * @return A list of relationship records in SqlRow (col: source, destination, metadata, etc).
    */
   @Nonnull
-  public <RELATIONSHIP extends RecordTemplate> List<SqlRow> findRelationshipsV2V3Core(
+  private <RELATIONSHIP extends RecordTemplate> List<SqlRow> findRelationshipsV2V3Core(
       @Nullable String sourceEntityType, @Nullable LocalRelationshipFilter sourceEntityFilter,
       @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
@@ -296,8 +298,9 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
       @Nonnull Class<ASSET_RELATIONSHIP> assetRelationshipClass, @Nullable Map<String, Object> wrapOptions,
       int offset, int count) {
-    if (wrapOptions == null) {
-      throw new IllegalArgumentException("Please check your use of the findRelationshipsV3 method. wrapOptions cannot be null.");
+    if (wrapOptions == null || !wrapOptions.containsKey(ASSET_RELATIONSHIP_TYPE)
+        || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(ASSET_RELATIONSHIP_TYPE))) {
+      throw new IllegalArgumentException("Please check your use of the findRelationshipsV3 method.");
     }
 
     List<SqlRow> sqlRows = findRelationshipsV2V3Core(

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -40,7 +40,7 @@ public class EbeanLocalRelationshipQueryDAO {
   public static final String RELATED_TO = "relatedTo";
   public static final String SOURCE = "source";
   public static final String METADATA = "metadata";
-  public static final String ASSET_RELATIONSHIP_TYPE = "relationship.return.type";
+  public static final String RELATIONSHIP_RETURN_TYPE = "relationship.return.type";
   public static final String MG_INTERNAL_ASSET_RELATIONSHIP_TYPE = "AssetRelationship.proto";
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
@@ -298,8 +298,8 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
       @Nonnull Class<ASSET_RELATIONSHIP> assetRelationshipClass, @Nullable Map<String, Object> wrapOptions,
       int offset, int count) {
-    if (wrapOptions == null || !wrapOptions.containsKey(ASSET_RELATIONSHIP_TYPE)
-        || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(ASSET_RELATIONSHIP_TYPE))) {
+    if (wrapOptions == null || !wrapOptions.containsKey(RELATIONSHIP_RETURN_TYPE)
+        || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(RELATIONSHIP_RETURN_TYPE))) {
       throw new IllegalArgumentException("Please check your use of the findRelationshipsV3 method.");
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -40,7 +40,7 @@ public class EbeanLocalRelationshipQueryDAO {
   public static final String RELATED_TO = "relatedTo";
   public static final String SOURCE = "source";
   public static final String METADATA = "metadata";
-  public static final String ASSET_RELATIONSHIP_TYPE = "asset.relationship.type";
+  public static final String ASSET_RELATIONSHIP_TYPE = "relationship.return.type";
   public static final String MG_INTERNAL_ASSET_RELATIONSHIP_TYPE = "AssetRelationship.proto";
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -732,7 +732,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
     Map<String, Object> wrapOptions = new HashMap<>();
-    wrapOptions.put(ASSET_RELATIONSHIP_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+    wrapOptions.put(RELATIONSHIP_RETURN_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
 
     List<AssetRelationship> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV3(
         null, null, "foo", destFilter,
@@ -784,7 +784,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
     Map<String, Object> wrapOptions = new HashMap<>();
-    wrapOptions.put(ASSET_RELATIONSHIP_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+    wrapOptions.put(RELATIONSHIP_RETURN_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
 
     List<AssetRelationship> belongsToOwner = _localRelationshipQueryDAO.findRelationshipsV3(
         null, null, "foo", destFilter,

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -53,6 +53,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.naming.OperationNotSupportedException;
@@ -62,6 +63,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
+import static com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO.*;
 import static com.linkedin.testing.TestUtils.*;
 import static org.testng.Assert.*;
 
@@ -729,10 +731,13 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
+    Map<String, Object> wrapOptions = new HashMap<>();
+    wrapOptions.put(ASSET_RELATIONSHIP_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+
     List<AssetRelationship> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV3(
         null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        AssetRelationship.class, new HashMap<>(),
+        AssetRelationship.class, wrapOptions,
         -1, -1);
 
     AssetRelationship expected = reportsToAlice.get(0);
@@ -778,10 +783,13 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     _localRelationshipQueryDAO.setSchemaConfig(schemaConfig);
 
+    Map<String, Object> wrapOptions = new HashMap<>();
+    wrapOptions.put(ASSET_RELATIONSHIP_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+
     List<AssetRelationship> belongsToOwner = _localRelationshipQueryDAO.findRelationshipsV3(
         null, null, "foo", destFilter,
         BelongsToV2.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        AssetRelationship.class, new HashMap<>(),
+        AssetRelationship.class, wrapOptions,
         -1, -1);
 
     AssetRelationship expected = belongsToOwner.get(0);

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS metadata_relationship_belongsto;
+DROP TABLE IF EXISTS metadata_relationship_belongstov2;
 DROP TABLE IF EXISTS metadata_relationship_reportsto;
 DROP TABLE IF EXISTS metadata_relationship_ownedby;
 DROP TABLE IF EXISTS metadata_relationship_pairswith;
@@ -9,6 +10,20 @@ DROP TABLE IF EXISTS metadata_entity_foo;
 DROP TABLE IF EXISTS metadata_entity_bar;
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata LONGTEXT NOT NULL,
     source VARCHAR(1000) NOT NULL,

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS metadata_relationship_belongsto;
+DROP TABLE IF EXISTS metadata_relationship_belongstov2;
 DROP TABLE IF EXISTS metadata_relationship_reportsto;
 DROP TABLE IF EXISTS metadata_relationship_ownedby;
 DROP TABLE IF EXISTS metadata_relationship_pairswith;
@@ -9,6 +10,20 @@ DROP TABLE IF EXISTS metadata_entity_foo;
 DROP TABLE IF EXISTS metadata_entity_bar;
 
 CREATE TABLE IF NOT EXISTS metadata_relationship_belongsto (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    metadata LONGTEXT NOT NULL,
+    source VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(100) NOT NULL,
+    destination VARCHAR(1000) NOT NULL,
+    destination_type VARCHAR(100) NOT NULL,
+    lastmodifiedon TIMESTAMP NOT NULL,
+    lastmodifiedby VARCHAR(255) NOT NULL,
+    deleted_ts DATETIME(6) DEFAULT NULL,
+    aspect VARCHAR(200) DEFAULT NULL, -- should be NOT NULL in production use cases
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS metadata_relationship_belongstov2 (
     id BIGINT NOT NULL AUTO_INCREMENT,
     metadata LONGTEXT NOT NULL,
     source VARCHAR(1000) NOT NULL,

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AssetRelationship.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/localrelationship/AssetRelationship.pdl
@@ -1,0 +1,22 @@
+namespace com.linkedin.testing.localrelationship
+
+
+/**
+ * A union of all supported relationship types.
+ */
+record AssetRelationship {
+
+  /**
+   * Source asset urn in the relationship
+   */
+  source: optional string = ""
+
+  /**
+   * The union of specific relationship models, which contains the destination entity reference
+   * and other relationship specific attributes, such as lineageType in DownstreamOf relationship
+   */
+  relatedTo: optional union[
+    reportsTo: ReportsTo,
+    belongsToV2: BelongsToV2
+  ]
+}


### PR DESCRIPTION
## Summary
To support Relationship 2.0 models, which doesnt have source in the relationship itself, we need a new API to return the source in a wrapper class along with the relationship2.0 model.

The internal use is AssetRelationship = source + relationship2.0 (destination only). I didn't want to hardcode the class here, so I left it extendable. User can pass it any RecordTemplate as wrapper class, but the implementation is only for AssetRelationship now.

I added a wrapOptions map in case we want to have other wrapper types in the future. Currently, it acts as a guard to prevent people who doesn't know this API to accidentally use it.

## Testing Done
./gradlew build
unit tests with relationship1.0 and 2.0

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
