### PR TITLE
feat(relationship ingestion): add multiple relationships in a single statement

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -244,7 +244,11 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     batchCount = 0;
     while (batchCount < MAX_BATCHES) {
       try {
-        // Use the runInTransactionWithRetry method to handle retries in case of transaction failures
+        // Use the runInTransactionWithRetry method to handle retries in case of transaction failures.
+        // Although this whole logic is executed within a runInTransactionWithRetry block already (in addCommon), the nested
+        // behavior is supported when using Ebean Transactions despite the fact that true nested transactions are not supported in MySQL.
+        // Ebean mimics the nested behavior by using MySQL savepoints under the hood which CAN be nested. Thus, if all the inner commits (below) succeed,
+        // but the outer commit (somewhere else outside this logic) does not, the WHOLE TRANSACTION (including the inner commits) will be rolled back.
         int rowsAffected = runInTransactionWithRetry(deletionSQL::execute, 3); // Retry up to 3 times in case of transient failures
         batchCount++;
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -129,14 +129,6 @@ public class SQLStatementUtils {
 
   private static final String SQL_URN_EXIST_TEMPLATE = "SELECT urn FROM %s WHERE urn = '%s' AND deleted_ts IS NULL";
 
-  private static final String INSERT_LOCAL_RELATIONSHIP = "INSERT INTO %s (metadata, source, destination, source_type, "
-      + "destination_type, lastmodifiedon, lastmodifiedby) VALUE (:metadata, :source, :destination, :source_type,"
-      + " :destination_type, :lastmodifiedon, :lastmodifiedby)";
-
-  private static final String INSERT_LOCAL_RELATIONSHIP_WITH_ASPECT = "INSERT INTO %s (metadata, source, destination, source_type, "
-      + "destination_type, lastmodifiedon, lastmodifiedby, aspect) VALUES (:metadata, :source, :destination, :source_type,"
-      + " :destination_type, :lastmodifiedon, :lastmodifiedby, :aspect)";
-
   private static final String INSERT_LOCAL_RELATIONSHIPS = "INSERT INTO %s (metadata, source, destination, source_type, "
       + "destination_type, lastmodifiedon, lastmodifiedby) VALUES ";
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -367,6 +367,9 @@ public class EbeanLocalRelationshipWriterDAOTest {
 
   @Test
   public void testConcurrentAddRelationships() throws Exception {
+    if (!_useAspectColumnForRelationshipRemoval) {
+      return;
+    }
     _localRelationshipWriterDAO.setUseAspectColumnForRelationshipRemoval(_useAspectColumnForRelationshipRemoval);
 
     BarUrn barUrn = BarUrn.createFromString("urn:li:bar:123");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -359,7 +359,6 @@ public class EbeanLocalRelationshipWriterDAOTest {
     _server.execute(Ebean.createSqlUpdate("truncate metadata_relationship_pairswith"));
   }
 
-
   @Test
   public void testRemoveRelationshipsSameAspectDifferentNamespace() throws URISyntaxException {
     if (!_useAspectColumnForRelationshipRemoval) {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -409,7 +409,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
     int expected = numThreads * relationshipsPerThread;
     assertEquals(expected, all.size());
 
-    // Optional: Verify uniqueness of destination URNs
+    // Verify uniqueness of destination URNs
     Set<String> uniqueDestinations = all.stream()
         .map(row -> row.getString("destination"))
         .collect(Collectors.toSet());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipWriterDAOTest.java
@@ -12,6 +12,7 @@ import com.linkedin.testing.BarUrnArray;
 import com.linkedin.testing.RelationshipV2Bar;
 import com.linkedin.testing.localrelationship.AspectFooBar;
 import com.linkedin.testing.localrelationship.PairsWith;
+import com.linkedin.testing.localrelationship.VersionOf;
 import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
@@ -386,10 +387,10 @@ public class EbeanLocalRelationshipWriterDAOTest {
       final int threadId = i;
       executor.submit(() -> {
         try {
-          List<PairsWith> relationships = new ArrayList<>();
+          List<VersionOf> relationships = new ArrayList<>();
           for (int j = 0; j < relationshipsPerThread; j++) {
             FooUrn destination = FooUrn.createFromString("urn:li:foo:" + threadId + "00000" + j);
-            relationships.add(new PairsWith().setSource(barUrn).setDestination(destination));
+            relationships.add(new VersionOf().setSource(barUrn).setDestination(destination));
           }
 
           _localRelationshipWriterDAO.addRelationships(barUrn, AspectFooBar.class, relationships, false);
@@ -405,7 +406,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
     executor.shutdown();
 
     // Verify all relationships were inserted
-    List<SqlRow> all = _server.createSqlQuery("select * from metadata_relationship_pairswith where deleted_ts is null").findList();
+    List<SqlRow> all = _server.createSqlQuery("select * from metadata_relationship_versionof where deleted_ts is null").findList();
     int expected = numThreads * relationshipsPerThread;
     assertEquals(expected, all.size());
 
@@ -417,7 +418,7 @@ public class EbeanLocalRelationshipWriterDAOTest {
     assertEquals(expected, uniqueDestinations.size());
 
     // Clean up
-    _server.execute(Ebean.createSqlUpdate("truncate metadata_relationship_pairswith"));
+    _server.execute(Ebean.createSqlUpdate("truncate metadata_relationship_versionof"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Relationship insertion performance can be potentially improved by combining multiple single-valued INSERT INTO statements into a single INSERT INTO statement with multiple values. Do that in batches of 1000.

Ref to the MySQL documentation on optimizing INSERT statement performance: https://dev.mysql.com/doc/refman/8.4/en/insert-optimization.html#:~:text=If%20you%20are%20inserting%20many,separate%20single%2Drow%20INSERT%20statements.

## Testing Done
make sure existing relationship unit tests pass. add a new unit test ingesting a single relationship to make sure that case is covered as well.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
