### PR TITLE
[fix] Updated batchGetUnion SQL query to use IN rather than UNION

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -258,11 +258,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   /**
    * Construct and execute a SQL statement as follows.
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
-   * UNION ALL
-   * SELECT urn, aspect2, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND JSON_EXTRACT(aspect2, '$.gma_deleted') IS NULL
-   * UNION ALL
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:2' AND JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
+   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
+   * AND urn IN ('urn:1', 'urn:2', 'urn:3')
    * @param aspectKeys a List of keys (urn, aspect pairings) to query for
    * @param keysCount number of keys to query
    * @param position position of the key to start from

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -82,8 +82,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   protected final EbeanServer _server;
   protected final Class<URN> _urnClass;
 
-  private final static int DEFAULT_BATCH_SIZE = 50;
-  private int _queryKeysCount = DEFAULT_BATCH_SIZE;
+  private int _queryKeysCount = 0;
   private IEbeanLocalAccess<URN> _localAccess;
   private EbeanLocalRelationshipWriterDAO _localRelationshipWriterDAO;
   private LocalRelationshipBuilderRegistry _localRelationshipBuilderRegistry = null;
@@ -1062,13 +1061,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       return Collections.emptyMap();
     }
 
-    final List<EbeanMetadataAspect> records;
-
-    if (_queryKeysCount == 0) {
-      records = batchGet(keys, keys.size());
-    } else {
-      records = batchGet(keys, _queryKeysCount);
-    }
+    final List<EbeanMetadataAspect> records = batchGet(keys, keys.size());
 
     // TODO: Improve this O(n^2) search
 
@@ -1131,18 +1124,13 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Sets the max keys allowed for each single query, not allowed more than the default batch size.
+   * Sets the max keys allowed for each single query.
    */
   public void setQueryKeysCount(int keysCount) {
     if (keysCount < 0) {
       throw new IllegalArgumentException("Query keys count must be non-negative: " + keysCount);
-    } else if (keysCount > DEFAULT_BATCH_SIZE) {
-      log.warn("Setting query keys count greater than " + DEFAULT_BATCH_SIZE
-          + " may cause performance issues. Defaulting to " + DEFAULT_BATCH_SIZE + ".");
-      _queryKeysCount = DEFAULT_BATCH_SIZE;
-    } else {
-      _queryKeysCount = keysCount;
     }
+    _queryKeysCount = keysCount;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -89,7 +89,7 @@ public class SQLStatementUtils {
           + "WHERE urn = :urn and (JSON_EXTRACT(%s, '$.lastmodifiedon') = :oldTimestamp OR JSON_EXTRACT(%s, '$.gma_deleted') IS NOT NULL);";
 
   private static final String SQL_READ_ASPECT_TEMPLATE =
-      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby FROM %%s WHERE urn = '%%s' AND %s", SOFT_DELETED_CHECK);
+      String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby FROM %%s WHERE %s AND urn IN (", SOFT_DELETED_CHECK);
 
   private static final String SQL_LIST_ASPECT_BY_URN_TEMPLATE =
       String.format("SELECT urn, %%s, lastmodifiedon, lastmodifiedby, createdfor FROM %%s WHERE urn = '%%s' AND %s AND %s", NONNULL_CHECK, SOFT_DELETED_CHECK);
@@ -106,7 +106,7 @@ public class SQLStatementUtils {
           + "as _total_count FROM %%s WHERE %s LIMIT %%s OFFSET %%s", NONNULL_CHECK,  NONNULL_CHECK);
 
   private static final String SQL_READ_ASPECT_WITH_SOFT_DELETED_TEMPLATE =
-      "SELECT urn, %s, lastmodifiedon, lastmodifiedby FROM %s WHERE urn = '%s'";
+      "SELECT urn, %s, lastmodifiedon, lastmodifiedby FROM %s WHERE urn IN (";
 
   private static final String INDEX_GROUP_BY_CRITERION = "SELECT count(*) as COUNT, %s FROM %s";
 
@@ -146,6 +146,7 @@ public class SQLStatementUtils {
 
   public static final String SOURCE = "source";
   public static final String DESTINATION = "destination";
+  private static final String RIGHT_PARENTHESIS = ")";
 
   private SQLStatementUtils() {
     // Util class
@@ -173,11 +174,7 @@ public class SQLStatementUtils {
    * single aspect column in the metadata entity tables. The query includes a filter for filtering out soft-deleted aspects.
    *
    * <p>Example:
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:1' AND aspect1 != '{"gma_deleted":true}'
-   * UNION ALL
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:2' AND aspect1 != '{"gma_deleted":true}'
-   * UNION ALL
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_bar WHERE urn = 'urn:1' AND aspect1 != '{"gma_deleted":true}'
+   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE aspect1 != '{"gma_deleted":true}' AND urn IN ('urn:1', 'urn:2')
    * </p>
    * @param aspectClass aspect class to query for
    * @param urns a Set of Urns to query for
@@ -190,16 +187,20 @@ public class SQLStatementUtils {
     if (urns.size() == 0) {
       throw new IllegalArgumentException("Need at least 1 urn to query.");
     }
-
     StringBuilder stringBuilder = new StringBuilder();
-    List<String> selectStatements = urns.stream().map(urn -> {
-      final String tableName = isTestMode ? getTestTableName(urn) : getTableName(urn);
-      final String columnName = getAspectColumnName(urn.getEntityType(), aspectClass);
-      final String sqlTemplate =
-          includeSoftDeleted ? SQL_READ_ASPECT_WITH_SOFT_DELETED_TEMPLATE : SQL_READ_ASPECT_TEMPLATE;
-      return String.format(sqlTemplate, columnName, tableName, escapeReservedCharInUrn(urn.toString()), columnName);
-    }).collect(Collectors.toList());
-    stringBuilder.append(String.join(" UNION ALL ", selectStatements));
+
+    final Urn firstUrn = urns.iterator().next();
+    final String columnName = getAspectColumnName(firstUrn.getEntityType(), aspectClass);
+    final String tableName = isTestMode ? getTestTableName(firstUrn) : getTableName(firstUrn);
+    // Generate URN list for IN clause
+    String urnList = urns.stream()
+        .map(urn -> "'" + escapeReservedCharInUrn(urn.toString()) + "'")
+        .collect(Collectors.joining(", "));
+    final String sqlTemplate =
+        includeSoftDeleted ? SQL_READ_ASPECT_WITH_SOFT_DELETED_TEMPLATE : SQL_READ_ASPECT_TEMPLATE;
+    stringBuilder.append(String.format(sqlTemplate, columnName, tableName, columnName));
+    stringBuilder.append(urnList);
+    stringBuilder.append(RIGHT_PARENTHESIS);
     return stringBuilder.toString();
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -146,6 +146,7 @@ public class SQLStatementUtils {
 
   public static final String SOURCE = "source";
   public static final String DESTINATION = "destination";
+  private static final String RIGHT_PARENTHESIS = ")";
 
   private SQLStatementUtils() {
     // Util class
@@ -200,7 +201,7 @@ public class SQLStatementUtils {
         includeSoftDeleted ? SQL_READ_ASPECT_WITH_SOFT_DELETED_TEMPLATE : SQL_READ_ASPECT_TEMPLATE;
     stringBuilder.append(String.format(sqlTemplate, columnName, tableName, columnName));
     stringBuilder.append(urnList);
-    stringBuilder.append(CLOSING_BRACKET);
+    stringBuilder.append(RIGHT_PARENTHESIS);
     return stringBuilder.toString();
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -146,7 +146,6 @@ public class SQLStatementUtils {
 
   public static final String SOURCE = "source";
   public static final String DESTINATION = "destination";
-  private static final String RIGHT_PARENTHESIS = ")";
 
   private SQLStatementUtils() {
     // Util class
@@ -200,7 +199,7 @@ public class SQLStatementUtils {
         includeSoftDeleted ? SQL_READ_ASPECT_WITH_SOFT_DELETED_TEMPLATE : SQL_READ_ASPECT_TEMPLATE;
     stringBuilder.append(String.format(sqlTemplate, columnName, tableName, columnName));
     stringBuilder.append(urnList);
-    stringBuilder.append(RIGHT_PARENTHESIS);
+    stringBuilder.append(CLOSING_BRACKET);
     return stringBuilder.toString();
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -75,11 +75,20 @@ public class SQLStatementUtilsTest {
     Set<Urn> set = new HashSet<>();
     set.add(fooUrn1);
     set.add(fooUrn2);
+    //test when includedSoftDeleted is false
     String expectedSql =
-        "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE urn = 'urn:li:foo:1' "
-            + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL UNION ALL SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
-            + "FROM metadata_entity_foo WHERE urn = 'urn:li:foo:2' AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL";
+        "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
+            + "FROM metadata_entity_foo "
+            + "WHERE JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL "
+            + "AND urn IN ('urn:li:foo:1', 'urn:li:foo:2')";
     assertEquals(SQLStatementUtils.createAspectReadSql(AspectFoo.class, set, false, false), expectedSql);
+
+    //test when includedSoftDeleted is true
+    expectedSql =
+        "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
+            + "FROM metadata_entity_foo "
+            + "WHERE urn IN ('urn:li:foo:1', 'urn:li:foo:2')";
+    assertEquals(SQLStatementUtils.createAspectReadSql(AspectFoo.class, set, true, false), expectedSql);
   }
 
   @Test


### PR DESCRIPTION
## Summary

In this PR, we have changed the underlying SQL queries for batchGetUnion to use IN rather than UNION ALL for same aspect class. This change is done after SQL level investigation where we found that these queries were taking more time to execute - taking about 10-15 seconds depending on the number of urns.

UNION ALL scans the table each time for every individual query. We can replace it with IN which will scan the table once for all the urns and will have faster query performance.

## Testing Done

## Performance Comparison: `UNION ALL` vs `IN`

We conducted tests comparing the performance of `UNION ALL` and `IN` for querying 5,000 and 10,000 URNs. The results clearly show that `IN` significantly improves query execution time.

### Test Results  

| Test Scenario              | Execution Time (real) | Command Used |
|----------------------------|----------------------|------------------------------------------------------------------|
| `UNION ALL` over 5K URNs  | 2.473s              | `time mysql --host=mysql-db-016.stg.linkedin.com --user=mg_devs metagalaxy_stg --password=xxx < union_all_5k.sql > result_union_all_5k.txt` |
| `IN` over 5K URNs        | **0.614s**           | `time mysql --host=mysql-db-016.stg.linkedin.com --user=mg_devs metagalaxy_stg --password=xxx < IN_5k.sql > result_IN_5k.txt` |
| `UNION ALL` over 10K URNs | 6.607s              | `time mysql --host=mysql-db-016.stg.linkedin.com --user=mg_devs metagalaxy_stg --password=xxx < union_all_10k.sql > result_union_all_10k.txt` |
| `IN` over 10K URNs       | **0.700s**           | `time mysql --host=mysql-db-016.stg.linkedin.com --user=mg_devs metagalaxy_stg --password=xxx < IN_10k.sql > result_IN_10k.txt` |

#### Note
I have used unique urns for each of these tests to remove the bias for database caching

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
