### PR TITLE
Adding shadowDao for read requests

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -48,11 +48,13 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 
 import static com.linkedin.metadata.dao.BaseReadDAO.*;
 import static com.linkedin.metadata.dao.utils.IngestionUtils.*;
@@ -73,6 +75,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
  * @param <INTERNAL_ASPECT_UNION> must be a valid internal aspect union type supported by the internal snapshot
  * @param <ASSET> must be a valid asset type defined in com.linkedin.metadata.asset
  */
+@Slf4j
 public abstract class BaseEntityResource<
     // @formatter:off
     KEY,
@@ -169,6 +172,11 @@ public abstract class BaseEntityResource<
 
   @Nullable
   protected BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> getShadowLocalDAO() {
+    return null; // override in resource class only if needed
+  }
+
+  @Nullable
+  protected BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> getShadowReadLocalDAO() {
     return null; // override in resource class only if needed
   }
 
@@ -1142,17 +1150,74 @@ public abstract class BaseEntityResource<
     final Map<URN, List<UnionTemplate>> urnAspectsMap =
         urns.stream().collect(Collectors.toMap(Function.identity(), urn -> new ArrayList<>()));
 
-    if (isInternalModelsEnabled) {
-      getLocalDAO().get(keys)
-          .forEach((key, aspect) -> aspect.ifPresent(metadata -> urnAspectsMap.get(key.getUrn())
-              .add(ModelUtils.newAspectUnion(_internalAspectUnionClass, metadata))));
+    if (getShadowLocalDAO() == null) {
+      if (isInternalModelsEnabled) {
+        getLocalDAO().get(keys)
+            .forEach((key, aspect) -> aspect.ifPresent(metadata -> urnAspectsMap.get(key.getUrn())
+                .add(ModelUtils.newAspectUnion(_internalAspectUnionClass, metadata))));
+      } else {
+        getLocalDAO().get(keys)
+            .forEach((key, aspect) -> aspect.ifPresent(metadata -> urnAspectsMap.get(key.getUrn())
+                .add(ModelUtils.newAspectUnion(_aspectUnionClass, metadata))));
+      }
+      return urnAspectsMap;
     } else {
-      getLocalDAO().get(keys)
-          .forEach((key, aspect) -> aspect.ifPresent(
-              metadata -> urnAspectsMap.get(key.getUrn()).add(ModelUtils.newAspectUnion(_aspectUnionClass, metadata))));
+      return getUrnAspectMapFromShadowDao(urns, aspectClasses, isInternalModelsEnabled);
     }
+  }
+
+  @Nonnull
+  private Map<URN, List<UnionTemplate>> getUrnAspectMapFromShadowDao(
+      @Nonnull Collection<URN> urns,
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
+      boolean isInternalModelsEnabled) {
+
+    // Construct keys for latest versions of all aspects
+    final Set<AspectKey<URN, ? extends RecordTemplate>> keys = urns.stream()
+        .flatMap(urn -> aspectClasses.stream().map(clazz -> new AspectKey<>(clazz, urn, LATEST_VERSION)))
+        .collect(Collectors.toSet());
+
+    Map<AspectKey<URN, ? extends RecordTemplate>, java.util.Optional<? extends RecordTemplate>> localResults =
+        getLocalDAO().get(keys);
+
+    BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> shadowDao = getShadowReadLocalDAO();
+    Map<AspectKey<URN, ? extends RecordTemplate>, java.util.Optional<? extends RecordTemplate>> shadowResults =
+        shadowDao.get(keys);
+
+    final Map<URN, List<UnionTemplate>> urnAspectsMap =
+        urns.stream().collect(Collectors.toMap(Function.identity(), urn -> new ArrayList<>()));
+
+    keys.forEach(key -> {
+      java.util.Optional<? extends RecordTemplate> localValue = localResults.getOrDefault(key, java.util.Optional.empty());
+      java.util.Optional<? extends RecordTemplate> shadowValue = shadowResults.getOrDefault(key, java.util.Optional.empty());
+
+      RecordTemplate valueToUse = null;
+
+      if (localValue.isPresent() && shadowValue.isPresent()) {
+        if (!Objects.equals(localValue.get(), shadowValue.get())) {
+          log.warn("Aspect mismatch for URN {} and aspect {}: local = {}, shadow = {}",
+              key.getUrn(), key.getAspectClass().getSimpleName(),
+              localValue.get(), shadowValue.get());
+          valueToUse = localValue.get(); // fallback to local if there's mismatch
+        } else {
+          valueToUse = shadowValue.get(); // match → use shadow
+        }
+      } else if (shadowValue.isPresent()) {
+        valueToUse = shadowValue.get();
+      } else if (localValue.isPresent()) {
+        valueToUse = localValue.get();
+      }
+
+      if (valueToUse != null) {
+        urnAspectsMap.get(key.getUrn()).add(ModelUtils.newAspectUnion(
+            (Class<? extends ASPECT_UNION>) (isInternalModelsEnabled ? _internalAspectUnionClass : _aspectUnionClass),
+            valueToUse));
+      }
+    });
+
     return urnAspectsMap;
   }
+
 
   @Nonnull
   private SNAPSHOT newSnapshot(@Nonnull URN urn, @Nonnull List<UnionTemplate> aspects) {


### PR DESCRIPTION
## Summary
This pull request introduces enhancements to the `BaseEntityResource` class, focusing on enabling support for shadow DAO reads, improving data consistency checks, and adding logging for mismatches. The most significant changes include the addition of a shadow DAO getter, a new method for handling shadow DAO reads, and conditional logic to reconcile data between local and shadow DAOs.

### New Shadow DAO Support:

* **Added `getShadowReadLocalDAO` method**: Introduced a protected method to retrieve a shadow DAO instance, allowing resource classes to override it if needed. This method returns `null` by default. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.javaR178-R182](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R178-R182))

* **Introduced `getUrnAspectMapFromShadowDao` method**: Added a private method to fetch and reconcile aspect data from both local and shadow DAOs. It logs warnings for mismatches and prioritizes shadow DAO data when available and consistent. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.javaR1153-R1220](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R1153-R1220))

### Data Reconciliation Logic:

* **Updated `getUrnAspectMap` method**: Modified the existing method to conditionally use the shadow DAO for fetching aspect data if it is available. If mismatches are detected, warnings are logged, and the local DAO data is used as a fallback. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.javaR1153-R1220](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R1153-R1220))

### Logging Enhancements:

* **Added Lombok's `@Slf4j` annotation**: Enabled logging for the `BaseEntityResource` class to facilitate debugging and monitoring of aspect mismatches between local and shadow DAOs. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [[1]](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R51-R57) [[2]](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R78)

## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
