### PR TITLE
[feat] Updating methods for get() and batchGet() APIs to filter by deleted_ts

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -118,7 +118,7 @@ public class SQLStatementUtils {
 
   private static final String SQL_GET_ALL_COLUMNS =
       "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = database() AND TABLE_NAME = '%s'";
-      
+
   private static final String SQL_URN_EXIST_TEMPLATE = "SELECT urn FROM %s WHERE urn = '%s' AND deleted_ts IS NULL";
 
   private static final String INSERT_LOCAL_RELATIONSHIP = "INSERT INTO %s (metadata, source, destination, source_type, "
@@ -209,6 +209,8 @@ public class SQLStatementUtils {
     stringBuilder.append(String.format(sqlTemplate, columnName, tableName, columnName));
     stringBuilder.append(urnList);
     stringBuilder.append(RIGHT_PARENTHESIS);
+    stringBuilder.append(" AND ");
+    stringBuilder.append(DELETED_TS_IS_NULL_CHECK);
     return stringBuilder.toString();
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -102,14 +102,16 @@ public class SQLStatementUtilsTest {
         "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
             + "FROM metadata_entity_foo "
             + "WHERE JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL "
-            + "AND urn IN ('urn:li:foo:1', 'urn:li:foo:2')";
+            + "AND urn IN ('urn:li:foo:1', 'urn:li:foo:2') "
+            + "AND deleted_ts IS NULL";
     assertEquals(SQLStatementUtils.createAspectReadSql(AspectFoo.class, set, false, false), expectedSql);
 
     //test when includedSoftDeleted is true
     expectedSql =
         "SELECT urn, a_aspectfoo, lastmodifiedon, lastmodifiedby "
             + "FROM metadata_entity_foo "
-            + "WHERE urn IN ('urn:li:foo:1', 'urn:li:foo:2')";
+            + "WHERE urn IN ('urn:li:foo:1', 'urn:li:foo:2') "
+            + "AND deleted_ts IS NULL";
     assertEquals(SQLStatementUtils.createAspectReadSql(AspectFoo.class, set, true, false), expectedSql);
   }
 


### PR DESCRIPTION
## Summary

This is PR#1 in a series of PRs which will contain code changes to support usage of deleted_ts column in DAO methods for read and write.

What?

* Updating the DAO queries for get and batchGet APIs to filter return rows only where `deleted_ts IS NULL`
* Updating unit tests to have an additional check on `deleted_ts`

Why?
* The DB table may contain "deleted" rows till the purge job runs. 
* Get and BatchGet APIs should not return results based on rows which are marked for deletion, i.e. records with `deleted_ts=<some_value>` should be excluded.

How?
* Updated the queries for get and batchGet to ALWAYS have the check `WHERE deleted_ts IS NULL` so that records marked for deletion are not shown in response of these api's.

Ref: [RFC: Delete Asset - Soft Delete in EGG](https://docs.google.com/document/d/1hamWjkvKTdzARVWYmxVBSmIsv2CrVjkUr9Zyxm22mec/edit?usp=sharing)

## Testing Done
- Local testing
- Fixed unit tests

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
