### PR TITLE
Added a method to backfill shadow relationship tables

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -776,7 +776,7 @@ public abstract class BaseEntityResource<
   }
 
   /**
-   * Backfill the shadow relationship tables from entity table.
+   * Backfill the shadow relationship tables from entity table. It's a temporary solution for EGG migration.
    * @param urns
    * @param aspectNames
    * @param isInternalModelsEnabled


### PR DESCRIPTION
## Summary

This pull request introduces functionality to handle shadow relationship table backfills in the `BaseEntityResource` class. The most significant changes include adding a new method to perform the backfill and updating the existing backfill logic to delegate to this new method if a shadow DAO is available.

### Enhancements to Backfill Logic:

* **Delegation to Shadow DAO**: Updated the `backfillRelationshipTables` method to check for the presence of a shadow DAO (`getShadowLocalDAO`). If available, the method delegates the backfill operation to the newly introduced `backfillShadowRelationshipTables` method.

* **New Backfill Method**: Added the `backfillShadowRelationshipTables` method to handle the backfilling of shadow relationship tables. This method iterates over the provided URNs and aspects, retrieves relationship updates using the shadow DAO, and constructs a `BackfillResult` object. It uses reflection to extract relationship details (source, destination, etc.) and handles errors with a `RuntimeException`

## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
