### PR TITLE
(feat) Add MAE Emission for Aspect Deletion

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
@@ -51,7 +51,7 @@ public abstract class BaseMetadataEventProducer<SNAPSHOT extends RecordTemplate,
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}
    */
   public abstract <ASPECT extends RecordTemplate> void produceMetadataAuditEvent(@Nonnull URN urn,
-      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue);
+      @Nullable ASPECT oldValue, @Nullable ASPECT newValue);
 
   /**
    * Produces an aspect specific Metadata Audit Event (MAE) after a metadata aspect is updated for an entity.
@@ -59,11 +59,13 @@ public abstract class BaseMetadataEventProducer<SNAPSHOT extends RecordTemplate,
    * @param urn {@link Urn} of the entity
    * @param oldValue the value prior to the update, or null if there's none.
    * @param newValue the value after the update
+   * @param aspectClass the class of ASPECT
    * @param auditStamp {@link AuditStamp} containing version auditing information for the metadata change
    * @param ingestionMode {@link IngestionMode} of the change
    */
   public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
-      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue, @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode);
+      @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+      @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode);
 
   /**
    * Produce Metadata Graph search metrics inside SearchDAO.

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseTrackingMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseTrackingMetadataEventProducer.java
@@ -18,18 +18,19 @@ public abstract class BaseTrackingMetadataEventProducer<SNAPSHOT extends RecordT
   }
 
   /**
-   * Same as inherited method {@link #produceAspectSpecificMetadataAuditEvent(Urn, RecordTemplate, RecordTemplate, AuditStamp, IngestionMode)}
+   * Same as inherited method {@link #produceAspectSpecificMetadataAuditEvent(Urn, RecordTemplate, RecordTemplate, Class, AuditStamp, IngestionMode)}
    * but with tracking context.
    * Produces an aspect specific Metadata Audit Event (MAE) after a metadata aspect is updated for an entity.
    *
    * @param urn {@link Urn} of the entity
    * @param oldValue the value prior to the update, or null if there's none.
    * @param newValue the value after the update
+   * @param aspectClass the class of ASPECT
    * @param trackingContext nullable tracking context passed in to be appended to produced MAEv5s
    * @param auditStamp {@link AuditStamp} containing version auditing information for the metadata change
    * @param ingestionMode {@link IngestionMode} of the change
    */
   public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
-      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue, @Nullable AuditStamp auditStamp,
-      @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionMode ingestionMode);
+      @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+      @Nullable AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionMode ingestionMode);
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducer.java
@@ -23,19 +23,20 @@ public class DummyMetadataEventProducer<URN extends Urn>
 
   @Override
   public <ASPECT extends RecordTemplate> void produceSnapshotBasedMetadataChangeEvent(@Nonnull URN urn,
-      @Nonnull ASPECT newValue) {
+      @Nullable ASPECT newValue) {
     // Do nothing
   }
 
   @Override
   public <ASPECT extends RecordTemplate> void produceMetadataAuditEvent(@Nonnull URN urn, @Nullable ASPECT oldValue,
-      @Nonnull ASPECT newValue) {
+      @Nullable ASPECT newValue) {
     // Do nothing
   }
 
   @Override
   public <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
-      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue, @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode) {
+      @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+      @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode) {
     // Do nothing
   }
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/GenericMetadataProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/GenericMetadataProducer.java
@@ -20,10 +20,12 @@ public interface GenericMetadataProducer {
    * @param urn {@link Urn} of the entity
    * @param oldValue The value prior to the update, or null if there's none.
    * @param newValue The value after the update
+   * @param aspectClass the class of the aspect
    * @param auditStamp Containing version auditing information for the metadata change
    * @param trackingContext Nullable tracking context passed in to be appended to produced MAEv5s
    * @param ingestionMode Different options for ingestion.
    */
   void produceAspectSpecificMetadataAuditEvent(@Nonnull Urn urn, @Nullable RecordTemplate oldValue, @Nonnull RecordTemplate newValue,
+      @Nonnull Class<? extends RecordTemplate> aspectClass,
       @Nullable AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionMode ingestionMode);
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOAspectVersionTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOAspectVersionTest.java
@@ -95,13 +95,17 @@ public class BaseLocalDAOAspectVersionTest {
     _dummyLocalDAO.add(urn, ver020201OldValue, auditStamp4);
 
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo1);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, foo1, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, foo1, AspectVersioned.class, _dummyAuditStamp, IngestionMode.LIVE);
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, foo1, ver010101);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, foo1, ver010101, auditStamp2, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, foo1, ver010101, AspectVersioned.class, auditStamp2, IngestionMode.LIVE);
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, ver010101, ver020101);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, ver010101, ver020101, auditStamp3, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, ver010101, ver020101, AspectVersioned.class, auditStamp3, IngestionMode.LIVE);
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, ver020101, ver020201OldValue);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, ver020101, ver020201OldValue, auditStamp4, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, ver020101, ver020201OldValue, AspectVersioned.class, auditStamp4, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockEventProducer);
   }
 
@@ -122,7 +126,8 @@ public class BaseLocalDAOAspectVersionTest {
     _dummyLocalDAO.add(urn, ver020101, _dummyAuditStamp);
 
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, null, ver020101);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, ver020101, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, ver020101, AspectVersioned.class, _dummyAuditStamp, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockEventProducer);
   }
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -273,7 +273,8 @@ public class BaseLocalDAOTest {
     _dummyLocalDAO.add(urn, foo, _dummyAuditStamp);
 
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, foo, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, foo, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, foo, foo);
     verifyNoMoreInteractions(_mockEventProducer);
   }
@@ -292,9 +293,11 @@ public class BaseLocalDAOTest {
     _dummyLocalDAO.add(urn, foo2, auditStamp2);
 
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo1);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, foo1, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, foo1, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, foo1, foo2);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, foo1, foo2, auditStamp2, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, foo1, foo2, AspectFoo.class, auditStamp2, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockEventProducer);
   }
 
@@ -313,7 +316,8 @@ public class BaseLocalDAOTest {
     _dummyLocalDAO.add(urn, foo3, _dummyAuditStamp);
 
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo1);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, foo1, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, foo1, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockEventProducer);
   }
 
@@ -329,9 +333,11 @@ public class BaseLocalDAOTest {
     _dummyLocalDAO.delete(urn, AspectFoo.class, _dummyAuditStamp);
 
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, foo, _dummyAuditStamp, IngestionMode.LIVE);
-    // TODO: ensure MAE is produced with newValue set as null for soft deleted aspect
-    // verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, foo, null);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, foo, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, foo, null);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, foo, null, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockEventProducer);
   }
 
@@ -356,9 +362,9 @@ public class BaseLocalDAOTest {
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, foo);
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, foo, foo);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null,
-        foo, _dummyAuditStamp, mockTrackingContext, IngestionMode.LIVE);
+        foo, AspectFoo.class, _dummyAuditStamp, mockTrackingContext, IngestionMode.LIVE);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, foo,
-        foo, _dummyAuditStamp, mockTrackingContext, IngestionMode.LIVE);
+        foo, AspectFoo.class, _dummyAuditStamp, mockTrackingContext, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 
@@ -538,7 +544,7 @@ public class BaseLocalDAOTest {
 
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, oldFoo, oldFoo);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
-        urn, oldFoo, oldFoo, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+        urn, oldFoo, oldFoo, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 
@@ -596,7 +602,7 @@ public class BaseLocalDAOTest {
 
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, oldFoo, newFoo);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
-        urn, oldFoo, newFoo, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+        urn, oldFoo, newFoo, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 
@@ -629,7 +635,7 @@ public class BaseLocalDAOTest {
 
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, newFoo);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
-        urn, null, newFoo, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+        urn, null, newFoo, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 
@@ -654,13 +660,13 @@ public class BaseLocalDAOTest {
     dummyLocalDAO.add(urn, fooBar1, _dummyAuditStamp);
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, fooBar1);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, fooBar1,
-        _dummyAuditStamp, null, IngestionMode.LIVE);
+        AspectFooBar.class, _dummyAuditStamp, null, IngestionMode.LIVE);
 
     AuditStamp auditStamp2 = makeAuditStamp("tester", 5678L);
     dummyLocalDAO.add(urn, fooBar2, auditStamp2);
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, fooBar1, mergedFooBar);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, fooBar1, mergedFooBar,
-        auditStamp2, null, IngestionMode.LIVE);
+        AspectFooBar.class, auditStamp2, null, IngestionMode.LIVE);
 
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
@@ -713,7 +719,11 @@ public class BaseLocalDAOTest {
     FooUrn result = _dummyLocalDAO.createAspectsWithCallbacks(urn, aspectValues, aspectCreateLambdas, _dummyAuditStamp, null);
     assertEquals(result, urn);
     verify(_mockEventProducer, times(2)).produceMetadataAuditEvent(urn, null, bar);
-    verify(_mockEventProducer, times(2)).produceAspectSpecificMetadataAuditEvent(urn, null, bar, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, bar, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, bar, AspectBar.class, _dummyAuditStamp, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockEventProducer);
   }
 
   @Test
@@ -732,7 +742,8 @@ public class BaseLocalDAOTest {
     _dummyLocalDAO.add(urn, foo, _dummyAuditStamp);
 
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, null, bar);
-    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, null, bar, _dummyAuditStamp, IngestionMode.LIVE);
+    verify(_mockEventProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, null, bar, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockEventProducer);
   }
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducerTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducerTest.java
@@ -18,6 +18,6 @@ public class DummyMetadataEventProducerTest {
     AspectFoo newValue = new AspectFoo().setValue("new");
 
     producer.produceMetadataAuditEvent(urn, oldValue, newValue);
-    producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, null, null);
+    producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, AspectFoo.class, null, null);
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanGenericLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanGenericLocalDAO.java
@@ -104,7 +104,7 @@ public class EbeanGenericLocalDAO implements GenericLocalDAO {
       if (!latest.isPresent()) {
         saveLatest(urn, aspectClass, newValue, null, auditStamp, null);
         if (!shouldSkipMAEUpdate(newValue)) {
-          _producer.produceAspectSpecificMetadataAuditEvent(urn, null, newValue, auditStamp, trackingContext, ingestionMode);
+          _producer.produceAspectSpecificMetadataAuditEvent(urn, null, newValue, aspectClass, auditStamp, trackingContext, ingestionMode);
         }
       } else {
         RecordTemplate currentValue = toRecordTemplate(aspectClass, latest.get().getAspect());
@@ -126,7 +126,7 @@ public class EbeanGenericLocalDAO implements GenericLocalDAO {
         saveLatest(urn, aspectClass, newValue, currentValue, auditStamp, latest.get().getExtraInfo().getAudit());
 
         if (!shouldSkipMAEUpdate(newValue)) {
-          _producer.produceAspectSpecificMetadataAuditEvent(urn, currentValue, newValue, auditStamp, trackingContext, ingestionMode);
+          _producer.produceAspectSpecificMetadataAuditEvent(urn, currentValue, newValue, aspectClass, auditStamp, trackingContext, ingestionMode);
         }
       }
       return null;
@@ -215,7 +215,7 @@ public class EbeanGenericLocalDAO implements GenericLocalDAO {
       IngestionTrackingContext trackingContext = buildIngestionTrackingContext(
             TrackingUtils.getRandomUUID(), BACKFILL_EMITTER, System.currentTimeMillis());
 
-      _producer.produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null, trackingContext, ingestionMode);
+      _producer.produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, aspect.getClass(), null, trackingContext, ingestionMode);
     }
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanGenericLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanGenericLocalDAOTest.java
@@ -210,7 +210,7 @@ public class EbeanGenericLocalDAOTest {
 
     // Expects _producer is called to emit a MAE.
     verify(_producer, times(1)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
-        eq(null), eq(aspectFoo1), eq(makeAuditStamp("tester")), eq(null), eq(null));
+        eq(null), eq(aspectFoo1), eq(AspectFoo.class), eq(makeAuditStamp("tester")), eq(null), eq(null));
 
     // When there is existing metadata
     _genericLocalDAO.save(fooUrn, AspectFoo.class, RecordUtils.toJsonString(aspectFoo2),
@@ -218,7 +218,7 @@ public class EbeanGenericLocalDAOTest {
 
     // Expects _producer to emit MAE that has both new and old values.
     verify(_producer, times(1)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
-        eq(aspectFoo1), eq(aspectFoo2), eq(makeAuditStamp("tester")), eq(null), eq(null));
+        eq(aspectFoo1), eq(aspectFoo2), eq(AspectFoo.class), eq(makeAuditStamp("tester")), eq(null), eq(null));
 
     verifyNoMoreInteractions(_producer);
   }
@@ -249,7 +249,7 @@ public class EbeanGenericLocalDAOTest {
         makeAuditStamp("tester"), null, null);
 
     verify(_producer, times(1)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
-        eq(null), eq(aspectFoo), eq(makeAuditStamp("tester")), eq(null), eq(null));
+        eq(null), eq(aspectFoo), eq(AspectFoo.class), eq(makeAuditStamp("tester")), eq(null), eq(null));
 
     Optional<GenericLocalDAO.MetadataWithExtraInfo> metadata = _genericLocalDAO.queryLatest(fooUrn, AspectFoo.class);
 
@@ -267,7 +267,7 @@ public class EbeanGenericLocalDAOTest {
 
     // does not produce MAE for deletion
     verify(_producer, times(0)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
-        any(), any(), any(), any(), any());
+        any(), any(), any(), any(), any(), any());
     verifyNoMoreInteractions(_producer);
   }
 
@@ -288,7 +288,7 @@ public class EbeanGenericLocalDAOTest {
 
     // does not produce MAE for deletion
     verify(_producer, times(0)).produceAspectSpecificMetadataAuditEvent(eq(fooUrn),
-        any(), any(), any(), any(), any());
+        any(), any(), any(), any(), any(), any());
     verifyNoMoreInteractions(_producer);
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -931,7 +931,8 @@ public class EbeanLocalDAOTest {
     Optional<AspectFoo> foo = dao.backfill(AspectFoo.class, urn);
 
     assertEquals(foo.get(), expected);
-    verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, expected, expected, null, IngestionMode.BOOTSTRAP);
+    verify(_mockProducer, times(1))
+        .produceAspectSpecificMetadataAuditEvent(urn, expected, expected, AspectFoo.class, null, IngestionMode.BOOTSTRAP);
     verifyNoMoreInteractions(_mockProducer);
   }
 
@@ -1017,7 +1018,8 @@ public class EbeanLocalDAOTest {
       for (Class<? extends RecordTemplate> clazz : aspects.get(urn).keySet()) {
         RecordTemplate aspect = aspects.get(urn).get(clazz);
         assertEquals(backfilledAspects.get(urn).get(clazz).get(), aspect);
-        verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, null, IngestionMode.BOOTSTRAP);
+        verify(_mockProducer, times(1))
+            .produceAspectSpecificMetadataAuditEvent(urn, aspect, aspect, clazz, null, IngestionMode.BOOTSTRAP);
       }
     }
     verifyNoMoreInteractions(_mockProducer);
@@ -1053,7 +1055,8 @@ public class EbeanLocalDAOTest {
       for (Class<? extends RecordTemplate> clazz : aspects.get(urn).keySet()) {
         assertTrue(backfilledAspects.get(urn.toString()).contains(getAspectName(clazz)));
         RecordTemplate metadata = aspects.get(urn).get(clazz);
-        verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, metadata, metadata, null, IngestionMode.BOOTSTRAP);
+        verify(_mockProducer, times(1))
+            .produceAspectSpecificMetadataAuditEvent(urn, metadata, metadata, clazz, null, IngestionMode.BOOTSTRAP);
       }
       assertFalse(backfilledAspects.get(urn.toString()).contains(getAspectName(AspectFooBar.class)));
     }
@@ -1090,7 +1093,8 @@ public class EbeanLocalDAOTest {
       for (Class<? extends RecordTemplate> clazz : aspects.get(urn).keySet()) {
         assertTrue(backfilledAspects.get(urn.toString()).contains(getAspectName(clazz)));
         RecordTemplate metadata = aspects.get(urn).get(clazz);
-        verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, metadata, metadata, null, IngestionMode.BOOTSTRAP);
+        verify(_mockProducer, times(1))
+            .produceAspectSpecificMetadataAuditEvent(urn, metadata, metadata, clazz, null, IngestionMode.BOOTSTRAP);
       }
       assertFalse(backfilledAspects.get(urn.toString()).contains(getAspectName(AspectBar.class)));
     }
@@ -1124,7 +1128,8 @@ public class EbeanLocalDAOTest {
       for (Class<? extends RecordTemplate> clazz : aspects.get(urn).keySet()) {
         assertTrue(backfilledAspects.get(urn.toString()).contains(getAspectName(clazz)));
         RecordTemplate metadata = aspects.get(urn).get(clazz);
-        verify(_mockProducer, times(1)).produceAspectSpecificMetadataAuditEvent(urn, metadata, metadata, null, IngestionMode.BOOTSTRAP);
+        verify(_mockProducer, times(1))
+            .produceAspectSpecificMetadataAuditEvent(urn, metadata, metadata, clazz, null, IngestionMode.BOOTSTRAP);
       }
     }
     verifyNoMoreInteractions(_mockProducer);
@@ -2351,7 +2356,7 @@ public class EbeanLocalDAOTest {
     InOrder inOrder = inOrder(_mockProducer);
     inOrder.verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, null, v1);
     inOrder.verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, v1, v0);
-    // TODO: verify that MAE was produced with newValue set as null for soft deleted aspect
+    inOrder.verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, v0, null);
     verifyNoMoreInteractions(_mockProducer);
   }
 
@@ -2536,8 +2541,8 @@ public class EbeanLocalDAOTest {
     InOrder inOrder = inOrder(_mockProducer);
     inOrder.verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, null, v1);
     inOrder.verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, v1, v0);
+    inOrder.verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, v0, null);
     inOrder.verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, null, foo);
-    // TODO: verify that MAE was produced with newValue set as null for soft deleted aspect
     verifyNoMoreInteractions(_mockProducer);
   }
 


### PR DESCRIPTION
## Summary

This PR adds MAE emission for deletion operations.

The main implementation methodology here is that a new variant of the `unwrapAddResult()` method is added with a `isDeletion` flag, which is called when a Delete is performed. Slightly different logic is then acted on.

In addition, this PR changes `@Nonnull newValue` --> `@Nullable newValue` in basically all locations that previous claim it as being Non-Null. This is done because:

1. This conceptually is aligned with the concept of a Delete operation, in which the "new value" is simply NULL.
2. We cannot keep it @Nonnull since that would imply attempting to instantiate an "empty" version of the Aspect class...
    1. We cannot instantiate ASPECT with an empty value; it goes against Java's nature of "type erasure" when compiling for generified types -- thus, passing the class is necessary.

Lastly, this PR adds `Class<ASPECT> aspectClass` as an argument for the MAE emission methods. This is necessary because the current way that the Aspect Class is deduced is from Reflection -- `newValue.getClass()` -- which is not a permissible operation if `newValue` is allowed to be `null`.

* Dependency on `getClass()`: https://jarvis.corp.linkedin.com/codesearch/result/?name=KafkaMetadataEventProducerUtil.java&path=metadata-models%2Fmetadata-dao-impl%2Fkafka-producer%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fmetadata%2Fdao%2Fproducer&reponame=linkedin-multiproduct%2Fmetadata-models#39
* It's interesting to note that directly in the DAO code, it is NOT marked as @Nonnull, which is a clear bug risk that magically has not been run into yet lol...

Note that alternatively, we could aggregate `{ oldValue, newValue, aspectClass }` into `BaseLocalDAO`'s `AddResult` class for a more extensible code architecture, but that would require changing its signature to `public`, and as of _right now_, the benefit isn't immediately huge.

## Testing Done

unit testing updated

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

## Next Steps

1. Make corresponding changes in `metadata-models` in order to satisfy the interface changes here
2. (ideally once testing is complete) Make a follow-up PR for backfill support (this is officially a P1 right now)