### PR TITLE
Reverting batching of INs in GQS

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -100,88 +100,23 @@ public class EbeanLocalRelationshipQueryDAO {
   @Nonnull
   public <SNAPSHOT extends RecordTemplate> List<SNAPSHOT> findEntities(@Nonnull Class<SNAPSHOT> snapshotClass,
       @Nonnull LocalRelationshipFilter filter, int offset, int count) throws OperationNotSupportedException {
-
-    // Check schema configuration and throw an exception if using the old schema mode
     if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
       throw new OperationNotSupportedException("findEntities is not supported in OLD_SCHEMA_MODE");
     }
     validateEntityFilter(filter, snapshotClass);
-    // List to hold the final results after processing all batches
-    List<SNAPSHOT> finalResults = new ArrayList<>();
 
-    // Separate IN criteria and other criteria for processing
-    List<LocalRelationshipCriterion> inCriteria = new ArrayList<>();
-    List<LocalRelationshipCriterion> otherCriteria = new ArrayList<>();
-
-    // Iterate through the criteria and split them into IN criteria and other criteria
-    for (LocalRelationshipCriterion c : filter.getCriteria()) {
-      if (c.getCondition() == Condition.IN) {
-        // Check if the IN criterion has a valid value
-        if (!c.getValue().isArray() || c.getValue().getArray() == null) {
-          throw new IllegalArgumentException("IN condition must have a non-null array value.");
-        }
-        inCriteria.add(c);
-      } else {
-        otherCriteria.add(c);
-      }
-    }
-    // If no IN criteria are present, simply execute a normal query
-    if (inCriteria.isEmpty()) {
-      return runAndCreateWhereQuery(filter, snapshotClass, offset, count);
-    }
-    // Sort IN criteria by size (descending order), prioritize the largest set
-    inCriteria.sort((a, b) -> Integer.compare(b.getValue().getArray().size(), a.getValue().getArray().size()));
-
-    // Get the largest IN criterion (first after sorting)
-    LocalRelationshipCriterion largestInCriterion = inCriteria.get(0);
-    List<String> allValues = largestInCriterion.getValue().getArray();
-    // Process in batches, with each batch having a maximum size defined by FILTER_BATCH_SIZE
-    for (int i = 0; i < allValues.size(); i += FILTER_BATCH_SIZE) {
-      // Sublist of values for this batch
-      List<String> subValues = allValues.subList(i, Math.min(i + FILTER_BATCH_SIZE, allValues.size()));
-      // Rebuild the IN criterion with the current batch of values
-      LocalRelationshipCriterion batchedInCriterion =
-          EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create(new StringArray(subValues)),
-              Condition.IN, largestInCriterion.getField().getAspectField());
-      // Merge other criteria and the current batched IN criterion
-      List<LocalRelationshipCriterion> mergedCriteria = new ArrayList<>(otherCriteria);
-      mergedCriteria.add(batchedInCriterion);
-      // Include the remaining IN criteria (excluding the largest one, which is batched)
-      for (int j = 1; j < inCriteria.size(); j++) {
-        mergedCriteria.add(inCriteria.get(j));
-      }
-      // Create a new filter with the merged criteria
-      LocalRelationshipFilter batchedFilter =
-          new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(mergedCriteria));
-      List<SNAPSHOT> partialResults = runAndCreateWhereQuery(batchedFilter, snapshotClass, offset, count);
-      finalResults.addAll(partialResults);
-    }
-    return finalResults;
-  }
-
-  /**
-   * Runs the SQL query based on the given filter and snapshot class, and returns the results as a list of snapshots.
-   * @param filter the filter to apply when querying the database.
-   * @param snapshotClass the snapshot class representing the entity type to retrieve.
-   * @param offset the offset for pagination.
-   * @param count the maximum number of records to return.
-   * @return a list of snapshot entities matching the filter criteria.
-   */
-  @VisibleForTesting
-  public <SNAPSHOT extends RecordTemplate> List<SNAPSHOT> runAndCreateWhereQuery(
-      @Nonnull LocalRelationshipFilter filter, @Nonnull Class<SNAPSHOT> snapshotClass, int offset, int count) {
+    // Build SQL
     final String tableName = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(snapshotClass));
-    StringBuilder sqlBuilder = new StringBuilder();
+    final StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("SELECT * FROM ").append(tableName);
-    if (filter.hasCriteria() && !filter.getCriteria().isEmpty()) {
-      sqlBuilder.append(" WHERE ")
-          .append(SQLStatementUtils.whereClause(filter, SUPPORTED_CONDITIONS, null,
-              _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled()));
+    if (filter.hasCriteria() && filter.getCriteria().size() > 0) {
+      sqlBuilder.append(" WHERE ").append(SQLStatementUtils.whereClause(filter, SUPPORTED_CONDITIONS, null,
+          _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled()));
     }
     sqlBuilder.append(" ORDER BY urn LIMIT ").append(Math.max(1, count)).append(" OFFSET ").append(Math.max(0, offset));
-    return _server.createSqlQuery(sqlBuilder.toString())
-        .findList()
-        .stream()
+
+    // Execute SQL
+    return _server.createSqlQuery(sqlBuilder.toString()).findList().stream()
         .map(sqlRow -> constructSnapshot(sqlRow, snapshotClass))
         .collect(Collectors.toList());
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -3,7 +3,6 @@ package com.linkedin.metadata.dao;
 import com.linkedin.data.DataMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.data.template.StringArray;
 import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.utils.ClassUtils;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
@@ -14,9 +13,7 @@ import com.linkedin.metadata.dao.utils.SQLSchemaUtils;
 import com.linkedin.metadata.dao.utils.SQLStatementUtils;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.LocalRelationshipCriterion;
-import com.linkedin.metadata.query.LocalRelationshipCriterionArray;
 import com.linkedin.metadata.query.LocalRelationshipFilter;
-import com.linkedin.metadata.query.LocalRelationshipValue;
 import com.linkedin.metadata.query.RelationshipDirection;
 import io.ebean.EbeanServer;
 import io.ebean.SqlRow;
@@ -105,17 +102,15 @@ public class EbeanLocalRelationshipQueryDAO {
     }
     validateEntityFilter(filter, snapshotClass);
 
-    // Build SQL
     final String tableName = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(snapshotClass));
     final StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("SELECT * FROM ").append(tableName);
-    if (filter.hasCriteria() && filter.getCriteria().size() > 0) {
+    if (filter.hasCriteria() && !filter.getCriteria().isEmpty()) {
       sqlBuilder.append(" WHERE ").append(SQLStatementUtils.whereClause(filter, SUPPORTED_CONDITIONS, null,
           _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled()));
     }
     sqlBuilder.append(" ORDER BY urn LIMIT ").append(Math.max(1, count)).append(" OFFSET ").append(Math.max(0, offset));
 
-    // Execute SQL
     return _server.createSqlQuery(sqlBuilder.toString()).findList().stream()
         .map(sqlRow -> constructSnapshot(sqlRow, snapshotClass))
         .collect(Collectors.toList());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -59,7 +59,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.naming.OperationNotSupportedException;
-import org.mockito.Mockito;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -91,6 +91,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
   @DataProvider(name = "inputList")
   public static Object[][] inputList() {
     return new Object[][] {
+        { true },
         { false }
     };
   }
@@ -1119,65 +1120,5 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Assertions
     assertEquals(fooSnapshotList.size(), 1); // Only one entity should match the criteria
-  }
-
-  @Test
-  public void testFindEntitiesBatchingMechanism() throws URISyntaxException, OperationNotSupportedException {
-    EbeanLocalRelationshipQueryDAO spyDao = Mockito.spy(_localRelationshipQueryDAO);
-
-    // Added 300 FooUrn entities with aspect AspectFoo and value "foo1" to "foo300"
-    for (int i = 1; i <= 300; i++) {
-      _fooUrnEBeanLocalAccess.add(new FooUrn(i), new AspectFoo().setValue("foo" + i), AspectFoo.class, new AuditStamp(),
-          null, false);
-    }
-
-    // Created one more FooUrn entity with aspect AspectBar with value "bar" and AspectFoo with value "foo5"
-    FooUrn one = new FooUrn(301);
-    _fooUrnEBeanLocalAccess.add(one, new AspectFoo().setValue("foo5"), AspectFoo.class, new AuditStamp(), null, false);
-    _fooUrnEBeanLocalAccess.add(one, new AspectBar().setValue("bar"), AspectBar.class, new AuditStamp(), null, false);
-
-    // Created one more FooUrn entity with aspect AspectBar with value "bar" and AspectFoo with value "foo6"
-    FooUrn two = new FooUrn(302);
-    _fooUrnEBeanLocalAccess.add(two, new AspectFoo().setValue("foo6"), AspectFoo.class, new AuditStamp(), null, false);
-    _fooUrnEBeanLocalAccess.add(two, new AspectBar().setValue("bar"), AspectBar.class, new AuditStamp(), null, false);
-
-    List<LocalRelationshipCriterion> criteriaList = new ArrayList<>();
-    List<String> allValues = new ArrayList<>();
-    for (int i = 1; i <= 202; i++) {
-      allValues.add("foo" + i);
-    }
-    criteriaList.add(
-        EBeanDAOUtils.buildRelationshipFieldCriterion(
-            LocalRelationshipValue.create(new StringArray(allValues)),
-            Condition.IN,
-            new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value")
-        )
-    );
-
-    // Create the EQUAL criterion for AspectBar
-    criteriaList.add(EBeanDAOUtils.buildRelationshipFieldCriterion(
-        LocalRelationshipValue.create("bar"),
-        Condition.EQUAL,
-        new AspectField().setAspect(AspectBar.class.getCanonicalName()).setPath("/value")
-    ));
-
-    LocalRelationshipFilter filter = new LocalRelationshipFilter();
-    filter.setCriteria(new LocalRelationshipCriterionArray(criteriaList));
-
-    // Retrieve entities (limit to 400 results for testing)
-    List<FooSnapshot> fooSnapshotList = spyDao.findEntities(FooSnapshot.class, filter, 0, 400);
-
-    // Assertions
-    assertEquals(fooSnapshotList.size(), 2);
-
-    // Verify the number of times runAndCreateWhereQuery was called
-    // The method should be called twice,
-    // once with 200 criteria(i_aspectfoo$value IN ('foo1', 'foo2', ..., 'foo200)) and once with 2 criteria (i_aspectfoo$value IN ('foo201', 'foo202'))
-    Mockito.verify(spyDao, Mockito.times(2)).runAndCreateWhereQuery(
-        Mockito.any(LocalRelationshipFilter.class),
-        Mockito.eq(FooSnapshot.class),
-        Mockito.anyInt(),
-        Mockito.anyInt()
-    );
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -352,10 +352,9 @@ public class SQLStatementUtilsTest {
     LocalRelationshipCriterionArray criteria2 = new LocalRelationshipCriterionArray(criterion5, criterion6);
     LocalRelationshipFilter filter2 = new LocalRelationshipFilter().setCriteria(criteria2);
 
-    String actual = SQLStatementUtils.whereClause(Collections.singletonMap(Condition.EQUAL, "="), false, new Pair<>(filter1, "foo"),
-        new Pair<>(filter2, "bar"));
     //test for multi filters with dollar virtual columns names
-    assertConditionsEqual(actual, "(foo.i_aspectfoo$value='value2' AND (foo.urn IN ('value1', 'value3')) "
+    assertConditionsEqual(SQLStatementUtils.whereClause(Collections.singletonMap(Condition.EQUAL, "="), false, new Pair<>(filter1, "foo"),
+            new Pair<>(filter2, "bar")), "(foo.i_aspectfoo$value='value2' AND (foo.urn IN ('value1', 'value3')) "
             + "AND foo.metadata$value='value4') AND (bar.urn IN ('value1', 'value2'))"
         );
 


### PR DESCRIPTION
## Summary
This PR is basically a partial revert of #518. In that PR, we were doing two things:
1. batching the INs to 200
2. Converting ORs to use IN

In this PR, we will revert part 1 and keep the part 2 where 

- it merges multiple EQUAL conditions on the same field into a single IN clause to reduce query complexity.


### 🧪 Example

#### For Multiple EQUAL conditions: 

**Previously:**
```sql
urn = 'value1' OR urn = 'value2' OR urn = 'value3'
```

**Now:**
```sql
urn IN ('value1', 'value2', 'value3')
```

## Testing Done
./gradlew build
## Testing Done

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
