### PR TITLE
(feat) Adding delete asset implementation

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -988,8 +988,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       return deletedAspects.stream()
           .filter(Objects::nonNull)
           .map(x -> ModelUtils.newEntityUnion(_aspectUnionClass, x)).collect(Collectors.toList());
-    }
-    else {
+    } else {
       // TODO: delete aspects implementation can be moved here instead of in addCommon()
       // Add common method should be used only for create and update
       return Collections.emptyList();
@@ -1063,8 +1062,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       int maxTransactionRetry,
       @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
-    IngestionParams nonNullIngestionParams = ingestionParams == null ?
-        new IngestionParams().setIngestionMode(IngestionMode.LIVE).setTestMode(false) : ingestionParams;
+    IngestionParams nonNullIngestionParams = ingestionParams == null
+        ? new IngestionParams().setIngestionMode(IngestionMode.LIVE).setTestMode(false) : ingestionParams;
     return deleteCommon(urn, aspectClasses, auditStamp, maxTransactionRetry, trackingContext, nonNullIngestionParams, true);
   }
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -978,7 +978,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     // If deleteAll is true, delete entire asset, else mark aspects as deleted iteratively in a transaction
     if (deleteAll) {
       Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>
-          results = cleanUp(urn, aspectClasses, auditStamp, maxTransactionRetry, trackingContext, ingestionParams.isTestMode());
+          results = permanentDelete(urn, aspectClasses, auditStamp, maxTransactionRetry, trackingContext, ingestionParams.isTestMode());
       Collection<RecordTemplate> deletedAspects = new ArrayList<>();
       results.forEach((key, value) -> {
         DeleteResult deleteResult = new DeleteResult(value.get(), key);
@@ -1327,7 +1327,17 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull List<? extends RecordTemplate> aspectValues, @Nonnull AuditStamp newAuditStamp,
       @Nullable IngestionTrackingContext trackingContext, boolean isTestMode);
 
-  protected abstract Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> cleanUp(@Nonnull URN urn,
+  /**
+   * Permanently deletes the entity from the table.
+   * @param urn the URN for the entity the aspect is attached to
+   * @param aspectClasses Aspect Classes of the aspects being deleted, must be supported aspect types in {@code ASPECT_UNION}
+   * @param auditStamp the audit stamp of this action
+   * @param maxTransactionRetry maximum number of transaction retries before throwing an exception
+   * @param trackingContext the tracking context for the operation
+   * @param isTestMode whether the test mode is enabled or not
+   * @return a map of the deleted aspects (their value before deletion), each wrapped in an instance of {@link ASPECT_UNION}
+   */
+  protected abstract Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> permanentDelete(@Nonnull URN urn,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nullable AuditStamp auditStamp,
       int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext, boolean isTestMode);
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/AspectCallbackRoutingClient.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/AspectCallbackRoutingClient.java
@@ -48,19 +48,6 @@ public interface AspectCallbackRoutingClient<ASPECT extends RecordTemplate> {
   }
 
   /**
-   * A method that routes the delete request to the appropriate custom API.
-   * @param urn the urn of the asset
-   * @param existingAspectValue the existing aspect value
-   * @param ingestionParams the ingestionParams of current update
-   * @param auditStamp the auditStamp of current request
-   * @return AspectCallbackResponse containing the updated aspect
-   */
-  default AspectCallbackResponse<ASPECT> routeAspectCallback(Urn urn, ASPECT existingAspectValue,
-      IngestionParams ingestionParams, AuditStamp auditStamp) {
-    return null;
-  }
-
-  /**
    * A method that returns whether to skip processing further ingestion.
    * @return true if the ingestion should be skipped, false otherwise
    */

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/AspectCallbackRoutingClient.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/ingestion/AspectCallbackRoutingClient.java
@@ -48,6 +48,19 @@ public interface AspectCallbackRoutingClient<ASPECT extends RecordTemplate> {
   }
 
   /**
+   * A method that routes the delete request to the appropriate custom API.
+   * @param urn the urn of the asset
+   * @param existingAspectValue the existing aspect value
+   * @param ingestionParams the ingestionParams of current update
+   * @param auditStamp the auditStamp of current request
+   * @return AspectCallbackResponse containing the updated aspect
+   */
+  default AspectCallbackResponse<ASPECT> routeAspectCallback(Urn urn, ASPECT existingAspectValue,
+      IngestionParams ingestionParams, AuditStamp auditStamp) {
+    return null;
+  }
+
+  /**
    * A method that returns whether to skip processing further ingestion.
    * @return true if the ingestion should be skipped, false otherwise
    */

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
@@ -5,6 +5,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.dao.utils.ModelUtils;
+import com.linkedin.metadata.events.ChangeType;
 import com.linkedin.metadata.events.IngestionMode;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -66,6 +67,21 @@ public abstract class BaseMetadataEventProducer<SNAPSHOT extends RecordTemplate,
   public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
       @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode);
+
+  /**
+   * Produces an aspect specific Metadata Audit Event (MAE) after a metadata aspect is updated for an entity with Change type.
+   * @param urn {@link Urn} of the entity
+   * @param oldValue the value prior to the update, or null if there's none.
+   * @param newValue the value after the update
+   * @param aspectClass the class of ASPECT
+   * @param auditStamp {@link AuditStamp} containing version auditing information for the metadata change
+   * @param ingestionMode {@link IngestionMode} of the change
+   * @param changeType {@link ChangeType} of the change
+   * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}
+   */
+  public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
+      @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+      @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode, ChangeType changeType);
 
   /**
    * Produce Metadata Graph search metrics inside SearchDAO.

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseTrackingMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/BaseTrackingMetadataEventProducer.java
@@ -4,6 +4,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.events.ChangeType;
 import com.linkedin.metadata.events.IngestionMode;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import javax.annotation.Nonnull;
@@ -33,4 +34,9 @@ public abstract class BaseTrackingMetadataEventProducer<SNAPSHOT extends RecordT
   public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
       @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nullable AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionMode ingestionMode);
+
+  public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
+      @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+      @Nullable AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionMode ingestionMode,
+      @Nonnull ChangeType changeType);
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducer.java
@@ -5,6 +5,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dummy.DummyAspect;
 import com.linkedin.metadata.dummy.DummySnapshot;
+import com.linkedin.metadata.events.ChangeType;
 import com.linkedin.metadata.events.IngestionMode;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -37,6 +38,25 @@ public class DummyMetadataEventProducer<URN extends Urn>
   public <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
       @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
       @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode) {
+    // Do nothing
+  }
+
+  /**
+   * Produces an aspect specific Metadata Audit Event (MAE) after a metadata aspect is updated for an entity with Change
+   * type.
+   *
+   * @param urn           {@link Urn} of the entity
+   * @param oldValue      the value prior to the update, or null if there's none.
+   * @param newValue      the value after the update
+   * @param aspectClass   the class of ASPECT
+   * @param auditStamp    {@link AuditStamp} containing version auditing information for the metadata change
+   * @param ingestionMode {@link IngestionMode} of the change
+   * @param changeType    {@link ChangeType} of the change
+   */
+  @Override
+  public <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
+      @Nullable ASPECT oldValue, @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass,
+      @Nullable AuditStamp auditStamp, @Nullable IngestionMode ingestionMode, ChangeType changeType) {
     // Do nothing
   }
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/producer/GenericMetadataProducer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/producer/GenericMetadataProducer.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao.producer;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.events.ChangeType;
 import com.linkedin.metadata.events.IngestionMode;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import javax.annotation.Nonnull;
@@ -28,4 +29,22 @@ public interface GenericMetadataProducer {
   void produceAspectSpecificMetadataAuditEvent(@Nonnull Urn urn, @Nullable RecordTemplate oldValue, @Nonnull RecordTemplate newValue,
       @Nonnull Class<? extends RecordTemplate> aspectClass,
       @Nullable AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext, @Nullable IngestionMode ingestionMode);
+
+  /**
+   * Produces an aspect specific Metadata Audit Event (MAE) after a metadata aspect is updated for an entity with Change type.
+   * @param urn {@link Urn} of the entity
+   * @param oldValue the value prior to the update, or null if there's none.
+   * @param newValue the value after the update
+   * @param aspectClass the class of the aspect
+   * @param auditStamp {@link AuditStamp} containing version auditing information for the metadata change
+   * @param trackingContext nullable tracking context passed in to be appended to produced MAEv5s
+   * @param ingestionMode {@link IngestionMode} of the change
+   * @param changeType {@link ChangeType} of the change
+   */
+  void produceAspectSpecificMetadataAuditEvent(@Nonnull Urn urn, @Nullable RecordTemplate oldValue,
+      @Nonnull RecordTemplate newValue, @Nonnull Class<? extends RecordTemplate> aspectClass,
+      @Nullable AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext,
+      @Nullable IngestionMode ingestionMode, @Nonnull ChangeType changeType);
+
+
 }

--- a/dao-api/src/main/pegasus/com/linkedin/metadata/events/ChangeType.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/events/ChangeType.pdl
@@ -13,4 +13,9 @@ enum ChangeType {
    * delete the latest version of metadata, if it exists
    */
   DELETE
+
+  /**
+   * delete entire metadata for the entity, if it exists
+   */
+   DELETE_ALL
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -101,7 +101,7 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> cleanUp(@Nonnull FooUrn urn,
+    protected Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> permanentDelete(@Nonnull FooUrn urn,
         @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nullable AuditStamp auditStamp,
         int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
       Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> result = new HashMap<>();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -309,7 +309,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    */
   @Override
   public int deleteAll(@Nonnull URN urn, boolean isTestMode) {
-    final String deleteSqlStatement = SQLStatementUtils.createDeleteSql(urn, isTestMode);
+    final String deleteSqlStatement = SQLStatementUtils.createDeleteAssetSql(urn, isTestMode);
     final SqlUpdate sqlUpdate = _server.createSqlUpdate(deleteSqlStatement);
     sqlUpdate.setParameter("urn", urn.toString());
     return sqlUpdate.execute();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -310,7 +310,6 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   @Override
   public int deleteAll(@Nonnull URN urn, boolean isTestMode) {
     final String deleteSqlStatement = SQLStatementUtils.createDeleteSql(urn, isTestMode);
-    _server.createSqlUpdate(deleteSqlStatement);
     final SqlUpdate sqlUpdate = _server.createSqlUpdate(deleteSqlStatement);
     sqlUpdate.setParameter("urn", urn.toString());
     return sqlUpdate.execute();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -299,6 +299,23 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     return EBeanDAOUtils.readSqlRows(sqlRows);
   }
 
+  /**
+   * Delete all aspects + urn for the given urn.
+   * By this time pre-deletion hooks should be processed.
+   * Old values are not needed for delete, But should be retrieved and used for in post-update hooks if needed.
+   * @param urn {@link Urn} for the entity
+   * @param isTestMode whether the operation is in test mode or not
+   * @return number of rows deleted.
+   */
+  @Override
+  public int deleteAll(@Nonnull URN urn, boolean isTestMode) {
+    final String deleteSqlStatement = SQLStatementUtils.createDeleteSql(urn, isTestMode);
+    _server.createSqlUpdate(deleteSqlStatement);
+    final SqlUpdate sqlUpdate = _server.createSqlUpdate(deleteSqlStatement);
+    sqlUpdate.setParameter("urn", urn.toString());
+    return sqlUpdate.execute();
+  }
+
   @Override
   public List<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       @Nullable URN lastUrn, int pageSize) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -49,7 +49,6 @@ import java.net.URISyntaxException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -672,14 +672,18 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  protected Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> cleanUp(@Nonnull URN urn,
+  protected Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> permanentDelete(@Nonnull URN urn,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nullable AuditStamp auditStamp,
       int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
+    // If the table does not have the URN, return empty map. Nothing to delete here.
     if (!exists(urn)) {
-      return null;
+      return Collections.emptyMap();
     }
+    // If the table has the URN, get the asset record, including all the aspects.
+    // This will be used to delete to return deleted record info in the API.
     Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> deletedAspects =
         get(aspectClasses, Collections.singleton(urn)).get(urn);
+    // Perform deletion using urn and return the previously retrieved record.
     return runInTransactionWithRetry(() -> {
       _localAccess.deleteAll(urn, isTestMode);
       return deletedAspects;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -86,6 +86,14 @@ public interface IEbeanLocalAccess<URN extends Urn> {
       int keysCount, int position, boolean includeSoftDeleted, boolean isTestMode);
 
   /**
+   * Delete all aspects + urn for the given urn.
+   * @param urn {@link Urn} for the entity
+   * @param isTestMode whether the operation is in test mode or not
+   * @return number of rows deleted
+   */
+  int deleteAll(@Nonnull URN urn, boolean isTestMode);
+
+  /**
    * Returns list of urns that satisfy the given filter conditions.
    *
    * <p>Results are ordered by the order criterion but defaults to sorting lexicographically by the string

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -71,6 +71,8 @@ public class SQLStatementUtils {
   public static final String SQL_INSERT_INTO_ASSET = "INSERT INTO %s (urn, lastmodifiedon, lastmodifiedby,";
   // VALUES suffix of the sql statement for inserting into metadata_aspect table with multiple aspects which will be combined with the INSERT prefix
   public static final String SQL_INSERT_ASSET_VALUES = "VALUES (:urn, :lastmodifiedon, :lastmodifiedby,";
+  // Delete prefix of the sql statement for deleting from metadata_aspect table
+  public static final String SQL_DELETE_ASSET_WITH_URN = "DELETE FROM %s WHERE urn = :urn";
   // closing bracket for the sql statement INSERT prefix
   // e.g. INSERT INTO metadata_aspect (urn, a_urn, lastmodifiedon, lastmodifiedby)
   public static final String CLOSING_BRACKET = ") ";
@@ -262,6 +264,17 @@ public class SQLStatementUtils {
     final String tableName = isTestMode ? getTestTableName(urn) : getTableName(urn);
     final String columnName = getAspectColumnName(urn.getEntityType(), aspectClass);
     return String.format(urnExtraction ? SQL_UPSERT_ASPECT_WITH_URN_TEMPLATE : SQL_UPSERT_ASPECT_TEMPLATE, tableName, columnName, columnName);
+  }
+
+  /**
+   * Create Delete SQL statement.
+   * @param urn entity urn
+   * @param isTestMode whether the test mode is enabled or not
+   * @return delete sql
+   */
+  public static <ASPECT extends RecordTemplate> String createDeleteSql(@Nonnull Urn urn, boolean isTestMode) {
+    final String tableName = isTestMode ? getTestTableName(urn) : getTableName(urn);
+    return String.format(SQL_DELETE_ASSET_WITH_URN, tableName);
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -272,7 +272,7 @@ public class SQLStatementUtils {
    * @param isTestMode whether the test mode is enabled or not
    * @return delete sql
    */
-  public static <ASPECT extends RecordTemplate> String createDeleteSql(@Nonnull Urn urn, boolean isTestMode) {
+  public static <ASPECT extends RecordTemplate> String createDeleteAssetSql(@Nonnull Urn urn, boolean isTestMode) {
     final String tableName = isTestMode ? getTestTableName(urn) : getTableName(urn);
     return String.format(SQL_DELETE_ASSET_WITH_URN, tableName);
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -30,8 +30,10 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -461,5 +463,14 @@ public class EbeanLocalAccessTest {
     int numRowsCreated = _ebeanLocalAccessFoo.create(fooUrn, aspectValues, aspectCreateLambdas, auditStamp, null, false);
     // Assert that 1 record is created for asset with FooUrn
     assertEquals(numRowsCreated, 1);
+  }
+
+  @Test
+  public void testDeleteAll() {
+    FooUrn fooUrn = makeFooUrn(201);
+    Set<Class<? extends RecordTemplate>> aspectsClasses = new HashSet<>();
+    aspectsClasses.add(AspectFoo.class);
+    int numRowsDeleted = _ebeanLocalAccessFoo.deleteAll(fooUrn, false);
+    assertEquals(numRowsDeleted, 1);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -30,10 +30,8 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -468,8 +466,14 @@ public class EbeanLocalAccessTest {
   @Test
   public void testDeleteAll() {
     FooUrn fooUrn = makeFooUrn(201);
-    Set<Class<? extends RecordTemplate>> aspectsClasses = new HashSet<>();
-    aspectsClasses.add(AspectFoo.class);
+    AspectFoo aspectFoo = new AspectFoo().setValue("foo");
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    List<RecordTemplate> aspectValues = new ArrayList<>();
+    aspectValues.add(aspectFoo);
+    List<BaseLocalDAO.AspectCreateLambda<? extends RecordTemplate>> aspectCreateLambdas = new ArrayList<>();
+    aspectCreateLambdas.add(new BaseLocalDAO.AspectCreateLambda(aspectFoo));
+    int createResult = _ebeanLocalAccessFoo.create(fooUrn, aspectValues, aspectCreateLambdas, auditStamp, null, false);
+    assertEquals(createResult, 1);
     int numRowsDeleted = _ebeanLocalAccessFoo.deleteAll(fooUrn, false);
     assertEquals(numRowsDeleted, 1);
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -70,6 +70,17 @@ public class SQLStatementUtilsTest {
   }
 
   @Test
+  public void testDeleteAssetSql() {
+    FooUrn fooUrn = makeFooUrn(1);
+    // isTestMode=true
+    String expectedSql = "DELETE FROM metadata_entity_foo_test WHERE urn = :urn";
+    assertEquals(SQLStatementUtils.createDeleteAssetSql(fooUrn, true), expectedSql);
+    // isTestMode=false
+    expectedSql = "DELETE FROM metadata_entity_foo WHERE urn = :urn";
+    assertEquals(SQLStatementUtils.createDeleteAssetSql(fooUrn, false), expectedSql);
+  }
+
+  @Test
   public void testCreateAspectReadSql() {
     FooUrn fooUrn1 = makeFooUrn(1);
     FooUrn fooUrn2 = makeFooUrn(2);


### PR DESCRIPTION
## Summary
- Adding new method for Delete Asset: `deleteAll` for hard delete (deleting urn and all aspects from db table)
- Added `ChangeType_DELETE_ALL` to differentiate between asset vs aspect deletion. This will be used in sending MAE events. In case of asset delete the ChangeType will be set to DELETE_ALL. 
- Added new abstract method `produceAspectSpecificMetadataAuditEvent` to `BaseTrackingMetadatProducer` and method `produceAspectSpecificMetadataAuditEvent` to interface `GenericMetadataProducer`. With these methods, both the `oldValue` and `newValue` are `@Nullable`. The methods contain additional `ChangeType` param. So eventually, these methods can be used to emit MAEs on all db operations . for example

|Action| Null Values | ChangeType |
|------|-------|--------------|
|create|oldValue is null|ChangeType.UPSERT|
|update| - | ChangeType.UPSERT|
|delete aspect | newValue is null | ChangeType.DELETE|
|delete asset | newValue is null | ChangeType.DELETE_ALL|

- Adding new helper method `deleteCommon`. Using the existing `addCommon` does not much sense for hard delete, since instead of updating column value to a constant `gma_deleted` we are deleting the entire row from table. 
- Creating new class `DeleteResult` to hold the result of delete, as the new value after delete will always be null. This can probably be re-used in aspect delete. 

References:
[RFC - Delete Asset](https://docs.google.com/document/d/1VdjyNbMrDnoMvgK2A9I_slndcvbPfhh0vq8NkaYLRDc/edit?usp=sharing)

## Testing Done
- Added unit tests
- Local Build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
