### PR TITLE
(refactor) Make NewValue optional in MAE

### DIFF
--- a/docs/what/mxev5.md
+++ b/docs/what/mxev5.md
@@ -162,7 +162,7 @@ import com.linkedin.identity.CorpUserInfo
     /**
      * Aspect of the CorpUserInfo after the update.
      */
-    newValue: CorpUserInfo
+    newValue: optional CorpUserInfo
 }
 ```
 

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MAEBarAspect.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/MAEBarAspect.pdl
@@ -44,7 +44,7 @@ record MAEBarAspect {
    */
   diffAnnotatedAspectBar: optional record AnnotatedAspectBarAudit {
     oldValue: optional AnnotatedAspectBar
-    newValue: AnnotatedAspectBar
+    newValue: optional AnnotatedAspectBar
     changeType: optional union[null, ChangeType] = null
   }
 
@@ -53,7 +53,7 @@ record MAEBarAspect {
    */
   diffAnotherAspectBar: optional record AnotherAspectBarAudit {
     oldValue: optional AnotherAspectBar
-    newValue: AnotherAspectBar
+    newValue: optional AnotherAspectBar
     changeType: optional union[null, ChangeType] = null
   }
 

--- a/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/gradle-plugins/metadata-annotations-test-models/src/main/pegasus/com/linkedin/testing/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -32,7 +32,7 @@ record MetadataAuditEvent {
   /**
    * Aspect of the AnnotatedAspectBar after the update.
    */
-  newValue: AnnotatedAspectBar
+  newValue: optional AnnotatedAspectBar
 
   /**
    * Change type.

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/AuditUnionEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/AuditUnionEvent.rythm
@@ -49,7 +49,7 @@ record MAE@(eventSpec.getShortTyperefName()) {
    */
   diff@(SchemaGeneratorUtil.stripNamespace(valueType)): optional record @(SchemaGeneratorUtil.stripNamespace(valueType))Audit {
     oldValue: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
-    newValue: @(SchemaGeneratorUtil.stripNamespace(valueType))
+    newValue: optional @(SchemaGeneratorUtil.stripNamespace(valueType))
     changeType: optional union[null, ChangeType] = null
   }
 

--- a/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
+++ b/gradle-plugins/metadata-events-generator-lib/src/main/resources/MetadataAuditEvent.rythm
@@ -35,7 +35,7 @@ record MetadataAuditEvent {
   /**
    * Aspect of the @eventSpec.getShortValueType() after the update.
    */
-  newValue: @eventSpec.getShortValueType()
+  newValue: optional @eventSpec.getShortValueType()
 
   /**
    * Change type.

--- a/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
+++ b/gradle-plugins/metadata-events-generator-plugin/src/test/groovy/com/linkedin/metadata/gradle/MetadataEventsGeneratorPluginIntegTest.groovy
@@ -172,7 +172,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Aspect of the TestAspect after the update.
          */
-        newValue: TestAspect
+        newValue: optional TestAspect
 
         /**
          * Change type.
@@ -304,7 +304,7 @@ class MetadataEventsGeneratorPluginIntegTest extends Specification {
         /**
          * Aspect of the TestTyperefAspect after the update.
          */
-        newValue: TestTyperefAspect
+        newValue: optional TestTyperefAspect
 
         /**
          * Change type.


### PR DESCRIPTION
## Summary

BUG=[META-21843](https://jira01.corp.linkedin.com:8443/browse/META-21843)

_**Milestone 9.1**_

This PR ensures that MAE's are generated with its `newValue` as an optional field.

This is to align with the expected behavior for a "DELETE MAE" which intuitively has a "null" value here.

Discussion: https://docs.google.com/document/d/1s_VJNZgsZ6x1k_aHwRpQ8f_a44ETOFXm7tMgI5-AbKk/edit?pli=1&tab=t.0#bookmark=id.wjh19iwjejza

This is a residual work to the groundwork laid in https://github.com/linkedin/datahub-gma/pull/513 -- but was missed since it wasn't required there but will be required for corresponding changes in `metadata-models`.

## Testing Done

updated unit testing

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
