### PR TITLE
Check if aspect is present before processing delete result

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -981,8 +981,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
           results = permanentDelete(urn, aspectClasses, auditStamp, maxTransactionRetry, trackingContext, ingestionParams.isTestMode());
       Collection<RecordTemplate> deletedAspects = new ArrayList<>();
       results.forEach((key, value) -> {
-        DeleteResult deleteResult = new DeleteResult(value.get(), key);
-        deletedAspects.add(unwrapDeleteResult(urn, deleteResult, auditStamp, trackingContext, ChangeType.DELETE_ALL));
+        // Check if aspect value present to avoid null pointer exception
+        if (value.isPresent()) {
+          DeleteResult deleteResult = new DeleteResult(value.get(), key);
+          deletedAspects.add(unwrapDeleteResult(urn, deleteResult, auditStamp, trackingContext, ChangeType.DELETE_ALL));
+        }
       });
 
       return deletedAspects.stream()

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -441,6 +441,39 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
+  public void testPermanentDeleteWithNullAspects() {
+    // DELETE ALL is not supported in the old schema.
+    if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
+      // First add a record to db
+      EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+      FooUrn urn = makeFooUrn(1);
+      AspectFoo foo = new AspectFoo().setValue("foo");
+      IngestionParams ingestionParams = new IngestionParams().setTestMode(false);
+      dao.setAlwaysEmitAuditEvent(false);
+      dao.setAlwaysEmitAspectSpecificAuditEvent(false);
+      dao.add(urn, foo, _dummyAuditStamp, null, ingestionParams);
+      // Verify the record was added: Foo aspect
+      BaseLocalDAO.AspectEntry<AspectFoo> aspectFooEntry = dao.getLatest(urn, AspectFoo.class, false);
+      assertEquals(aspectFooEntry.getAspect().getValue(), "foo");
+      assertNotNull(dao.get(AspectFoo.class, urn).get());
+      // Delete the record: provide 2 aspect class in the list of aspects to delete BUT only 1 aspect was added
+      Set<Class<? extends RecordTemplate>> aspectClasses = new HashSet<>();
+      // 2 aspects to be deleted: AspectFoo and AspectBar
+      aspectClasses.add(AspectFoo.class);
+      aspectClasses.add(AspectBar.class);
+      Collection<EntityAspectUnion> results = dao.deleteAll(urn, aspectClasses, _dummyAuditStamp);
+      // Only 1 aspect existed (Foo), so we should only get 1 result
+      // No exception should be thrown
+      assertEquals(results.size(), 1);
+      EntityAspectUnion deletedAspect = results.iterator().next();
+      assertEquals(deletedAspect.getAspectFoo().getValue(), "foo");
+      // Verify the record was deleted and no longer exists in db
+      BaseLocalDAO.AspectEntry<AspectFoo> aspectFooEntryDeleted = dao.getLatest(urn, AspectFoo.class, false);
+      assertNull(aspectFooEntryDeleted.getAspect());
+    }
+  }
+
+  @Test
   public void testAddWithIngestionAnnotation() throws URISyntaxException {
     EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
     FooUrn urn = makeFooUrn(1);


### PR DESCRIPTION
## Summary
- TL;DR: Check if the aspect value is present before using `.get` and processing the DeleteResult.
- Error founf in API testing

<details>

<summary>Log: Line984 </summary>

```
Caused by: java.util.NoSuchElementException: No value present                                                                                                                     
at java.base/java.util.Optional.get(Optional.java:143)                                                                                                                              
at com.linkedin.metadata.dao.BaseLocalDAO.lambda$deleteCommon$11(BaseLocalDAO.java:984)                                                                                             
at java.base/java.util.HashMap.forEach(HashMap.java:1421)                                                                                                                       
at com.linkedin.metadata.dao.BaseLocalDAO.deleteCommon(
```

</details>

- Explanation:
    - The input from user to delete API for deleteAll is an empty list of aspects. 
    - The deletion is done using the URN, but the MAEs are emitted for every aspect. So..
    - The service retrieves all the aspect class names that are part of this aspect and provides the list to the DAO level delete API - in order to process the MAEs for all aspects that will be deleted. 
    - Since the aspect class names are retrieved from the model, at the db level, the row to be deleted may or may not have all the aspect columns populated. 
    - Do a `.isPresentCheck` before trying to retrieve and process the aspect value. 
    - Only for the aspects that are present, create the DeleteResult object and populate the old value.
    - Use this old value to emit the MAE. 

example: Deletion for DemoAsset.
Scenario: For DemoAsset, 
- only status is added. and then deleteAll is called. 
- The DemoAsset contains other aspects like `DemoInfo`. Thus, the aspectClasses input list will contain the DemoInfo.class too, but the column does not contain any value. 
- Without the `isPresent()` check `.get` will return a null at 
```
DeleteResult deleteResult = new DeleteResult(value.get(), key);
```

## Testing Done
- Unit test added
- Local build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
