### PR TITLE
[feat] add with optimistic locking in BaseLocalDAO

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -76,6 +76,8 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import pegasus.com.linkedin.metadata.events.IngestionAspectETag;
+import pegasus.com.linkedin.metadata.events.IngestionAspectETagArray;
 
 import static com.linkedin.metadata.dao.utils.IngestionUtils.*;
 import static com.linkedin.metadata.dao.utils.ModelUtils.*;
@@ -484,7 +486,6 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     _emitAuditEvent = emitAuditEvent;
   }
 
-
   /**
    * Logic common to both {@link #add(Urn, Class, Function, AuditStamp)} and {@link #delete(Urn, Class, AuditStamp, int)} methods.
    *
@@ -549,15 +550,40 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       return new AddResult<>(oldValue, oldValue, aspectClass);
     }
 
+    final AuditStamp optimisticLockAuditStamp = extractOptimisticLockForAspectFromIngestionParamsIfPossible(ingestionParams, aspectClass);
+
     // Save the newValue as the latest version
     long largestVersion =
-        saveLatest(urn, aspectClass, oldValue, oldAuditStamp, newValue, auditStamp, latest.isSoftDeleted,
-            trackingContext, ingestionParams.isTestMode());
+        saveLatest(urn, aspectClass, oldValue,
+            optimisticLockAuditStamp != null ? optimisticLockAuditStamp : oldAuditStamp,
+            newValue, auditStamp, latest.isSoftDeleted, trackingContext, ingestionParams.isTestMode());
 
     // Apply retention policy
     applyRetention(urn, aspectClass, getRetention(aspectClass), largestVersion);
 
     return new AddResult<>(oldValue, newValue, aspectClass);
+  }
+
+  private static <ASPECT extends RecordTemplate> AuditStamp extractOptimisticLockForAspectFromIngestionParamsIfPossible(
+      @Nullable IngestionParams ingestionParams, @Nonnull Class<ASPECT> aspectClass) {
+    if (ingestionParams == null) {
+      return null;
+    }
+
+    AuditStamp optimisticLockAuditStamp = null;
+
+    final IngestionAspectETagArray ingestionAspectETags = ingestionParams.getIngestionETags();
+
+    if (ingestionAspectETags != null) {
+      for (IngestionAspectETag ingestionAspectETag: ingestionAspectETags) {
+        if (aspectClass.getSimpleName().equals(ingestionAspectETag.getAspect_name()) && ingestionAspectETag.getETag() != null) {
+          optimisticLockAuditStamp = new AuditStamp();
+          optimisticLockAuditStamp.setTime(ingestionAspectETag.getETag());
+          break;
+        }
+      }
+    }
+    return optimisticLockAuditStamp;
   }
 
   /**
@@ -1313,7 +1339,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param urn the URN for the entity the aspect is attached to
    * @param aspectClass the aspectClass of the aspect being saved
    * @param oldEntry {@link RecordTemplate} of the previous latest value of aspect, null if new value is the first version
-   * @param oldAuditStamp the audit stamp of the previous latest aspect, null if new value is the first version
+   * @param optimisticLockAuditStamp the audit stamp of the previous latest aspect, null if new value is the first version. Used for optimistic locking.
    * @param newEntry {@link RecordTemplate} of the new latest value of aspect
    * @param newAuditStamp the audit stamp for the operation
    * @param isSoftDeleted flag to indicate if the previous latest value of aspect was soft deleted
@@ -1321,7 +1347,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return the largest version
    */
   protected abstract <ASPECT extends RecordTemplate> long saveLatest(@Nonnull URN urn,
-      @Nonnull Class<ASPECT> aspectClass, @Nullable ASPECT oldEntry, @Nullable AuditStamp oldAuditStamp,
+      @Nonnull Class<ASPECT> aspectClass, @Nullable ASPECT oldEntry, @Nullable AuditStamp optimisticLockAuditStamp,
       @Nullable ASPECT newEntry, @Nonnull AuditStamp newAuditStamp, boolean isSoftDeleted,
       @Nullable IngestionTrackingContext trackingContext, boolean isTestMode);
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -564,7 +564,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     return new AddResult<>(oldValue, newValue, aspectClass);
   }
 
-  private static <ASPECT extends RecordTemplate> AuditStamp extractOptimisticLockForAspectFromIngestionParamsIfPossible(
+  @VisibleForTesting
+  protected  <ASPECT extends RecordTemplate> AuditStamp extractOptimisticLockForAspectFromIngestionParamsIfPossible(
       @Nullable IngestionParams ingestionParams, @Nonnull Class<ASPECT> aspectClass) {
     if (ingestionParams == null) {
       return null;
@@ -576,7 +577,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     if (ingestionAspectETags != null) {
       for (IngestionAspectETag ingestionAspectETag: ingestionAspectETags) {
-        if (aspectClass.getSimpleName().equals(ingestionAspectETag.getAspect_name()) && ingestionAspectETag.getETag() != null) {
+        if (aspectClass.getSimpleName().equalsIgnoreCase(ingestionAspectETag.getAspect_name())
+            && ingestionAspectETag.getETag() != null) {
           optimisticLockAuditStamp = new AuditStamp();
           optimisticLockAuditStamp.setTime(ingestionAspectETag.getETag());
           break;

--- a/dao-api/src/main/pegasus/pegasus/com/linkedin/metadata/events/IngestionAspectETag.pdl
+++ b/dao-api/src/main/pegasus/pegasus/com/linkedin/metadata/events/IngestionAspectETag.pdl
@@ -6,7 +6,7 @@ namespace pegasus.com.linkedin.metadata.events
 record IngestionAspectETag {
 
   /**
-   * aspect FQCN
+   * aspect field name, e.g. "status"
    */
   aspect_name: optional string = ""
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -818,4 +818,25 @@ public class BaseLocalDAOTest {
 
     assertEquals(result.getTime(), Long.valueOf(1234L));
   }
+
+  @Test
+  public void testExtractOptimisticLockForAspectFromIngestionParamsIfPossibleIngestionParamsIsNull() {
+    AuditStamp result = _dummyLocalDAO.extractOptimisticLockForAspectFromIngestionParamsIfPossible(null, AspectFoo.class);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testExtractOptimisticLockForAspectFromIngestionParamsIfPossibleAspectNameDoesntMatch() {
+    IngestionAspectETag ingestionAspectETag = new IngestionAspectETag();
+    ingestionAspectETag.setAspect_name("aspectBar");
+    ingestionAspectETag.setETag(1234L);
+
+    IngestionParams ingestionParams = new IngestionParams();
+    ingestionParams.setIngestionETags(new IngestionAspectETagArray(ingestionAspectETag));
+
+    AuditStamp result = _dummyLocalDAO.extractOptimisticLockForAspectFromIngestionParamsIfPossible(ingestionParams, AspectFoo.class);
+
+    assertNull(result);
+  }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -52,6 +52,8 @@ import org.mockito.stubbing.OngoingStubbing;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import pegasus.com.linkedin.metadata.events.IngestionAspectETag;
+import pegasus.com.linkedin.metadata.events.IngestionAspectETagArray;
 
 import static com.linkedin.common.AuditStamps.*;
 import static org.mockito.Mockito.*;
@@ -801,5 +803,19 @@ public class BaseLocalDAOTest {
 
     // Verify that the result is the same as the input aspect since it's not registered
     assertEquals(result.getUpdatedAspect(), foo);
+  }
+
+  @Test
+  public void testExtractOptimisticLockForAspectFromIngestionParamsIfPossible() {
+    IngestionAspectETag ingestionAspectETag = new IngestionAspectETag();
+    ingestionAspectETag.setAspect_name("aspectFoo");
+    ingestionAspectETag.setETag(1234L);
+
+    IngestionParams ingestionParams = new IngestionParams();
+    ingestionParams.setIngestionETags(new IngestionAspectETagArray(ingestionAspectETag));
+
+    AuditStamp result = _dummyLocalDAO.extractOptimisticLockForAspectFromIngestionParamsIfPossible(ingestionParams, AspectFoo.class);
+
+    assertEquals(result.getTime(), Long.valueOf(1234L));
   }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -87,7 +87,7 @@ public class BaseLocalDAOTest {
 
     @Override
     protected <ASPECT extends RecordTemplate> long saveLatest(FooUrn urn, Class<ASPECT> aspectClass, ASPECT oldEntry,
-        AuditStamp oldAuditStamp, ASPECT newEntry, AuditStamp newAuditStamp, boolean isSoftDeleted,
+        AuditStamp optimisticLockAuditStamp, ASPECT newEntry, AuditStamp newAuditStamp, boolean isSoftDeleted,
         @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
       return 0;
     }


### PR DESCRIPTION
## Summary
IngestionParams now can contain a list of IngestionETags (aspect name -> timestamp). If this is provided by user, we will use the provided timestamp for optimistic locking for given aspect.

The optimistic locking mechanism was already in place. Before it was locking only during the ingestion, now since we have given the eTags, the locking period can be extended for user to have read-modify-write consistency.

## Testing Done
./graldew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
