### PR TITLE
(BugFix): Small bug in Forced Index Logic

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -519,7 +519,7 @@ public class EbeanLocalRelationshipQueryDAO {
    * @param offset                  offset to start from. If < 0, will start from 0.
    */
   @Nonnull
-  private String buildFindRelationshipSQL(
+  protected String buildFindRelationshipSQL(
       @Nonnull final String relationshipTableName, @Nonnull final LocalRelationshipFilter relationshipFilter,
       @Nullable final String sourceTableName, @Nullable final LocalRelationshipFilter sourceEntityFilter,
       @Nullable final String destTableName, @Nullable final LocalRelationshipFilter destinationEntityFilter,
@@ -545,7 +545,8 @@ public class EbeanLocalRelationshipQueryDAO {
         //TODO: Add a safeguard to check if the FORCE_IDX_ON_DESTINATION is present in the table, we can check once on bootup and then caching the result
         // Check if any relationship-level filter is on "destination"
         for (LocalRelationshipCriterion criterion : relationshipFilter.getCriteria()) {
-          if (DESTINATION_FIELD.equals(criterion.getField())) {
+          LocalRelationshipCriterion.Field field = criterion.getField();
+          if (field.getUrnField() != null && DESTINATION_FIELD.equals(field.getUrnField().getName())) {
             sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
             break;
           }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -519,7 +519,7 @@ public class EbeanLocalRelationshipQueryDAO {
    * @param offset                  offset to start from. If < 0, will start from 0.
    */
   @Nonnull
-  protected String buildFindRelationshipSQL(
+  private String buildFindRelationshipSQL(
       @Nonnull final String relationshipTableName, @Nonnull final LocalRelationshipFilter relationshipFilter,
       @Nullable final String sourceTableName, @Nullable final LocalRelationshipFilter sourceEntityFilter,
       @Nullable final String destTableName, @Nullable final LocalRelationshipFilter destinationEntityFilter,


### PR DESCRIPTION
## Summary
Updated the `buildFindRelationshipSQL` method in `EbeanLocalRelationshipQueryDAO.java` to compare the `urnField` of the `LocalRelationshipCriterion.Field` object with `DESTINATION_FIELD` before appending `FORCE_IDX_ON_DESTINATION` to the `sqlBuilder`.
## Testing Done
./gradlew build

Check the debugger section

<img width="1724" alt="Screenshot 2025-04-17 at 9 44 50 AM" src="https://github.com/user-attachments/assets/55f8e93f-28af-4ed0-a769-a465ff21d8bc" />

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
