### PR TITLE
Add dual read to BaseVersionedAspectResource

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -123,7 +123,6 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
         log.warn("Aspect mismatch for URN {}, version {}: local = {}, shadow = {}", urn, version, local, shadow);
         return local; // fallback to primary
       } else {
-        log.info("Aspect match for URN {}, version {}", urn, version);
         return shadow;
       }
     } else if (shadowOpt.isPresent()) {
@@ -166,7 +165,6 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
       return new CollectionResult<>(localValues, localResult.getMetadata()); // Fallback to local
     }
 
-    log.info("Match in getAllWithMetadata for URN {}", urn);
     return new CollectionResult<>(shadowValues, shadowResult.getMetadata());
   }
 

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -23,9 +23,12 @@ import com.linkedin.restli.server.annotations.RestMethod;
 import com.linkedin.restli.server.annotations.ReturnEntity;
 import com.linkedin.restli.server.resources.CollectionResourceTaskTemplate;
 import java.time.Clock;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 
 import static com.linkedin.metadata.dao.BaseReadDAO.*;
 
@@ -39,6 +42,7 @@ import static com.linkedin.metadata.dao.BaseReadDAO.*;
  * @param <ASPECT_UNION> must be a valid union of aspect models defined in com.linkedin.metadata.aspect
  * @param <ASPECT> must be a valid aspect type inside ASPECT_UNION
  */
+@Slf4j
 public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION extends UnionTemplate, ASPECT extends RecordTemplate>
     extends CollectionResourceTaskTemplate<Long, ASPECT> {
 
@@ -79,6 +83,13 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
   }
 
   /**
+   * Returns {@link BaseLocalDAO} for read-shadowing the aspect.
+   */
+  protected BaseLocalDAO<ASPECT_UNION, URN> getLocalReadShadowDAO() {
+    return null;
+  }
+
+  /**
    * Constructs an entity-specific {@link Urn} based on the entity's {@link PathKeys}.
    */
   @Nonnull
@@ -90,9 +101,39 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
   public Task<ASPECT> get(@Nonnull Long version) {
     return RestliUtils.toTask(() -> {
       final URN urn = getUrn(getContext().getPathKeys());
-      return getLocalDAO().get(new AspectKey<>(_aspectClass, urn, version))
-          .orElseThrow(RestliUtils::resourceNotFoundException);
+      if (getLocalReadShadowDAO() == null) {
+        return getLocalDAO().get(new AspectKey<>(_aspectClass, urn, version))
+            .orElseThrow(RestliUtils::resourceNotFoundException);
+      }
+      return getAspectFromReadShadowDAO(urn, version);
     });
+  }
+
+  private ASPECT getAspectFromReadShadowDAO(URN urn, Long version) {
+    AspectKey<URN, ASPECT> key = new AspectKey<>(_aspectClass, urn, version);
+
+    Optional<ASPECT> localOpt = getLocalDAO().get(key);
+    Optional<ASPECT> shadowOpt = getLocalReadShadowDAO().get(key);
+
+    if (localOpt.isPresent() && shadowOpt.isPresent()) {
+      ASPECT local = localOpt.get();
+      ASPECT shadow = shadowOpt.get();
+
+      if (!Objects.equals(local, shadow)) {
+        log.warn("Aspect mismatch for URN {}, version {}: local = {}, shadow = {}", urn, version, local, shadow);
+        return local; // fallback to primary
+      } else {
+        log.info("Aspect match for URN {}, version {}", urn, version);
+        return shadow;
+      }
+    } else if (shadowOpt.isPresent()) {
+      log.warn("Only shadow has value for URN {}, version {}", urn, version);
+      return shadowOpt.get();
+    } else if (localOpt.isPresent()) {
+      log.info("Only local has value for URN {}, version {}", urn, version);
+      return localOpt.get();
+    }
+    throw RestliUtils.resourceNotFoundException();
   }
 
   @RestMethod.GetAll
@@ -101,11 +142,32 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
       @PagingContextParam @Nonnull PagingContext pagingContext) {
     return RestliUtils.toTask(() -> {
       final URN urn = getUrn(getContext().getPathKeys());
-
-      final ListResult<ASPECT> listResult =
-          getLocalDAO().list(_aspectClass, urn, pagingContext.getStart(), pagingContext.getCount());
-      return new CollectionResult<>(listResult.getValues(), listResult.getMetadata());
+      if (getLocalReadShadowDAO() == null) {
+        final ListResult<ASPECT> listResult =
+            getLocalDAO().list(_aspectClass, urn, pagingContext.getStart(), pagingContext.getCount());
+        return new CollectionResult<>(listResult.getValues(), listResult.getMetadata());
+      }
+      return getAllWithMetadataFromReadShadowDAO(urn, pagingContext);
     });
+  }
+
+  private CollectionResult<ASPECT, ListResultMetadata> getAllWithMetadataFromReadShadowDAO(URN urn, PagingContext pagingContext) {
+    ListResult<ASPECT> localResult =
+        getLocalDAO().list(_aspectClass, urn, pagingContext.getStart(), pagingContext.getCount());
+
+    ListResult<ASPECT> shadowResult =
+        getLocalReadShadowDAO().list(_aspectClass, urn, pagingContext.getStart(), pagingContext.getCount());
+
+    List<ASPECT> localValues = localResult.getValues();
+    List<ASPECT> shadowValues = shadowResult.getValues();
+
+    if (!Objects.equals(localValues, shadowValues)) {
+      log.warn("Mismatch in getAllWithMetadata for URN {}: local = {}, shadow = {}", urn, localValues, shadowValues);
+      return new CollectionResult<>(localValues, localResult.getMetadata()); // Fallback to local
+    }
+
+    log.info("Match in getAllWithMetadata for URN {}", urn);
+    return new CollectionResult<>(shadowValues, shadowResult.getMetadata());
   }
 
   @RestMethod.Create


### PR DESCRIPTION
## Summary
This pull request introduces enhancements to the `BaseVersionedAspectResource` class, focusing on integrating shadow DAO functionality for read operations. The changes aim to improve data consistency checks and logging while maintaining fallback mechanisms. Below is a summary of the most significant changes grouped by theme.

### Shadow DAO Integration:

* Added a new method, `getLocalReadShadowDAO`, to retrieve the shadow DAO for read operations. This method returns `null` by default, allowing subclasses to override it as needed.
* Modified the `get` method to use the shadow DAO for retrieving aspects when available. If both local and shadow DAOs return values, the method compares them and logs any mismatches, falling back to the local DAO in case of discrepancies.
* Introduced the private helper method `getAspectFromReadShadowDAO` to handle aspect retrieval from both DAOs, including mismatch logging and fallback logic.

### Enhancements to `getAllWithMetadata`:

* Updated the `getAllWithMetadata` method to incorporate shadow DAO functionality. If both DAOs return results, the method compares them, logs mismatches, and defaults to local DAO data in case of discrepancies.
* Added the helper method `getAllWithMetadataFromReadShadowDAO` to encapsulate the logic for comparing results from local and shadow DAOs, including detailed logging.

### Logging Improvements:

* Annotated the class with `@Slf4j` to enable logging.
* Added detailed log statements to capture mismatches and matches between local and shadow DAO data in both `get` and `getAllWithMetadata` methods.

These changes enhance the robustness of the `BaseVersionedAspectResource` class by introducing shadow DAO support for read operations, improving logging for debugging, and ensuring fallback mechanisms are in place for data consistency.
## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
