### PR TITLE
Add POC to enable option to include non-current edge in single hop query

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -582,7 +582,6 @@ public class EbeanLocalRelationshipQueryDAO {
         sqlBuilder.append(includeNonCurrentRelationships ? " WHERE " : " AND ").append(whereClause);
       }
     } else if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
-      sqlBuilder.append("WHERE rt.deleted_ts IS NULL");
       StringBuilder whereClauseBuilder = new StringBuilder();
       if (!includeNonCurrentRelationships) {
         whereClauseBuilder.append("rt.deleted_ts IS NULL");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -9,6 +9,7 @@ import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
 import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.dao.utils.MultiHopsTraversalSqlGenerator;
 import com.linkedin.metadata.dao.utils.RecordUtils;
+import com.linkedin.metadata.dao.utils.RelationshipLookUpContext;
 import com.linkedin.metadata.dao.utils.SQLSchemaUtils;
 import com.linkedin.metadata.dao.utils.SQLStatementUtils;
 import com.linkedin.metadata.query.Condition;
@@ -167,7 +168,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable Class<DEST_SNAPSHOT> destinationEntityClass, @Nonnull LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter, int offset, int count) {
     return findRelationships(sourceEntityClass, sourceEntityFilter, destinationEntityClass, destinationEntityFilter, relationshipType,
-        relationshipFilter, offset, count, false);
+        relationshipFilter, offset, count, new RelationshipLookUpContext());
   }
 
   /**
@@ -189,7 +190,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable Class<SRC_SNAPSHOT> sourceEntityClass, @Nonnull LocalRelationshipFilter sourceEntityFilter,
       @Nullable Class<DEST_SNAPSHOT> destinationEntityClass, @Nonnull LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter, int offset,
-      int count, boolean includeNonCurrentRelationships) {
+      int count, RelationshipLookUpContext relationshipLookUpContext) {
     validateEntityFilter(sourceEntityFilter, sourceEntityClass);
     validateEntityFilter(destinationEntityFilter, destinationEntityClass);
     validateRelationshipFilter(relationshipFilter);
@@ -214,7 +215,7 @@ public class EbeanLocalRelationshipQueryDAO {
         destTableName,
         destinationEntityFilter,
         count,
-        offset, includeNonCurrentRelationships);
+        offset, relationshipLookUpContext);
 
     List<SqlRow> rows = executeSqlWithIndexCheck(sql, relationshipTableName);
 
@@ -240,10 +241,10 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable String sourceEntityType, @Nullable LocalRelationshipFilter sourceEntityFilter,
       @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
-      int offset, int count, boolean includeNonCurrentRelationships) {
+      int offset, int count, RelationshipLookUpContext relationshipLookUpContext) {
     List<SqlRow> sqlRows = findRelationshipsV2V3Core(
         sourceEntityType, sourceEntityFilter, destinationEntityType, destinationEntityFilter,
-        relationshipType, relationshipFilter, offset, count, includeNonCurrentRelationships);
+        relationshipType, relationshipFilter, offset, count, relationshipLookUpContext);
 
     return sqlRows.stream()
         .map(row -> RecordUtils.toRecordTemplate(relationshipType, row.getString(METADATA)))
@@ -268,7 +269,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable String sourceEntityType, @Nullable LocalRelationshipFilter sourceEntityFilter,
       @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
-      int offset, int count, boolean includeNonCurrentRelationships) {
+      int offset, int count, RelationshipLookUpContext relationshipLookUpContext) {
     validateEntityTypeAndFilter(sourceEntityFilter, sourceEntityType);
     validateEntityTypeAndFilter(destinationEntityFilter, destinationEntityType);
     validateRelationshipFilter(relationshipFilter);
@@ -282,7 +283,7 @@ public class EbeanLocalRelationshipQueryDAO {
         relationshipTableName, relationshipFilter,
         sourceTableName, sourceEntityFilter,
         destTableName, destinationEntityFilter,
-        count, offset, includeNonCurrentRelationships);
+        count, offset, relationshipLookUpContext);
     // Temporary log to help debug the slow SQL query
     log.info("Executing SQL for GQS: {}", sql);
     return executeSqlWithIndexCheck(sql, relationshipTableName);
@@ -310,7 +311,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
       @Nonnull Class<ASSET_RELATIONSHIP> assetRelationshipClass, @Nullable Map<String, Object> wrapOptions,
-      int offset, int count, boolean includeNonCurrentRelationships) {
+      int offset, int count, RelationshipLookUpContext relationshipLookUpContext) {
     if (wrapOptions == null || !wrapOptions.containsKey(RELATIONSHIP_RETURN_TYPE)
         || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(RELATIONSHIP_RETURN_TYPE))) {
       throw new IllegalArgumentException("Please check your use of the findRelationshipsV3 method.");
@@ -318,7 +319,7 @@ public class EbeanLocalRelationshipQueryDAO {
 
     List<SqlRow> sqlRows = findRelationshipsV2V3Core(
         sourceEntityType, sourceEntityFilter, destinationEntityType, destinationEntityFilter,
-        relationshipType, relationshipFilter, offset, count, includeNonCurrentRelationships);
+        relationshipType, relationshipFilter, offset, count, relationshipLookUpContext);
 
     return sqlRows.stream()
         .map(row -> createAssetRelationshipWrapperForRelationship(
@@ -531,8 +532,9 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull final String relationshipTableName, @Nonnull final LocalRelationshipFilter relationshipFilter,
       @Nullable final String sourceTableName, @Nullable final LocalRelationshipFilter sourceEntityFilter,
       @Nullable final String destTableName, @Nullable final LocalRelationshipFilter destinationEntityFilter,
-      int limit, int offset, boolean includeNonCurrentRelationships) {
+      int limit, int offset, RelationshipLookUpContext relationshipLookUpContext) {
 
+    boolean includeNonCurrentRelationships = relationshipLookUpContext.isIncludeNonCurrentRelationships();
     StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("SELECT rt.* FROM ").append(relationshipTableName).append(" rt ");
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -162,6 +162,14 @@ public class EbeanLocalRelationshipQueryDAO {
     return results;
   }
 
+  public <SRC_SNAPSHOT extends RecordTemplate, DEST_SNAPSHOT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<RELATIONSHIP> findRelationships(
+      @Nullable Class<SRC_SNAPSHOT> sourceEntityClass, @Nonnull LocalRelationshipFilter sourceEntityFilter,
+      @Nullable Class<DEST_SNAPSHOT> destinationEntityClass, @Nonnull LocalRelationshipFilter destinationEntityFilter,
+      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter, int offset, int count) {
+    return findRelationships(sourceEntityClass, sourceEntityFilter, destinationEntityClass, destinationEntityFilter, relationshipType,
+        relationshipFilter, offset, count, false);
+  }
+
   /**
    * Finds a list of relationships of a specific type based on the given filters.
    * The SRC_SNAPSHOT and DEST_SNAPSHOT class must be defined within com.linkedin.metadata.snapshot package in metadata-models.
@@ -180,7 +188,8 @@ public class EbeanLocalRelationshipQueryDAO {
   public <SRC_SNAPSHOT extends RecordTemplate, DEST_SNAPSHOT extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<RELATIONSHIP> findRelationships(
       @Nullable Class<SRC_SNAPSHOT> sourceEntityClass, @Nonnull LocalRelationshipFilter sourceEntityFilter,
       @Nullable Class<DEST_SNAPSHOT> destinationEntityClass, @Nonnull LocalRelationshipFilter destinationEntityFilter,
-      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter, int offset, int count) {
+      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter, int offset,
+      int count, boolean includeNonCurrentRelationships) {
     validateEntityFilter(sourceEntityFilter, sourceEntityClass);
     validateEntityFilter(destinationEntityFilter, destinationEntityClass);
     validateRelationshipFilter(relationshipFilter);
@@ -205,7 +214,7 @@ public class EbeanLocalRelationshipQueryDAO {
         destTableName,
         destinationEntityFilter,
         count,
-        offset);
+        offset, includeNonCurrentRelationships);
 
     List<SqlRow> rows = executeSqlWithIndexCheck(sql, relationshipTableName);
 
@@ -213,7 +222,6 @@ public class EbeanLocalRelationshipQueryDAO {
         .map(row -> RecordUtils.toRecordTemplate(relationshipType, row.getString("metadata")))
         .collect(Collectors.toList());
   }
-
   /**
    * Finds a list of relationships of a specific type (Urn) based on the given filters if applicable.
    *
@@ -232,10 +240,10 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable String sourceEntityType, @Nullable LocalRelationshipFilter sourceEntityFilter,
       @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
-      int offset, int count) {
+      int offset, int count, boolean includeNonCurrentRelationships) {
     List<SqlRow> sqlRows = findRelationshipsV2V3Core(
         sourceEntityType, sourceEntityFilter, destinationEntityType, destinationEntityFilter,
-        relationshipType, relationshipFilter, offset, count);
+        relationshipType, relationshipFilter, offset, count, includeNonCurrentRelationships);
 
     return sqlRows.stream()
         .map(row -> RecordUtils.toRecordTemplate(relationshipType, row.getString(METADATA)))
@@ -260,7 +268,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable String sourceEntityType, @Nullable LocalRelationshipFilter sourceEntityFilter,
       @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
-      int offset, int count) {
+      int offset, int count, boolean includeNonCurrentRelationships) {
     validateEntityTypeAndFilter(sourceEntityFilter, sourceEntityType);
     validateEntityTypeAndFilter(destinationEntityFilter, destinationEntityType);
     validateRelationshipFilter(relationshipFilter);
@@ -274,7 +282,7 @@ public class EbeanLocalRelationshipQueryDAO {
         relationshipTableName, relationshipFilter,
         sourceTableName, sourceEntityFilter,
         destTableName, destinationEntityFilter,
-        count, offset);
+        count, offset, includeNonCurrentRelationships);
     // Temporary log to help debug the slow SQL query
     log.info("Executing SQL for GQS: {}", sql);
     return executeSqlWithIndexCheck(sql, relationshipTableName);
@@ -302,7 +310,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
       @Nonnull Class<ASSET_RELATIONSHIP> assetRelationshipClass, @Nullable Map<String, Object> wrapOptions,
-      int offset, int count) {
+      int offset, int count, boolean includeNonCurrentRelationships) {
     if (wrapOptions == null || !wrapOptions.containsKey(RELATIONSHIP_RETURN_TYPE)
         || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(RELATIONSHIP_RETURN_TYPE))) {
       throw new IllegalArgumentException("Please check your use of the findRelationshipsV3 method.");
@@ -310,7 +318,7 @@ public class EbeanLocalRelationshipQueryDAO {
 
     List<SqlRow> sqlRows = findRelationshipsV2V3Core(
         sourceEntityType, sourceEntityFilter, destinationEntityType, destinationEntityFilter,
-        relationshipType, relationshipFilter, offset, count);
+        relationshipType, relationshipFilter, offset, count, includeNonCurrentRelationships);
 
     return sqlRows.stream()
         .map(row -> createAssetRelationshipWrapperForRelationship(
@@ -523,7 +531,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull final String relationshipTableName, @Nonnull final LocalRelationshipFilter relationshipFilter,
       @Nullable final String sourceTableName, @Nullable final LocalRelationshipFilter sourceEntityFilter,
       @Nullable final String destTableName, @Nullable final LocalRelationshipFilter destinationEntityFilter,
-      int limit, int offset) {
+      int limit, int offset, boolean includeNonCurrentRelationships) {
 
     StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("SELECT rt.* FROM ").append(relationshipTableName).append(" rt ");
@@ -560,7 +568,9 @@ public class EbeanLocalRelationshipQueryDAO {
         }
       }
 
-      sqlBuilder.append("WHERE rt.deleted_ts is NULL");
+      if (!includeNonCurrentRelationships) {
+        sqlBuilder.append("WHERE rt.deleted_ts is NULL");
+      }
 
       filters.add(new Pair<>(relationshipFilter, "rt"));
 
@@ -569,22 +579,33 @@ public class EbeanLocalRelationshipQueryDAO {
           filters.toArray(new Pair[filters.size()]));
 
       if (whereClause != null) {
-        sqlBuilder.append(" AND ").append(whereClause);
+        sqlBuilder.append(includeNonCurrentRelationships ? " WHERE " : " AND ").append(whereClause);
       }
     } else if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
       sqlBuilder.append("WHERE rt.deleted_ts IS NULL");
+      StringBuilder whereClauseBuilder = new StringBuilder();
+      if (!includeNonCurrentRelationships) {
+        whereClauseBuilder.append("rt.deleted_ts IS NULL");
+      }
       if (sourceEntityFilter != null) {
         validateEntityFilterOnlyOneUrn(sourceEntityFilter);
         if (sourceEntityFilter.hasCriteria() && sourceEntityFilter.getCriteria().size() > 0) {
-          sqlBuilder.append(
+          whereClauseBuilder.append(
               SQLStatementUtils.whereClauseOldSchema(SUPPORTED_CONDITIONS, sourceEntityFilter.getCriteria(), SQLStatementUtils.SOURCE));
         }
       }
       if (destinationEntityFilter != null) {
         validateEntityFilterOnlyOneUrn(destinationEntityFilter);
         if (destinationEntityFilter.hasCriteria() && destinationEntityFilter.getCriteria().size() > 0) {
-          sqlBuilder.append(
+          whereClauseBuilder.append(
               SQLStatementUtils.whereClauseOldSchema(SUPPORTED_CONDITIONS, destinationEntityFilter.getCriteria(), SQLStatementUtils.DESTINATION));
+        }
+      }
+      if (whereClauseBuilder.length() != 0) {
+        if (includeNonCurrentRelationships) {
+          sqlBuilder.append("WHERE ").append(whereClauseBuilder.toString().replaceFirst("^AND\\s+", ""));
+        } else {
+          sqlBuilder.append("WHERE ").append(whereClauseBuilder);
         }
       }
     } else {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/RelationshipLookUpContext.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/RelationshipLookUpContext.java
@@ -1,0 +1,23 @@
+package com.linkedin.metadata.dao.utils;
+
+import lombok.Getter;
+
+
+/**
+ * Context object for relationship lookup operations.
+ * This class allows configuration of whether to include non-current relationships
+ * (such as historical or soft-deleted relationships) during lookup operations.
+ */
+public class RelationshipLookUpContext {
+
+  @Getter
+  boolean includeNonCurrentRelationships;
+  public RelationshipLookUpContext(boolean includeNonCurrentRelationships) {
+    this.includeNonCurrentRelationships = includeNonCurrentRelationships;
+  }
+
+  public RelationshipLookUpContext() {
+    // By default, not include the nonCurrentRelationship
+    this(false);
+  }
+}

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -16,6 +16,7 @@ import com.linkedin.metadata.dao.IEbeanLocalAccess;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
 import com.linkedin.metadata.dao.utils.EmbeddedMariaInstance;
+import com.linkedin.metadata.dao.utils.RelationshipLookUpContext;
 import com.linkedin.metadata.dao.utils.SQLSchemaUtils;
 import com.linkedin.metadata.dao.utils.SQLStatementUtils;
 import com.linkedin.metadata.query.AspectField;
@@ -363,7 +364,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     // Asserts
     assertEquals(reportsToAlice.size(), 2);
@@ -380,7 +381,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     // Expect: only bob reports to Alice
     assertEquals(reportsToAlice.size(), 1);
@@ -435,7 +436,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ConsumeFrom> consumeFromSamza = _localRelationshipQueryDAO.findRelationshipsV2("bar", filterUrn, "foo", null,
         ConsumeFrom.class,
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     assertEquals(consumeFromSamza.size(), 2); // Because Samza consumes from 1. kafka and 2. restli
 
@@ -450,7 +451,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
       List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationshipsV2("bar", filterUrn, "foo", null,
           ConsumeFrom.class,
           filterRelationship,
-          -1, -1, false);
+          -1, -1, new RelationshipLookUpContext());
 
       // Assert
       assertEquals(consumeFromSamzaInNearline.size(), 1); // Because Samza only consumes kafka in NEARLINE.
@@ -516,7 +517,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew1 can be found
     List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, "crew", filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     assertEquals(ownedByCrew1.size(), 3);
 
@@ -530,7 +531,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew2 can be found
     List<OwnedBy> ownedByCrew2 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, "crew", filterUrn2,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     assertEquals(ownedByCrew2.size(), 2);
   }
@@ -584,7 +585,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew can be filtered by source entity, e.g. only include kafka
     List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2("foo", filterUrn1, "crew", filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     assertEquals(ownedByCrew1.size(), 1);
   }
@@ -610,7 +611,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertThrows(IllegalArgumentException.class, () -> {
       _localRelationshipQueryDAO.findRelationshipsV2("foo", filterUrn1, "crew", filterUrn,
           OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-          -1, -1, false);
+          -1, -1, new RelationshipLookUpContext());
     });
   }
 
@@ -673,7 +674,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, 3, false);
+        -1, 3, new RelationshipLookUpContext());
 
     // Asserts only 3 reports-to relationships are returned
     assertEquals(reportsToAlice.size(), 3);
@@ -681,7 +682,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        2, 10, false);
+        2, 10, new RelationshipLookUpContext());
 
     // Asserts 3 returns, and the content starts from the 3rd report (Lisa)
     assertEquals(reportsToAlice.size(), 3);
@@ -692,7 +693,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        2, -1, false);
+        2, -1, new RelationshipLookUpContext());
 
     // Asserts 5 returns, because offset cannot be applied when count isn't specified.
     assertEquals(reportsToAlice.size(), 5);
@@ -740,7 +741,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         AssetRelationship.class, wrapOptions,
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     AssetRelationship expected = reportsToAlice.get(0);
     assertEquals(expected.getSource(), "urn:li:foo:2");
@@ -792,7 +793,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         null, null, "foo", destFilter,
         BelongsToV2.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         AssetRelationship.class, wrapOptions,
-        -1, -1, false);
+        -1, -1, new RelationshipLookUpContext());
 
     AssetRelationship expected = belongsToOwner.get(0);
     assertEquals(expected.getSource(), "urn:li:foo:2");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -363,7 +363,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1);
+        -1, -1, false);
 
     // Asserts
     assertEquals(reportsToAlice.size(), 2);
@@ -380,7 +380,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1);
+        -1, -1, false);
 
     // Expect: only bob reports to Alice
     assertEquals(reportsToAlice.size(), 1);
@@ -435,7 +435,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ConsumeFrom> consumeFromSamza = _localRelationshipQueryDAO.findRelationshipsV2("bar", filterUrn, "foo", null,
         ConsumeFrom.class,
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1);
+        -1, -1, false);
 
     assertEquals(consumeFromSamza.size(), 2); // Because Samza consumes from 1. kafka and 2. restli
 
@@ -444,13 +444,13 @@ public class EbeanLocalRelationshipQueryDAOTest {
       LocalRelationshipCriterion filterRelationshipCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
           LocalRelationshipValue.create("NEARLINE"), Condition.EQUAL, new RelationshipField().setPath("/environment"));
 
-    LocalRelationshipFilter filterRelationship = new LocalRelationshipFilter().setCriteria(
-        new LocalRelationshipCriterionArray(filterRelationshipCriterion)).setDirection(RelationshipDirection.OUTGOING);
+      LocalRelationshipFilter filterRelationship = new LocalRelationshipFilter().setCriteria(
+          new LocalRelationshipCriterionArray(filterRelationshipCriterion)).setDirection(RelationshipDirection.OUTGOING);
 
-    List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationshipsV2("bar", filterUrn, "foo", null,
-        ConsumeFrom.class,
-        filterRelationship,
-        -1, -1);
+      List<ConsumeFrom> consumeFromSamzaInNearline = _localRelationshipQueryDAO.findRelationshipsV2("bar", filterUrn, "foo", null,
+          ConsumeFrom.class,
+          filterRelationship,
+          -1, -1, false);
 
       // Assert
       assertEquals(consumeFromSamzaInNearline.size(), 1); // Because Samza only consumes kafka in NEARLINE.
@@ -516,7 +516,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew1 can be found
     List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, "crew", filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1);
+        -1, -1, false);
 
     assertEquals(ownedByCrew1.size(), 3);
 
@@ -530,7 +530,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew2 can be found
     List<OwnedBy> ownedByCrew2 = _localRelationshipQueryDAO.findRelationshipsV2(null, null, "crew", filterUrn2,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1);
+        -1, -1, false);
 
     assertEquals(ownedByCrew2.size(), 2);
   }
@@ -584,7 +584,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // test owned by of crew can be filtered by source entity, e.g. only include kafka
     List<OwnedBy> ownedByCrew1 = _localRelationshipQueryDAO.findRelationshipsV2("foo", filterUrn1, "crew", filterUrn,
         OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, -1);
+        -1, -1, false);
 
     assertEquals(ownedByCrew1.size(), 1);
   }
@@ -610,7 +610,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertThrows(IllegalArgumentException.class, () -> {
       _localRelationshipQueryDAO.findRelationshipsV2("foo", filterUrn1, "crew", filterUrn,
           OwnedBy.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-          -1, -1);
+          -1, -1, false);
     });
   }
 
@@ -673,7 +673,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ReportsTo> reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        -1, 3);
+        -1, 3, false);
 
     // Asserts only 3 reports-to relationships are returned
     assertEquals(reportsToAlice.size(), 3);
@@ -681,7 +681,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        2, 10);
+        2, 10, false);
 
     // Asserts 3 returns, and the content starts from the 3rd report (Lisa)
     assertEquals(reportsToAlice.size(), 3);
@@ -692,7 +692,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     reportsToAlice = _localRelationshipQueryDAO.findRelationshipsV2(
         null, null, "foo", filter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-        2, -1);
+        2, -1, false);
 
     // Asserts 5 returns, because offset cannot be applied when count isn't specified.
     assertEquals(reportsToAlice.size(), 5);
@@ -740,7 +740,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         null, null, "foo", destFilter,
         ReportsTo.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         AssetRelationship.class, wrapOptions,
-        -1, -1);
+        -1, -1, false);
 
     AssetRelationship expected = reportsToAlice.get(0);
     assertEquals(expected.getSource(), "urn:li:foo:2");
@@ -792,7 +792,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         null, null, "foo", destFilter,
         BelongsToV2.class, new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         AssetRelationship.class, wrapOptions,
-        -1, -1);
+        -1, -1, false);
 
     AssetRelationship expected = belongsToOwner.get(0);
     assertEquals(expected.getSource(), "urn:li:foo:2");


### PR DESCRIPTION
## Summary
Add POC to enable option to include non-current edge in single hop query
## Testing Done
Change the existing unit test, and also did snapshot and local deployment, verified that the existing behavior remains unchanged and new behavior works as expected
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
