### PR TITLE
[feat] history relationship dedup logic

### DIFF
--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
@@ -143,3 +143,7 @@ ALTER TABLE metadata_entity_bar ADD a_aspectfoo JSON;
 
 -- add foo aspect to burger entity
 ALTER TABLE metadata_entity_burger ADD a_aspectfoo JSON;
+
+-- add new index virtual column 'type'
+ALTER TABLE metadata_relationship_belongstov2 ADD COLUMN `metadata0type` VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.type')));

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -143,3 +143,7 @@ ALTER TABLE metadata_entity_bar ADD a_aspectfoo JSON;
 
 -- add baz aspect to burger entity
 ALTER TABLE metadata_entity_burger ADD a_aspectfoo JSON;
+
+-- add new index virtual column 'type'
+ALTER TABLE metadata_relationship_belongstov2 ADD COLUMN `metadata$type` VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.type')));

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
@@ -163,3 +163,7 @@ ALTER TABLE metadata_entity_bar ADD COLUMN i_aspectfoo0value VARCHAR(255)
 -- add new virtual column 'value' to relationship table
 ALTER TABLE metadata_relationship_consumefrom ADD COLUMN metadata0environment VARCHAR(255)
     GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.environment')));
+
+-- add new index virtual column 'type'
+ALTER TABLE metadata_relationship_belongstov2 ADD COLUMN `metadata0type` VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.type')));

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -179,3 +179,7 @@ ALTER TABLE metadata_entity_bar ADD COLUMN i_aspectfoo$value VARCHAR(255)
 -- add new virtual column 'value' to relationship table
 ALTER TABLE metadata_relationship_consumefrom ADD COLUMN metadata$environment VARCHAR(255)
     GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.environment')));
+
+-- add new index virtual column 'type'
+ALTER TABLE metadata_relationship_belongstov2 ADD COLUMN `metadata$type` VARCHAR(255)
+    GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.type')));


### PR DESCRIPTION
## Summary
This PR enables DAO level de-duplication logic for non current relationship look up. Will use source, destination, and metadata.type (if exist, for example for downstreamof) to dedeup.

FYI
mariadb is not on the version that supports CTE (WITH keyword). I used another expression.

## Testing Done
./gradlew build

SQL generated:
```
SELECT * FROM (SELECT rt.*, ROW_NUMBER() OVER (PARTITION BY rt.source, rt.destination ORDER BY rt.lastmodifiedon DESC) AS row_num FROM metadata_relationship_downstreamof rt INNER JOIN metadata_entity_dataset dt ON dt.urn=rt.destination INNER JOIN metadata_entity_dataset st ON st.urn=rt.source  WHERE (dt.urn='urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD)') AND (st.urn='urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD)')) ranked_rows WHERE row_num = 1;
```

tested in db:

2 records can be found originally
```
MySQL [metagalaxy]> select * from metadata_relationship_downstreamof where source = 'urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD)' and destination = 'urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD)';
+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+-----------------------------------------------------------------------------------+------------------+---------------------+--------------------------+----------------------------+---------------+------------------------------------------+--------------------------------------+---------------------------+---------------------------+------------------------------------------+
| id        | metadata                                                                                                                                                                                                                                                                                                                                                                                                                   | source                                                                                    | source_type | destination                                                                       | destination_type | lastmodifiedon      | lastmodifiedby           | deleted_ts                 | metadata$type | metadata$auditStampActor                 | aspect                               | metadata$auditStampTimeAt | metadata$audit_stamp$time | metadata$audit_stamp$actor               |
+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+-----------------------------------------------------------------------------------+------------------+---------------------+--------------------------+----------------------------+---------------+------------------------------------------+--------------------------------------+---------------------------+---------------------------+------------------------------------------+
| 227436377 | {"type": "VIEW", "source": "urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD)", "destination": "urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD)", "auditStampActor": "urn:li:multiProduct:wherehows-samza-hive", "auditStampTimeAt": 1741068291175}                                                                                              | urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD) | dataset     | urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD) | dataset          | 2025-05-29 16:27:08 | urn:li:principal:UNKNOWN | 2025-05-29 16:27:08.000000 | VIEW          | urn:li:multiProduct:wherehows-samza-hive | com.linkedin.dataset.UpstreamLineage | 1741068291175             |                      NULL | NULL                                     |
| 334769553 | {"type": "VIEW", "source": "urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD)", "audit_stamp": {"time": 1741068291175, "actor": "urn:li:multiProduct:wherehows-samza-hive"}, "destination": "urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD)", "auditStampActor": "urn:li:multiProduct:wherehows-samza-hive", "auditStampTimeAt": 1741068291175} | urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD) | dataset     | urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD) | dataset          | 2025-05-29 16:27:09 | urn:li:principal:UNKNOWN | NULL                       | VIEW          | urn:li:multiProduct:wherehows-samza-hive | com.linkedin.dataset.UpstreamLineage | 1741068291175             |             1741068291175 | urn:li:multiProduct:wherehows-samza-hive |
+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+-----------------------------------------------------------------------------------+------------------+---------------------+--------------------------+----------------------------+---------------+------------------------------------------+--------------------------------------+---------------------------+---------------------------+------------------------------------------+
```

generated query will only return the latest one record:
```
MySQL [metagalaxy]> SELECT * FROM (SELECT rt.*, ROW_NUMBER() OVER (PARTITION BY rt.source, rt.destination ORDER BY rt.lastmodifiedon DESC) AS row_num FROM metadata_relationship_downstreamof rt INNER JOIN metadata_entity_dataset dt ON dt.urn=rt.destination INNER JOIN metadata_entity_dataset st ON st.urn=rt.source  WHERE (dt.urn='urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD)') AND (st.urn='urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD)')) ranked_rows WHERE row_num = 1;
ERROR 2006 (HY000): MySQL server has gone away
No connection. Trying to reconnect...
Connection id:    114011452
Current database: metagalaxy

+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+-----------------------------------------------------------------------------------+------------------+---------------------+--------------------------+------------+---------------+------------------------------------------+--------------------------------------+---------------------------+---------------------------+------------------------------------------+---------+
| id        | metadata                                                                                                                                                                                                                                                                                                                                                                                                                   | source                                                                                    | source_type | destination                                                                       | destination_type | lastmodifiedon      | lastmodifiedby           | deleted_ts | metadata$type | metadata$auditStampActor                 | aspect                               | metadata$auditStampTimeAt | metadata$audit_stamp$time | metadata$audit_stamp$actor               | row_num |
+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+-----------------------------------------------------------------------------------+------------------+---------------------+--------------------------+------------+---------------+------------------------------------------+--------------------------------------+---------------------------+---------------------------+------------------------------------------+---------+
| 334769553 | {"type": "VIEW", "source": "urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD)", "audit_stamp": {"time": 1741068291175, "actor": "urn:li:multiProduct:wherehows-samza-hive"}, "destination": "urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD)", "auditStampActor": "urn:li:multiProduct:wherehows-samza-hive", "auditStampTimeAt": 1741068291175} | urn:li:dataset:(urn:li:dataPlatform:gridTable,u_llsins.temp_qa_358920_content_check,PROD) | dataset     | urn:li:dataset:(urn:li:dataPlatform:gridTable,prod_learningadmin.categoryv2,PROD) | dataset          | 2025-05-29 16:27:09 | urn:li:principal:UNKNOWN | NULL       | VIEW          | urn:li:multiProduct:wherehows-samza-hive | com.linkedin.dataset.UpstreamLineage | 1741068291175             |             1741068291175 | urn:li:multiProduct:wherehows-samza-hive |       1 |
+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-------------+-----------------------------------------------------------------------------------+------------------+---------------------+--------------------------+------------+---------------+------------------------------------------+--------------------------------------+---------------------------+---------------------------+------------------------------------------+---------+
```


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
