### PR TITLE
[fix]Replacing null with Optional.empty() for optional param

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -700,7 +700,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     for (int i = 0; i < aspectValues.size(); i++) {
       RecordTemplate aspectValue = aspectValues.get(i);
       AspectCreateLambda<? extends RecordTemplate> createLambda = aspectCreateLambdas.get(i);
-      AspectUpdateResult result = aspectCallbackHelper(urn, aspectValue, null, createLambda.ingestionParams);
+      AspectUpdateResult result = aspectCallbackHelper(urn, aspectValue, Optional.empty(), createLambda.ingestionParams);
       // skip the normal ingestion to the DAO
       if (result.isSkipProcessing()) {
         continue;


### PR DESCRIPTION
## Summary
The aspectCallbackHelper takes Optional params where a null was being provided. This would lead to NPE
example:
```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Optional.isPresent()" because "value" is null
```
Replacing null with `Optional.empty()` for proper handling.

## Testing Done
local build

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
