### PR TITLE
expose AuditStamp to AspectCallbackRoutingClient

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -658,7 +658,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     }
     // this will skip the pre/in update callbacks
     if (!isRawUpdate) {
-      AspectUpdateResult result = aspectCallbackHelper(urn, newValue, oldValue, updateTuple.getIngestionParams());
+      AspectUpdateResult result = aspectCallbackHelper(urn, newValue, oldValue, updateTuple.getIngestionParams(), auditStamp);
       newValue = (ASPECT) result.getUpdatedAspect();
       // skip the normal ingestion to the DAO
       if (result.isSkipProcessing()) {
@@ -1075,7 +1075,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * Same as above {@link #add(Urn, RecordTemplate, AuditStamp)} but with tracking context.
    * Note: If you update the lambda function (ignored - newValue),
-   * make sure to update {@link #aspectCallbackHelper(Urn, RecordTemplate, Optional, IngestionParams)}as well
+   * make sure to update {@link #aspectCallbackHelper(Urn, RecordTemplate, Optional, IngestionParams, AuditStamp)}as well
    * to avoid any inconsistency between the lambda function and the add method.
    */
   @Nonnull
@@ -1920,12 +1920,12 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return AspectUpdateResult which contains updated aspect value
    */
   protected <ASPECT extends RecordTemplate> AspectUpdateResult aspectCallbackHelper(URN urn, ASPECT newAspectValue,
-      Optional<ASPECT> oldAspectValue, IngestionParams ingestionParams) {
+      Optional<ASPECT> oldAspectValue, IngestionParams ingestionParams, AuditStamp auditStamp) {
 
     if (_aspectCallbackRegistry != null && _aspectCallbackRegistry.isRegistered(
         newAspectValue.getClass(), urn.getEntityType())) {
       AspectCallbackRoutingClient client = _aspectCallbackRegistry.getAspectCallbackRoutingClient(newAspectValue.getClass(), urn.getEntityType());
-      AspectCallbackResponse aspectCallbackResponse = client.routeAspectCallback(urn, newAspectValue, oldAspectValue, ingestionParams);
+      AspectCallbackResponse aspectCallbackResponse = client.routeAspectCallback(urn, newAspectValue, oldAspectValue, ingestionParams, auditStamp);
       ASPECT updatedAspect = (ASPECT) aspectCallbackResponse.getUpdatedAspect();
       log.info("Aspect callback routing completed in BaseLocalDao, urn: {}, updated aspect: {}", urn, updatedAspect);
       return new AspectUpdateResult(updatedAspect, client.isSkipProcessing());

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -700,7 +700,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     for (int i = 0; i < aspectValues.size(); i++) {
       RecordTemplate aspectValue = aspectValues.get(i);
       AspectCreateLambda<? extends RecordTemplate> createLambda = aspectCreateLambdas.get(i);
-      AspectUpdateResult result = aspectCallbackHelper(urn, aspectValue, null, createLambda.ingestionParams);
+      AspectUpdateResult result = aspectCallbackHelper(urn, aspectValue, null, createLambda.ingestionParams, auditStamp);
       // skip the normal ingestion to the DAO
       if (result.isSkipProcessing()) {
         continue;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/AspectCallbackRoutingClient.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/AspectCallbackRoutingClient.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.dao.ingestion;
 
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.internal.IngestionParams;
@@ -31,6 +32,21 @@ public interface AspectCallbackRoutingClient<ASPECT extends RecordTemplate> {
       Optional<ASPECT> existingAspectValue, IngestionParams ingestionParams) {
     return routeAspectCallback(urn, newAspectValue, existingAspectValue);
   }
+
+  /**
+   * A method that routes the updates request to the appropriate custom API.
+   * @param urn the urn of the asset
+   * @param newAspectValue the aspect to be updated
+   * @param existingAspectValue the existing aspect value
+   * @param ingestionParams the ingestionParams of current update
+   * @param auditStamp the auditStamp of current request
+   * @return AspectCallbackResponse containing the updated aspect
+   */
+  default AspectCallbackResponse<ASPECT> routeAspectCallback(Urn urn, ASPECT newAspectValue,
+      Optional<ASPECT> existingAspectValue, IngestionParams ingestionParams, AuditStamp auditStamp) {
+    return routeAspectCallback(urn, newAspectValue, existingAspectValue, ingestionParams);
+  }
+
   /**
    * A method that returns whether to skip processing further ingestion.
    * @return true if the ingestion should be skipped, false otherwise

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -678,7 +678,7 @@ public class BaseLocalDAOTest {
 
     AspectCallbackRegistry aspectCallbackRegistry = new AspectCallbackRegistry(aspectCallbackMap);
     _dummyLocalDAO.setAspectCallbackRegistry(aspectCallbackRegistry);
-    BaseLocalDAO.AspectUpdateResult result = _dummyLocalDAO.aspectCallbackHelper(urn, foo, Optional.empty(), null);
+    BaseLocalDAO.AspectUpdateResult result = _dummyLocalDAO.aspectCallbackHelper(urn, foo, Optional.empty(), null, null);
     AspectFoo newAspect = (AspectFoo) result.getUpdatedAspect();
     assertEquals(newAspect, bar);
   }
@@ -749,7 +749,7 @@ public class BaseLocalDAOTest {
     _dummyLocalDAO.setAspectCallbackRegistry(aspectCallbackRegistry);
 
     // Call the add method
-    BaseLocalDAO.AspectUpdateResult result = _dummyLocalDAO.aspectCallbackHelper(urn, foo, Optional.empty(), null);
+    BaseLocalDAO.AspectUpdateResult result = _dummyLocalDAO.aspectCallbackHelper(urn, foo, Optional.empty(), null, null);
 
     // Verify that the result is the same as the input aspect since it's not registered
     assertEquals(result.getUpdatedAspect(), foo);

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -428,7 +428,7 @@ public abstract class BaseAspectRoutingResource<
           AspectCallbackRegistry registry = getLocalDAO().getAspectCallbackRegistry();
           if (!skipExtraProcessing && registry != null && registry.isRegistered(aspect.getClass(), urn.getEntityType())) {
             log.info(String.format("Executing registered pre-update routing lambda for aspect class %s.", aspect.getClass()));
-            aspect = aspectCallbackHelper((URN) urn, aspect, registry);
+            aspect = aspectCallbackHelper((URN) urn, aspect, registry, ingestionParams, auditStamp);
             log.info("PreUpdateRouting completed in ingestInternalAsset, urn: {}, updated aspect: {}", urn, aspect);
             // Get the fqcn of the aspect class
             String aspectFQCN = aspect.getClass().getCanonicalName();
@@ -700,9 +700,10 @@ public abstract class BaseAspectRoutingResource<
    * @param registry the aspect callback registry
    * @return the updated aspect
    */
-  private RecordTemplate aspectCallbackHelper(URN urn, RecordTemplate aspect, AspectCallbackRegistry registry) {
+  private RecordTemplate aspectCallbackHelper(URN urn, RecordTemplate aspect, AspectCallbackRegistry registry,
+      IngestionParams ingestionParams, AuditStamp auditStamp) {
     AspectCallbackRoutingClient preUpdateClient = registry.getAspectCallbackRoutingClient(aspect.getClass(), urn.getEntityType());
-    AspectCallbackResponse aspectCallbackResponse = preUpdateClient.routeAspectCallback(urn, aspect, null);
+    AspectCallbackResponse aspectCallbackResponse = preUpdateClient.routeAspectCallback(urn, aspect, null, ingestionParams, auditStamp);
     return aspectCallbackResponse.getUpdatedAspect();
   }
 }


### PR DESCRIPTION
## Summary
Expose AuditStamp to AspectCallbackRoutingClient as in restli world, we cannot easily get CallContext and AuditStamp easily outside the resources class. 
## Testing Done
unit test 
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
