### PR TITLE
Converting OR to IN

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -410,62 +410,79 @@ public class SQLStatementUtils {
   public static String whereClause(@Nonnull LocalRelationshipFilter filter,
       @Nonnull Map<Condition, String> supportedConditions, @Nullable String tablePrefix,
       boolean nonDollarVirtualColumnsEnabled) {
-    if (!filter.hasCriteria() || filter.getCriteria().size() == 0) {
+    if (!filter.hasCriteria() || filter.getCriteria().isEmpty()) {
       throw new IllegalArgumentException("Empty filter cannot construct where clause.");
     }
-
-    // Group the conditions by field.
+    // Group criteria by their respective field for more efficient processing
     Map<String, List<Pair<Condition, LocalRelationshipValue>>> groupByField = new HashMap<>();
     filter.getCriteria().forEach(criterion -> {
+      // Parse field based on the criterion and add to the corresponding group.
       String field = parseLocalRelationshipField(criterion, tablePrefix, nonDollarVirtualColumnsEnabled);
-      List<Pair<Condition, LocalRelationshipValue>> group = groupByField.getOrDefault(field, new ArrayList<>());
-      group.add(new Pair<>(criterion.getCondition(), criterion.getValue()));
-      groupByField.put(field, group);
+      groupByField.computeIfAbsent(field, k -> new ArrayList<>())
+          .add(new Pair<>(criterion.getCondition(), criterion.getValue()));
     });
-
     List<String> andClauses = new ArrayList<>();
+    // Process each group of criteria for a specific field
     for (Map.Entry<String, List<Pair<Condition, LocalRelationshipValue>>> entry : groupByField.entrySet()) {
-      List<String> orClauses = new ArrayList<>();
-      boolean useInClause = entry.getKey().equals("urn") && entry.getValue().size() > 1; // Check if we're dealing with 'urn' and multiple values
+      String field = entry.getKey();
+      List<Pair<Condition, LocalRelationshipValue>> pairs = entry.getValue();
 
-      if (useInClause) {
-        // If it's 'urn' and there are multiple values, use IN
-        List<String> values = new ArrayList<>();
-        for (Pair<Condition, LocalRelationshipValue> pair : entry.getValue()) {
-          values.add("'" + parseLocalRelationshipValue(pair.getValue1()) + "'");
-        }
-        orClauses.add(entry.getKey() + " IN (" + String.join(", ", values) + ")");
-      } else {
-        // Otherwise, use OR for individual conditions
-        for (Pair<Condition, LocalRelationshipValue> pair : entry.getValue()) {
-          if (pair.getValue0() == Condition.IN) {
-            if (!pair.getValue1().isArray()) {
-              throw new IllegalArgumentException("IN condition must be paired with array value");
-            }
-            orClauses.add(entry.getKey() + " IN " + parseLocalRelationshipValue(pair.getValue1()));
-          } else {
-            orClauses.add(entry.getKey() + supportedConditions.get(pair.getValue0()) + "'" + parseLocalRelationshipValue(pair.getValue1()) + "'");
+      List<String> equalValues = new ArrayList<>(); // To hold criteria with equal conditions
+      List<String> inValues = new ArrayList<>();    // To accumulate values for IN conditions
+      List<String> orClauses = new ArrayList<>();   // To hold criteria with other conditions
+
+      // Process each pair of condition and value
+      for (Pair<Condition, LocalRelationshipValue> pair : pairs) {
+        Condition condition = pair.getValue0();
+        LocalRelationshipValue value = pair.getValue1();
+
+        // Handle IN condition, which expects an array-like value
+        if (condition == Condition.IN) {
+          if (!value.isArray()) {
+            throw new IllegalArgumentException("IN condition must be paired with array value");
           }
+          // Assuming value.getArray() returns a StringArray, we need to convert it to a List<String>
+          List<String> inValueList = value.getArray(); // Convert StringArray to List<String>
+          inValues.addAll(inValueList); // Add the values to inValues list
+        } else if (condition == Condition.EQUAL) {
+          // Handle EQUAL condition by collecting values for later IN conversion if needed
+          equalValues.add(parseLocalRelationshipValue(value));
+        } else {
+          // Handle any other conditions (non-IN, non-EQUAL)
+          orClauses.add(field + supportedConditions.get(condition) + "'" + parseLocalRelationshipValue(value) + "'");
         }
       }
-
+      // If there are multiple IN conditions, combine them into one IN clause
+      if (!inValues.isEmpty()) {
+        // Create a single IN clause from all values in the inValues list
+        orClauses.add(
+            field + " IN (" + inValues.stream().map(v -> "'" + v + "'").collect(Collectors.joining(", ")) + ")");
+      }
+      // If there are multiple EQUAL conditions, combine them into a single IN clause
+      if (!equalValues.isEmpty()) {
+        if (equalValues.size() == 1) {
+          orClauses.add(field + "=" + "'" + equalValues.get(0) + "'"); // Single EQUAL condition
+        } else {
+          // Combine multiple EQUAL conditions as an IN clause
+          orClauses.add(
+              field + " IN (" + equalValues.stream().map(v -> "'" + v + "'").collect(Collectors.joining(", ")) + ")");
+        }
+      }
+      // If only one OR clause is created, add it directly, else combine OR clauses
       if (orClauses.size() == 1) {
         andClauses.add(orClauses.get(0));
       } else {
         andClauses.add("(" + String.join(" OR ", orClauses) + ")");
       }
     }
+    // If there's only one AND clause, return it directly (remove parentheses if necessary)
     if (andClauses.size() == 1) {
       String andClause = andClauses.get(0);
-      if (andClauses.get(0).startsWith("(")) {
-        return andClause.substring(1, andClause.length() - 1);
-      }
-      return andClause;
+      return andClause.startsWith("(") ? andClause.substring(1, andClause.length() - 1) : andClause;
     }
+    // Join all AND clauses with 'AND' and return the result
     return String.join(" AND ", andClauses);
   }
-
-
 
   /**
    * Construct the where clause SQL from a filter when running in old schema mode. Assumes that all filters are applied on
@@ -508,13 +525,13 @@ public class SQLStatementUtils {
     }
 
     if (field.isRelationshipField()) {
-      return tablePrefix + field.getRelationshipField().getName() + SQLSchemaUtils.processPath(field.getRelationshipField().getPath(), delimiter);
+      return tablePrefix + field.getRelationshipField().getName() + processPath(field.getRelationshipField().getPath(), delimiter);
     }
 
     if (field.isAspectField()) {
       // entity type from Urn definition.
       String assetType = getAssetType(field.getAspectField());
-      return tablePrefix + SQLSchemaUtils.getGeneratedColumnName(assetType, field.getAspectField().getAspect(),
+      return tablePrefix + getGeneratedColumnName(assetType, field.getAspectField().getAspect(),
           field.getAspectField().getPath(), nonDollarVirtualColumnsEnabled);
     }
 
@@ -540,17 +557,20 @@ public class SQLStatementUtils {
     return assetType;
   }
 
-
+  /**
+   * Parse the local relationship value to a string.
+   * @param localRelationshipValue the local relationship value
+   * @return the parsed string
+   */
   private static String parseLocalRelationshipValue(@Nonnull final LocalRelationshipValue localRelationshipValue) {
     if (localRelationshipValue.isArray()) {
-      return  "(" + localRelationshipValue.getArray().stream().map(s -> "'" + StringEscapeUtils.escapeSql(s) + "'")
+      return "(" + localRelationshipValue.getArray().stream().map(s -> "'" + StringEscapeUtils.escapeSql(s) + "'")
           .collect(Collectors.joining(", ")) + ")";
     }
-
     if (localRelationshipValue.isString()) {
-      return localRelationshipValue.getString();
+      // Escape SQL special characters here to avoid SQL injection
+      return StringEscapeUtils.escapeSql(localRelationshipValue.getString());
     }
-
     throw new IllegalArgumentException("Unrecognized field value");
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -196,8 +196,8 @@ public class SQLStatementUtilsTest {
 
     LocalRelationshipCriterionArray criteria = new LocalRelationshipCriterionArray(criterion1, criterion2);
     LocalRelationshipFilter filter = new LocalRelationshipFilter().setCriteria(criteria);
-    assertEquals(SQLStatementUtils.whereClause(filter, Collections.singletonMap(Condition.EQUAL, "="), null, false), "urn='value1' OR urn='value2'");
-    assertEquals(SQLStatementUtils.whereClause(filter, Collections.singletonMap(Condition.EQUAL, "="), null, true), "urn='value1' OR urn='value2'");
+    assertEquals(SQLStatementUtils.whereClause(filter, Collections.singletonMap(Condition.EQUAL, "="), null, false), "urn IN ('value1', 'value2')");
+    assertEquals(SQLStatementUtils.whereClause(filter, Collections.singletonMap(Condition.EQUAL, "="), null, true), "urn IN ('value1', 'value2')");
   }
 
   @Test
@@ -226,6 +226,7 @@ public class SQLStatementUtilsTest {
 
   @Test
   public void testWhereClauseMultiConditionMixedName() {
+    // Create criteria for each field
     LocalRelationshipCriterion.Field field1 = new LocalRelationshipCriterion.Field();
     field1.setUrnField(new UrnField());
     LocalRelationshipCriterion criterion1 = new LocalRelationshipCriterion()
@@ -254,12 +255,21 @@ public class SQLStatementUtilsTest {
         .setCondition(Condition.EQUAL)
         .setValue(LocalRelationshipValue.create("value4"));
 
+    // Group all criteria into a LocalRelationshipCriterionArray
     LocalRelationshipCriterionArray criteria = new LocalRelationshipCriterionArray(criterion1, criterion2, criterion3, criterion4);
     LocalRelationshipFilter filter = new LocalRelationshipFilter().setCriteria(criteria);
-    assertConditionsEqual(SQLStatementUtils.whereClause(filter, Collections.singletonMap(Condition.EQUAL, "="), null, false),
-        "(urn='value1' OR urn='value3') AND metadata$value='value4' AND i_aspectfoo$value='value2'");
+
+    // Generate SQL using whereClause method
+    String x = SQLStatementUtils.whereClause(filter, Collections.singletonMap(Condition.EQUAL, "="), null, false);
+    System.out.println(x);
+
+    // The urn field should use IN for multiple values
+    assertConditionsEqual(x,
+        "(urn IN 'value1', 'value3') AND metadata$value='value4' AND i_aspectfoo$value='value2'");
+
+    // Check for non-dollar virtual column case
     assertConditionsEqual(SQLStatementUtils.whereClause(filter, Collections.singletonMap(Condition.EQUAL, "="), null, true),
-        "(urn='value1' OR urn='value3') AND metadata0value='value4' AND i_aspectfoo0value='value2'");
+        "(urn IN 'value1', 'value3') AND metadata0value='value4' AND i_aspectfoo0value='value2'");
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -352,10 +352,9 @@ public class SQLStatementUtilsTest {
     LocalRelationshipCriterionArray criteria2 = new LocalRelationshipCriterionArray(criterion5, criterion6);
     LocalRelationshipFilter filter2 = new LocalRelationshipFilter().setCriteria(criteria2);
 
-    String actual = SQLStatementUtils.whereClause(Collections.singletonMap(Condition.EQUAL, "="), false, new Pair<>(filter1, "foo"),
-        new Pair<>(filter2, "bar"));
     //test for multi filters with dollar virtual columns names
-    assertConditionsEqual(actual, "(foo.i_aspectfoo$value='value2' AND (foo.urn IN ('value1', 'value3')) "
+    assertConditionsEqual(SQLStatementUtils.whereClause(Collections.singletonMap(Condition.EQUAL, "="), false, new Pair<>(filter1, "foo"),
+            new Pair<>(filter2, "bar")), "(foo.i_aspectfoo$value='value2' AND (foo.urn IN ('value1', 'value3')) "
             + "AND foo.metadata$value='value4') AND (bar.urn IN ('value1', 'value2'))"
         );
 


### PR DESCRIPTION
## Summary
This PR is basically a partial revert of #518. In that PR, we were doing two things:
1. batching the INs to 200
2. Converting ORs to use IN

In this PR, we will revert part 1 and keep the part 2 where 

- it merges multiple EQUAL conditions on the same field into a single IN clause to reduce query complexity.


### 🧪 Example

#### For Multiple EQUAL conditions: 

**Previously:**
```sql
urn = 'value1' OR urn = 'value2' OR urn = 'value3'
```

**Now:**
```sql
urn IN ('value1', 'value2', 'value3')
```

## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
