### PR TITLE
Add flag to enable/disable schema check

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManager.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManager.java
@@ -60,8 +60,16 @@ public class FlywaySchemaEvolutionManager implements SchemaEvolutionManager {
         .load();
   }
 
-  @Override
-  public void ensureSchemaUpToDate() {
+  /**
+   * Apply pending schema evolution to databases.
+   * @param enableSchemaCheck If set to true, flyway will only apply the "low risk" DDL changes.
+   */
+  public void ensureSchemaUpToDate(boolean enableSchemaCheck) {
+    if (!enableSchemaCheck) {
+      _flyway.migrate();
+      return;
+    }
+
     //Retrieves the full set of infos about pending migrations, available locally, but not yet applied to the DB
     MigrationInfo[] pendingMigrations = _flyway.info().pending();
 
@@ -94,6 +102,11 @@ public class FlywaySchemaEvolutionManager implements SchemaEvolutionManager {
       }
     }
 
+    _flyway.migrate();
+  }
+
+  @Override
+  public void ensureSchemaUpToDate() {
     _flyway.migrate();
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManagerTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManagerTest.java
@@ -42,7 +42,7 @@ public class FlywaySchemaEvolutionManagerTest {
     assertFalse(checkTableExists("metadata_entity_bar"));
 
     // Execute the evolution scripts to bring schema up-to-date.
-    _schemaEvolutionManager.ensureSchemaUpToDate();
+    _schemaEvolutionManager.ensureSchemaUpToDate(true);
 
     // V1__create_foo_entity_table.sql create metadata_entity_foo table.
     assertTrue(checkTableExists("metadata_entity_foo"));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManagerTestWithoutServiceIdentifier.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/FlywaySchemaEvolutionManagerTestWithoutServiceIdentifier.java
@@ -47,7 +47,7 @@ public class FlywaySchemaEvolutionManagerTestWithoutServiceIdentifier {
     assertFalse(checkTableExists("my_another_version_table"));
 
     // Execute the evolution scripts to bring schema up-to-date.
-    _schemaEvolutionManager.ensureSchemaUpToDate();
+    _schemaEvolutionManager.ensureSchemaUpToDate(true);
 
     // V1__create_foobaz_entity_table.sql create metadata_entity_foobaz table.
     assertTrue(checkTableExists("metadata_entity_foobaz"));


### PR DESCRIPTION
## Summary
Add flag to enable/disable schema check.

This is needed to disable schema check for local testing purpose. In local testing, we generally want to execute all the scripts automatically.

## Testing Done
unit test

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
