### PR TITLE
Updating exists() check and filter query to filter by deleted_ts column

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -478,15 +478,9 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     filterSql.append(SQLStatementUtils.createFilterSql(_entityType, indexFilter, false, _nonDollarVirtualColumnsEnabled));
 
     if (lastUrn != null) {
-      // because createFilterSql will only include a WHERE clause if there are non-urn filters, we need to make sure
-      // that we add a WHERE if it wasn't added already.
+      // because createFilterSql will always include a WHERE clause to filter by deleted_ts is NULL
+      // We will append the lastUrn condition to the WHERE clause with AND operator.
       String operator = "AND";
-
-      if (indexFilter == null
-          || !indexFilter.hasCriteria()
-          || indexFilter.getCriteria().stream().allMatch(criteria -> isUrn(criteria.getAspect()))) {
-        operator = "WHERE";
-      }
 
       filterSql.append(String.format(" %s URN > '%s'", operator, lastUrn));
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -111,27 +111,19 @@ public class SQLIndexFilterUtils {
           sqlFilters.add(String.format(SOFT_DELETED_CHECK, aspectColumn));
         }
 
-    for (IndexCriterion indexCriterion : indexFilter.getCriteria()) {
-      final String aspect = indexCriterion.getAspect();
-      if (!isUrn(aspect)) {
-        // if aspect is not urn, then check aspect is not soft deleted and is not null
-        final String aspectColumn = getAspectColumnName(entityType, indexCriterion.getAspect());
-        sqlFilters.add(aspectColumn + " IS NOT NULL");
-        sqlFilters.add(String.format(SOFT_DELETED_CHECK, aspectColumn));
-      }
-
-      final IndexPathParams pathParams = indexCriterion.getPathParams(GetMode.NULL);
-      if (pathParams != null) {
-        validateConditionAndValue(indexCriterion);
-        final Condition condition = pathParams.getCondition();
-        final String indexColumn = getGeneratedColumnName(entityType, aspect, pathParams.getPath(), nonDollarVirtualColumnsEnabled);
-        final String tableName = SQLSchemaUtils.getTableName(entityType);
-        // New: Skip filter if column doesn't exist
-        if (!schemaValidator.columnExists(tableName, indexColumn)) {
-          log.warn("Skipping filter: virtual column '{}' not found in table '{}'", indexColumn, tableName);
-          continue;
+        final IndexPathParams pathParams = indexCriterion.getPathParams(GetMode.NULL);
+        if (pathParams != null) {
+          validateConditionAndValue(indexCriterion);
+          final Condition condition = pathParams.getCondition();
+          final String indexColumn = getGeneratedColumnName(entityType, aspect, pathParams.getPath(), nonDollarVirtualColumnsEnabled);
+          final String tableName = SQLSchemaUtils.getTableName(entityType);
+          // New: Skip filter if column doesn't exist
+          if (!schemaValidator.columnExists(tableName, indexColumn)) {
+            log.warn("Skipping filter: virtual column '{}' not found in table '{}'", indexColumn, tableName);
+            continue;
+          }
+          sqlFilters.add(parseSqlFilter(indexColumn, condition, pathParams.getValue()));
         }
-        sqlFilters.add(parseSqlFilter(indexColumn, condition, pathParams.getValue()));
       }
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -98,7 +98,7 @@ public class SQLIndexFilterUtils {
     List<String> sqlFilters = new ArrayList<>();
 
     if (indexFilter == null || !indexFilter.hasCriteria()) {
-      return "";
+      return "WHERE deleted_ts IS NULL ";
     }
 
     for (IndexCriterion indexCriterion : indexFilter.getCriteria()) {
@@ -120,9 +120,9 @@ public class SQLIndexFilterUtils {
     }
 
     if (sqlFilters.isEmpty()) {
-      return "";
+      return "WHERE deleted_ts IS NULL ";
     } else {
-      return "WHERE " + String.join("\nAND ", sqlFilters);
+      return "WHERE deleted_ts IS NULL \nAND " + String.join("\nAND ", sqlFilters);
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang.StringEscapeUtils;
 
 import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
-import static com.linkedin.metadata.dao.utils.SQLStatementUtils.SOFT_DELETED_CHECK;
+import static com.linkedin.metadata.dao.utils.SQLStatementUtils.*;
 
 
 /**
@@ -97,33 +97,32 @@ public class SQLIndexFilterUtils {
   public static String parseIndexFilter(@Nonnull String entityType, @Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled) {
     List<String> sqlFilters = new ArrayList<>();
 
-    if (indexFilter == null || !indexFilter.hasCriteria()) {
-      return "WHERE deleted_ts IS NULL ";
-    }
+    // Process index filter criteria if present
+    if (indexFilter != null && indexFilter.hasCriteria()) {
+      for (IndexCriterion indexCriterion : indexFilter.getCriteria()) {
+        final String aspect = indexCriterion.getAspect();
+        if (!isUrn(aspect)) {
+          // if aspect is not urn, then check aspect is not soft deleted and is not null
+          final String aspectColumn = getAspectColumnName(entityType, indexCriterion.getAspect());
+          sqlFilters.add(aspectColumn + " IS NOT NULL");
+          sqlFilters.add(String.format(SOFT_DELETED_CHECK, aspectColumn));
+        }
 
-    for (IndexCriterion indexCriterion : indexFilter.getCriteria()) {
-      final String aspect = indexCriterion.getAspect();
-      if (!isUrn(aspect)) {
-        // if aspect is not urn, then check aspect is not soft deleted and is not null
-        final String aspectColumn = getAspectColumnName(entityType, indexCriterion.getAspect());
-        sqlFilters.add(aspectColumn + " IS NOT NULL");
-        sqlFilters.add(String.format(SOFT_DELETED_CHECK, aspectColumn));
+        final IndexPathParams pathParams = indexCriterion.getPathParams(GetMode.NULL);
+        if (pathParams != null) {
+          validateConditionAndValue(indexCriterion);
+          final Condition condition = pathParams.getCondition();
+          final String indexColumn = getGeneratedColumnName(entityType, aspect, pathParams.getPath(), nonDollarVirtualColumnsEnabled);
+          sqlFilters.add(parseSqlFilter(indexColumn, condition, pathParams.getValue()));
+        }
       }
-
-      final IndexPathParams pathParams = indexCriterion.getPathParams(GetMode.NULL);
-      if (pathParams != null) {
-        validateConditionAndValue(indexCriterion);
-        final Condition condition = pathParams.getCondition();
-        final String indexColumn = getGeneratedColumnName(entityType, aspect, pathParams.getPath(), nonDollarVirtualColumnsEnabled);
-        sqlFilters.add(parseSqlFilter(indexColumn, condition, pathParams.getValue()));
-      }
     }
 
-    if (sqlFilters.isEmpty()) {
-      return "WHERE deleted_ts IS NULL ";
-    } else {
-      return "WHERE deleted_ts IS NULL \nAND " + String.join("\nAND ", sqlFilters);
-    }
+    // Add soft deleted check.
+    sqlFilters.add(DELETED_TS_IS_NULL_CHECK);
+
+    return "WHERE " + String.join("\nAND ", sqlFilters);
+
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -38,6 +38,8 @@ public class SQLStatementUtils {
 
   public static final String SOFT_DELETED_CHECK = "JSON_EXTRACT(%s, '$.gma_deleted') IS NULL"; // true when not soft deleted
 
+  public static final String DELETED_TS_IS_NULL_CHECK = "deleted_ts IS NULL"; // true when the deleted_ts is NULL, meaning the record is not soft deleted
+
   public static final String NONNULL_CHECK = "%s IS NOT NULL"; // true when the value of aspect_column is not NULL
 
   // Build manual SQL update query to enable optimistic locking on a given column

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -114,7 +114,7 @@ public class SQLStatementUtils {
 
   private static final String SQL_GET_ALL_COLUMNS =
       "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = database() AND TABLE_NAME = '%s'";
-  private static final String SQL_URN_EXIST_TEMPLATE = "SELECT urn FROM %s WHERE urn = '%s'";
+  private static final String SQL_URN_EXIST_TEMPLATE = "SELECT urn FROM %s WHERE urn = '%s' AND deleted_ts IS NULL";
 
   private static final String INSERT_LOCAL_RELATIONSHIP = "INSERT INTO %s (metadata, source, destination, source_type, "
       + "destination_type, lastmodifiedon, lastmodifiedby) VALUE (:metadata, :source, :destination, :source_type,"

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
@@ -50,10 +50,10 @@ public class SQLIndexFilterUtilsTest {
 
     String sql = SQLIndexFilterUtils.parseIndexFilter(FooUrn.ENTITY_TYPE, indexFilter, false);
     assertEquals(sql,
-        "WHERE a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo$id < 12");
+        "WHERE deleted_ts IS NULL \nAND a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo$id < 12");
 
     sql = SQLIndexFilterUtils.parseIndexFilter(FooUrn.ENTITY_TYPE, indexFilter, true);
     assertEquals(sql,
-        "WHERE a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo0id < 12");
+        "WHERE deleted_ts IS NULL \nAND a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo0id < 12");
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtilsTest.java
@@ -50,10 +50,10 @@ public class SQLIndexFilterUtilsTest {
 
     String sql = SQLIndexFilterUtils.parseIndexFilter(FooUrn.ENTITY_TYPE, indexFilter, false);
     assertEquals(sql,
-        "WHERE deleted_ts IS NULL \nAND a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo$id < 12");
+        "WHERE a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo$id < 12\nAND deleted_ts IS NULL");
 
     sql = SQLIndexFilterUtils.parseIndexFilter(FooUrn.ENTITY_TYPE, indexFilter, true);
     assertEquals(sql,
-        "WHERE deleted_ts IS NULL \nAND a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo0id < 12");
+        "WHERE a_aspectfoo IS NOT NULL\nAND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\nAND i_aspectfoo0id < 12\nAND deleted_ts IS NULL");
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -120,10 +120,12 @@ public class SQLStatementUtilsTest {
     indexFilter.setCriteria(indexCriterionArray);
 
     String sql1 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false);
-    String expectedSql1 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
+    String expectedSql1 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE deleted_ts IS NULL \n"
+        + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo$value < 50) as _total_count FROM metadata_entity_foo\n" + "WHERE a_aspectfoo IS NOT NULL\n"
+        + "AND i_aspectfoo$value < 50) as _total_count FROM metadata_entity_foo\n" + "WHERE deleted_ts IS NULL \n"
+        + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo$value < 50";
@@ -131,10 +133,12 @@ public class SQLStatementUtilsTest {
     assertEquals(sql1, expectedSql1);
 
     String sql2 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, true);
-    String expectedSql2 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
+    String expectedSql2 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE deleted_ts IS NULL \n"
+        + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo0value < 50) as _total_count FROM metadata_entity_foo\n" + "WHERE a_aspectfoo IS NOT NULL\n"
+        + "AND i_aspectfoo0value < 50) as _total_count FROM metadata_entity_foo\n" + "WHERE deleted_ts IS NULL \n"
+        + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo0value < 50";
@@ -163,14 +167,14 @@ public class SQLStatementUtilsTest {
 
     String sql1 = SQLStatementUtils.createGroupBySql("foo", indexFilter, indexGroupByCriterion, false);
     assertEquals(sql1, "SELECT count(*) as COUNT, i_aspectfoo$value FROM metadata_entity_foo\n"
-        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "WHERE deleted_ts IS NULL \n" + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo$value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value < 50\n"
         + "GROUP BY i_aspectfoo$value");
 
     String sql2 = SQLStatementUtils.createGroupBySql("foo", indexFilter, indexGroupByCriterion, true);
     assertEquals(sql2, "SELECT count(*) as COUNT, i_aspectfoo0value FROM metadata_entity_foo\n"
-        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "WHERE deleted_ts IS NULL \n" + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo0value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value < 50\n"
         + "GROUP BY i_aspectfoo0value");
@@ -471,5 +475,15 @@ public class SQLStatementUtilsTest {
 
     aspectField.setAsset(BarAsset.class.getCanonicalName());
     assertEquals(SQLStatementUtils.getAssetType(aspectField), BarUrn.ENTITY_TYPE);
+  }
+
+  @Test
+  public void testExistsSql() {
+    FooUrn fooUrn =  makeFooUrn(1);
+    String expectedSql = "SELECT urn "
+        + "FROM metadata_entity_foo "
+        + "WHERE urn = 'urn:li:foo:1' "
+        + "AND deleted_ts IS NULL";
+    assertConditionsEqual(SQLStatementUtils.createExistSql(fooUrn), expectedSql);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -120,28 +120,26 @@ public class SQLStatementUtilsTest {
     indexFilter.setCriteria(indexCriterionArray);
 
     String sql1 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false);
-    String expectedSql1 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE deleted_ts IS NULL \n"
-        + "AND a_aspectfoo IS NOT NULL\n"
+    String expectedSql1 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo$value < 50) as _total_count FROM metadata_entity_foo\n" + "WHERE deleted_ts IS NULL \n"
-        + "AND a_aspectfoo IS NOT NULL\n"
-        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
-        + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo$value < 50";
+        + "AND i_aspectfoo$value < 50\n" + "AND deleted_ts IS NULL)" + " as _total_count FROM metadata_entity_foo\n"
+        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "AND i_aspectfoo$value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "AND i_aspectfoo$value < 50\n" + "AND deleted_ts IS NULL";
 
     assertEquals(sql1, expectedSql1);
 
     String sql2 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, true);
-    String expectedSql2 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE deleted_ts IS NULL \n"
-        + "AND a_aspectfoo IS NOT NULL\n"
+    String expectedSql2 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo0value < 50) as _total_count FROM metadata_entity_foo\n" + "WHERE deleted_ts IS NULL \n"
-        + "AND a_aspectfoo IS NOT NULL\n"
-        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
-        + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo0value < 50";
+        + "AND i_aspectfoo0value < 50\n" + "AND deleted_ts IS NULL)" + " as _total_count FROM metadata_entity_foo\n"
+        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "AND i_aspectfoo0value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "AND i_aspectfoo0value < 50\n" + "AND deleted_ts IS NULL";
 
     assertEquals(sql2, expectedSql2);
   }
@@ -167,17 +165,17 @@ public class SQLStatementUtilsTest {
 
     String sql1 = SQLStatementUtils.createGroupBySql("foo", indexFilter, indexGroupByCriterion, false);
     assertEquals(sql1, "SELECT count(*) as COUNT, i_aspectfoo$value FROM metadata_entity_foo\n"
-        + "WHERE deleted_ts IS NULL \n" + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo$value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value < 50\n"
-        + "GROUP BY i_aspectfoo$value");
+        + "AND deleted_ts IS NULL\n" + "GROUP BY i_aspectfoo$value");
 
     String sql2 = SQLStatementUtils.createGroupBySql("foo", indexFilter, indexGroupByCriterion, true);
     assertEquals(sql2, "SELECT count(*) as COUNT, i_aspectfoo0value FROM metadata_entity_foo\n"
-        + "WHERE deleted_ts IS NULL \n" + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo0value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value < 50\n"
-        + "GROUP BY i_aspectfoo0value");
+        + "AND deleted_ts IS NULL\n" + "GROUP BY i_aspectfoo0value");
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -558,7 +558,7 @@ public class SQLStatementUtilsTest {
         + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo$age >= 25\n" + "AND a_aspectbar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectbar, '$.gma_deleted') IS NULL\n" + "AND i_aspectbar$name = 'PizzaMan'\n"
-        + "GROUP BY i_aspectbar$name");
+        + "AND deleted_ts IS NULL\n" + "GROUP BY i_aspectbar$name");
   }
 
   @Test
@@ -595,6 +595,7 @@ public class SQLStatementUtilsTest {
         + "AND a_aspectbar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectbar, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectbar$name = 'PizzaMan'\n"
+        + "AND deleted_ts IS NULL\n"
         + "GROUP BY i_aspectbar$name");
   }
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all-with-non-dollar-virtual-column-names.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
 );
 
@@ -21,6 +22,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
 );
 
@@ -30,6 +32,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
     );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-access-create-all.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
 );
 
@@ -21,6 +22,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
 );
 
@@ -30,6 +32,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
 );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all-with-non-dollar-virtual-column-names.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
     );
 
@@ -23,6 +24,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo_test (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo_test PRIMARY KEY (urn)
     );
 
@@ -32,6 +34,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
     );
 
@@ -41,6 +44,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
     );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-dao-create-all.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
 );
 
@@ -23,6 +24,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo_test (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo_test PRIMARY KEY (urn)
 );
 
@@ -32,6 +34,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
 );
 
@@ -41,6 +44,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_burger (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts datetime(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_burger PRIMARY KEY (urn)
 );
 


### PR DESCRIPTION
## Summary

This is PR#1 in a series of PRs which will contain code changes to support usage of `deleted_ts` column in DAO methods for read and write.

What?
- Adding a check on `deleted_ts` column in dao level queries for exists() and filter() methods.
- Updating unit tests to check the query strings now include `deleted_ts` check.
- Updating test tables to have `deleted_ts` column with NULL as the default value.

Why?
- `deleted_ts` column is required for supporting delete operations on EGG databases. Instead of doing a hard delete using `DELETE FROM <table> where <some condition>`, the records to be deleted with have a non-null value for `deleted_ts` column indicating the record has been deleted. It will actually be removed from the table periodically by a scheduled purge job. Till then, records marked as deleted should be filtered out.
- All DAO level operations need to be modified to handle the new column  
    - For read(exists, get, batchGet and filter) by doing a simple `IS NULL` check 
    - For write(create, update, delete) the logic needs to be modified and will be done in the following PRs. 

How?
- Update the filter method to ALWAYS have a check on deleted_ts column so that only records that are NOT marked for deletion are returned in the filtered results. This is consistent with the current behavior. 
- Update the exists method to return true IFF record is NOT marked as deleted. 

Ref: [RFC: Delete Asset - Soft Delete in EGG](https://docs.google.com/document/d/1hamWjkvKTdzARVWYmxVBSmIsv2CrVjkUr9Zyxm22mec/edit?usp=sharing)

## Testing Done

1. Local Build
2. Updated some existing unit tests and added 1 unit test

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
