### PR TITLE
fix: skip ingestion when user callback service return updated aspect as NULL

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -668,7 +668,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       AspectUpdateResult result = aspectCallbackHelper(urn, newValue, oldValue, updateTuple.getIngestionParams(), auditStamp);
       newValue = (ASPECT) result.getUpdatedAspect();
       // skip the normal ingestion to the DAO
-      if (result.isSkipProcessing()) {
+      if (newValue == null || result.isSkipProcessing()) {
         return null;
       }
     }


### PR DESCRIPTION
## Summary
We allow NULL to be produced by user callback service so it indicates the aspect shouldn't be ingested into DAO.
Note: The Type cast on NULL won't through exception.
## Testing Done
N/A
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
