### PR TITLE
Add shadow write support at BaseVersionedAspectResource and BaseAspec…

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
@@ -173,6 +173,10 @@ public abstract class BaseAspectV2Resource<
     return RestliUtils.toTask(() -> {
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       getLocalDAO().delete(urn, this._aspectClass, auditStamp);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.delete(urn, this._aspectClass, auditStamp);
+      }
       return new UpdateResponse(HttpStatus.S_200_OK);
     });
   }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
@@ -82,7 +82,9 @@ public abstract class BaseAspectV2Resource<
    *
    * @return {@link BaseLocalDAO} for shadowing the aspect.
    */
-  protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO();
+  protected BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO() {
+    return null;
+  }
 
   /**
    * Get the ASPECT associated with URN.

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
@@ -79,8 +79,7 @@ public abstract class BaseAspectV2Resource<
   protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalDAO();
 
   /**
-   *
-   * @return {@link BaseLocalDAO} for shadowing the aspect.
+   * Returns {@link BaseLocalDAO} for shadowing the aspect.
    */
   protected BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO() {
     return null;

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java
@@ -39,7 +39,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 
 
 /**
- * This resource is intended to be used as top level resousce, instead of a sub resource.
+ * This resource is intended to be used as top level resource, instead of a sub resource.
  * For sub-resource please use {@link BaseVersionedAspectResource}
  *
  * @param <URN> must be a valid {@link Urn} type
@@ -79,6 +79,12 @@ public abstract class BaseAspectV2Resource<
   protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalDAO();
 
   /**
+   *
+   * @return {@link BaseLocalDAO} for shadowing the aspect.
+   */
+  protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO();
+
+  /**
    * Get the ASPECT associated with URN.
    */
   @RestMethod.Get
@@ -112,6 +118,10 @@ public abstract class BaseAspectV2Resource<
     return RestliUtils.toTask(() -> {
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       getLocalDAO().add(urn, aspect, auditStamp);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.add(urn, aspect, auditStamp);
+      }
       return new CreateResponse(HttpStatus.S_201_CREATED);
     });
   }
@@ -123,6 +133,10 @@ public abstract class BaseAspectV2Resource<
     return RestliUtils.toTask(() -> {
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       getLocalDAO().add(urn, aspect, auditStamp, trackingContext, ingestionParams);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.add(urn, aspect, auditStamp, trackingContext, ingestionParams);
+      }
       return new CreateResponse(HttpStatus.S_201_CREATED);
     });
   }
@@ -138,6 +152,10 @@ public abstract class BaseAspectV2Resource<
     return RestliUtils.toTask(() -> {
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       final ASPECT newValue = getLocalDAO().add(urn, _aspectClass, createLambda, auditStamp);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.add(urn, _aspectClass, createLambda, auditStamp);
+      }
       return new CreateKVResponse<>(urn, newValue);
     });
   }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -137,6 +137,10 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
       final URN urn = getUrn(getContext().getPathKeys());
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       getLocalDAO().delete(urn, this._aspectClass, auditStamp);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.delete(urn, this._aspectClass, auditStamp);
+      }
       return new UpdateResponse(HttpStatus.S_200_OK);
     });
   }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -75,7 +75,9 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
    *
    * @return {@link BaseLocalDAO} for shadowing the aspect.
    */
-  protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO();
+  protected BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO() {
+    return null;
+  }
 
   /**
    * Constructs an entity-specific {@link Urn} based on the entity's {@link PathKeys}.

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -72,6 +72,12 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
   protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalDAO();
 
   /**
+   *
+   * @return {@link BaseLocalDAO} for shadowing the aspect.
+   */
+  protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO();
+
+  /**
    * Constructs an entity-specific {@link Urn} based on the entity's {@link PathKeys}.
    */
   @Nonnull
@@ -109,6 +115,10 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
       final URN urn = getUrn(getContext().getPathKeys());
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       getLocalDAO().add(urn, aspect, auditStamp);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.add(urn, aspect, auditStamp);
+      }
       return new CreateResponse(HttpStatus.S_201_CREATED);
     });
   }
@@ -139,6 +149,10 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
       final URN urn = getUrn(getContext().getPathKeys());
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       getLocalDAO().add(urn, aspectClass, createLambda, auditStamp);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.add(urn, aspectClass, createLambda, auditStamp);
+      }
       return new CreateResponse(HttpStatus.S_201_CREATED);
     });
   }
@@ -156,6 +170,10 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
       final URN urn = getUrn(getContext().getPathKeys());
       final AuditStamp auditStamp = getAuditor().requestAuditStamp(getContext().getRawRequestContext());
       final ASPECT newValue = getLocalDAO().add(urn, aspectClass, createLambda, auditStamp);
+      BaseLocalDAO<ASPECT_UNION, URN> shadowLocalDao = getLocalShadowDAO();
+      if (shadowLocalDao != null) {
+        shadowLocalDao.add(urn, aspectClass, createLambda, auditStamp);
+      }
       return new CreateKVResponse<>(LATEST_VERSION, newValue);
     });
   }

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -72,8 +72,7 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
   protected abstract BaseLocalDAO<ASPECT_UNION, URN> getLocalDAO();
 
   /**
-   *
-   * @return {@link BaseLocalDAO} for shadowing the aspect.
+   * Returns {@link BaseLocalDAO} for shadowing the aspect.
    */
   protected BaseLocalDAO<ASPECT_UNION, URN> getLocalShadowDAO() {
     return null;


### PR DESCRIPTION
## Summary
This pull request introduces support for shadowing aspects in the `BaseAspectV2Resource` and `BaseVersionedAspectResource` classes by adding a new method to retrieve a shadow DAO and updating various methods to interact with it. Additionally, a minor typo in a comment was corrected.

### Shadow DAO Support

* **Added `getLocalShadowDAO` method**: Introduced a new protected method `getLocalShadowDAO` in both `BaseAspectV2Resource` and `BaseVersionedAspectResource` to return a shadow DAO for handling aspect shadowing. By default, it returns `null`. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java`: [[1]](diffhunk://#diff-7fe95a80ebc47b75fa86c40d11f29b45c41b875e8ecc40c32127028243bf3bb8R81-R88) `restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java`: [[2]](diffhunk://#diff-856c0f1c3ca212eb85193ee959707adac139e754b2520a9cc733f9adcf5575feR74-R81)

* **Updated aspect operations to use shadow DAO**: 
  - In `BaseAspectV2Resource`, methods such as `create`, `createWithTracking`, `createAndGet`, and `delete` now check for a non-null shadow DAO and use it to perform corresponding operations. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java`: [[1]](diffhunk://#diff-7fe95a80ebc47b75fa86c40d11f29b45c41b875e8ecc40c32127028243bf3bb8R123-R126) [[2]](diffhunk://#diff-7fe95a80ebc47b75fa86c40d11f29b45c41b875e8ecc40c32127028243bf3bb8R138-R141) [[3]](diffhunk://#diff-7fe95a80ebc47b75fa86c40d11f29b45c41b875e8ecc40c32127028243bf3bb8R157-R160) [[4]](diffhunk://#diff-7fe95a80ebc47b75fa86c40d11f29b45c41b875e8ecc40c32127028243bf3bb8R176-R179)
  - Similarly, in `BaseVersionedAspectResource`, methods like `create`, `delete`, `create(Class<ASPECT>, ...)`, and `createAndGet(Class<ASPECT>, ...)` were updated to include shadow DAO interactions. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java`: [[1]](diffhunk://#diff-856c0f1c3ca212eb85193ee959707adac139e754b2520a9cc733f9adcf5575feR120-R123) [[2]](diffhunk://#diff-856c0f1c3ca212eb85193ee959707adac139e754b2520a9cc733f9adcf5575feR140-R143) [[3]](diffhunk://#diff-856c0f1c3ca212eb85193ee959707adac139e754b2520a9cc733f9adcf5575feR158-R161) [[4]](diffhunk://#diff-856c0f1c3ca212eb85193ee959707adac139e754b2520a9cc733f9adcf5575feR179-R182)

### Minor Fixes

* **Fixed typo in comment**: Corrected "resousce" to "resource" in a comment in `BaseAspectV2Resource`. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.java`: [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectV2Resource.javaL42-R42](diffhunk://#diff-7fe95a80ebc47b75fa86c40d11f29b45c41b875e8ecc40c32127028243bf3bb8L42-R42))

## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
