### PR TITLE
Enable optional dual-write support in BaseEntityResource via shadow DAO

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -392,7 +392,7 @@ public abstract class BaseEntityResource<
     return RestliUtils.toTask(() -> {
       final URN urn = (URN) ModelUtils.getUrnFromSnapshot(snapshot);
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
-      ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {
+      ModelUtils.getAspectsFromSnapshot(snapshot).stream().forEach(aspect -> {
         if (!aspectsToIgnore.contains(aspect.getClass())) {
           // Write to primary
           getLocalDAO().add(urn, aspect, auditStamp, trackingContext, ingestionParams);

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -386,9 +386,8 @@ public abstract class BaseEntityResource<
    */
   @Nonnull
   protected Task<Void> ingestInternal(@Nonnull SNAPSHOT snapshot,
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectsToIgnore,
-      @Nullable IngestionTrackingContext trackingContext,
-      @Nullable IngestionParams ingestionParams) {
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectsToIgnore, @Nullable IngestionTrackingContext trackingContext,
+      @Nullable IngestionParams ingestionParams)  {
 
     return RestliUtils.toTask(() -> {
       final URN urn = (URN) ModelUtils.getUrnFromSnapshot(snapshot);

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -388,7 +388,6 @@ public abstract class BaseEntityResource<
   protected Task<Void> ingestInternal(@Nonnull SNAPSHOT snapshot,
       @Nonnull Set<Class<? extends RecordTemplate>> aspectsToIgnore, @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams)  {
-
     return RestliUtils.toTask(() -> {
       final URN urn = (URN) ModelUtils.getUrnFromSnapshot(snapshot);
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());


### PR DESCRIPTION
## Summary

This PR introduces optional dual-write support in BaseEntityResource by allowing a shadow DAO to be configured per resource.

✅ Key Changes:

- Added a new protected method:

```java
@Nullable
protected BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> getShadowLocalDAO()
```
Returns null by default. Resources can override this to enable shadow writes.

- Updated the following ingestion methods to support dual-write if a shadow DAO is present:
``` java
ingestInternal(...)

rawIngestInternal(...)

ingestInternalAsset(...)

rawIngestAssetInternal(...)
```

In each case, the ingestion is done to both the primary and shadow DAOs if getShadowLocalDAO() is non-null.

🧪 Next Steps:
Resource classes like Demos.java can opt into dual-write by overriding getShadowLocalDAO() and injecting a second DAO.

## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
