### PR TITLE
(Improvement) Adding Force Index for graph queries filtering on destination field of relationship tables

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -46,8 +46,8 @@ public class EbeanLocalRelationshipQueryDAO {
   public static final String RELATIONSHIP_RETURN_TYPE = "relationship.return.type";
   public static final String MG_INTERNAL_ASSET_RELATIONSHIP_TYPE = "AssetRelationship.proto";
   private static final int FILTER_BATCH_SIZE = 200;
-  private static final String FORCE_IDX_ON_SOURCE = " FORCE INDEX (idx_source_deleted_ts) ";
   private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_comp_dest_del_ts) ";
+  private static final String DESTINATION_FIELD =  "destination";
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -611,7 +611,7 @@ public class EbeanLocalRelationshipQueryDAO {
       } else if (!relationshipFilter.getCriteria().isEmpty()) {
         // Check if any relationship-level filter is on "destination"
         for (LocalRelationshipCriterion criterion : relationshipFilter.getCriteria()) {
-          if ("destination".equals(criterion.getField())) {
+          if (DESTINATION_FIELD.equals(criterion.getField())) {
             sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
             break;
           }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -48,7 +48,7 @@ public class EbeanLocalRelationshipQueryDAO {
   public static final String RELATIONSHIP_RETURN_TYPE = "relationship.return.type";
   public static final String MG_INTERNAL_ASSET_RELATIONSHIP_TYPE = "AssetRelationship.proto";
   private static final int FILTER_BATCH_SIZE = 200;
-  private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_comp_dest_del_ts) ";
+  private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_destination_deleted_ts) ";
   private static final String DESTINATION_FIELD =  "destination";
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
@@ -694,12 +694,11 @@ public class EbeanLocalRelationshipQueryDAO {
       return _server.createSqlQuery(sql).findList();
     } catch (PersistenceException e) {
       Throwable cause = e.getCause();
-      if (cause instanceof SQLException && cause.getMessage() != null &&
-          cause.getMessage().contains("doesn't exist in table")) {
-
+      if (cause instanceof SQLException && cause.getMessage() != null
+          && cause.getMessage().contains("doesn't exist in table")) {
         String errorMsg = String.format(
-            "Missing index when querying table '%s'. " +
-                "Make sure FORCE INDEX targets like idx_destination_deleted_ts or idx_source_deleted_ts are created.",
+            "Missing index when querying table '%s'. "
+                + "Make sure FORCE INDEX targets like idx_destination_deleted_ts or idx_source_deleted_ts are created.",
             relationshipTableName);
         log.error(errorMsg);
         throw new IllegalStateException(errorMsg, e);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -664,7 +664,6 @@ public class EbeanLocalRelationshipQueryDAO {
         sqlBuilder.append(" OFFSET ").append(offset);
       }
     }
-    System.out.println("Generated SQL: " + sqlBuilder);
     return sqlBuilder.toString();
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -612,6 +612,7 @@ public class EbeanLocalRelationshipQueryDAO {
         // non-mg entity case, applying dest filter on relationship table
         filters.add(new Pair<>(destinationEntityFilter, "rt"));
       } else if (!relationshipFilter.getCriteria().isEmpty()) {
+        //TODO: Add a safeguard to check if the FORCE_IDX_ON_DESTINATION is present in the table, we can check once on bootup and then caching the result
         // Check if any relationship-level filter is on "destination"
         for (LocalRelationshipCriterion criterion : relationshipFilter.getCriteria()) {
           if (DESTINATION_FIELD.equals(criterion.getField())) {


### PR DESCRIPTION
## Summary

We discovered that GQS queries which filters on the destination field of relationship tables were not performing as expected. They were using the wrong index(idx_destination), which was causing performance issues. So, we will force the use of the correct index`idx_destination_deleted_ts` by adding a FORCE INDEX hint to the queries.

 I checked for source filtering, it's using the index efficiently - don't want to over-engineer it right now

## Testing Done
./gradlew build

## Next Steps
- Ensure all the relationship table has the index `idx_destination_deleted_ts`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
