### PR TITLE
Emit MAE for each updated aspect

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -723,6 +723,12 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
           Collectors.toList()).isEmpty();
 
     int numRows = createNewAspect(urn, aspectCreateLambdas, aspectValues, auditStamp, trackingContext, isTestModeFalseForAll);
+    for (RecordTemplate aspectValue : aspectValues) {
+      // For each aspect, we need to trigger emit MAE
+      // In new asset creation, old value is null
+      unwrapAddResult(urn, new AddResult<>(null, aspectValue, (Class<RecordTemplate>) aspectValue.getClass()),
+          auditStamp, trackingContext);
+    }
     return numRows > 0 ? urn : null;
   }
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -712,6 +712,8 @@ public class BaseLocalDAOTest {
 
     FooUrn result = _dummyLocalDAO.createAspectsWithCallbacks(urn, aspectValues, aspectCreateLambdas, _dummyAuditStamp, null);
     assertEquals(result, urn);
+    verify(_mockEventProducer, times(2)).produceMetadataAuditEvent(urn, null, bar);
+    verify(_mockEventProducer, times(2)).produceAspectSpecificMetadataAuditEvent(urn, null, bar, _dummyAuditStamp, IngestionMode.LIVE);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Fixing bug for missing MAE emission from create method
- Create method does not re-use the same logic branch as the update. Thus the MAE emit method needs to be called from create method as well.
- Each aspect is processed iteratively and MAE is emitted for each.

## Testing Done
- Updated unit test

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
