### PR TITLE
Updating method for create(), update() and delete() to handle soft delete by setting deleted_ts

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1338,12 +1338,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nullable IngestionTrackingContext trackingContext, boolean isTestMode);
 
   /**
-   * Permanently deletes the entity from the table.
+   * Mark the asset as deleted.
    *
    * @param urn        the URN for the entity the aspect is attached to
    * @param isTestMode whether the test mode is enabled or not
-   * @return a map of the deleted aspects (their value before deletion), each wrapped in an instance of
-   * {@link ASPECT_UNION}
+   * @return the number of rows updated in delete operation.
    */
   protected abstract int permanentDelete(@Nonnull URN urn, boolean isTestMode);
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -757,7 +757,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     boolean isTestModeFalseForAll = aspectCreateLambdas.stream().filter(aspectCreateLambda -> aspectCreateLambda.getIngestionParams().isTestMode()).collect(
           Collectors.toList()).isEmpty();
 
-    int numRows = createNewAspect(urn, aspectCreateLambdas, aspectValues, auditStamp, trackingContext, isTestModeFalseForAll);
+    int numRows = createNewAssetWithAspects(urn, aspectCreateLambdas, aspectValues, auditStamp, trackingContext, isTestModeFalseForAll);
     for (RecordTemplate aspectValue : aspectValues) {
       // For each aspect, we need to trigger emit MAE
       // In new asset creation, old value is null
@@ -979,54 +979,6 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     );
   }
 
-  /**
-   * The common method that can be used for both: deletion of aspects and entity.
-   *
-   * @param urn                 the URN for the entity the aspects are attached to
-   * @param aspectClasses       Aspect Classes of the aspects being deleted, must be supported aspect types in
-   *                            {@code ASPECT_UNION}
-   * @param auditStamp          the audit stamp of this action
-   * @param trackingContext     the tracking context for the operation
-   * @param ingestionParams     ingestion parameters
-   * @param deleteAll           if true, delete the entire asset, else mark aspects as deleted iteratively in a
-   *                            transaction
-   * @param maxTransactionRetry maximum number of transaction retries before throwing an exception
-   * @return a collection of the deleted aspects (their value before deletion), each wrapped in an instance of
-   * {@link ASPECT_UNION}
-   */
-  protected Collection<ASPECT_UNION> deleteCommon(@Nonnull URN urn,
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
-      @Nonnull AuditStamp auditStamp, int maxTransactionRetry,
-      @Nullable IngestionTrackingContext trackingContext,
-      @Nullable IngestionParams ingestionParams,
-      boolean deleteAll) {
-
-    // TODO: Handle pre-deletion callbacks if any
-
-    // If deleteAll is true, delete entire asset, else mark aspects as deleted iteratively in a transaction
-    if (deleteAll) {
-      Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>
-          results = permanentDelete(urn, aspectClasses, auditStamp, maxTransactionRetry, trackingContext, ingestionParams.isTestMode());
-      Collection<RecordTemplate> deletedAspects = new ArrayList<>();
-      results.forEach((key, value) -> {
-        // Check if aspect value present to avoid null pointer exception
-        if (value.isPresent()) {
-          DeleteResult deleteResult = new DeleteResult(value.get(), key);
-          deletedAspects.add(unwrapDeleteResult(urn, deleteResult, auditStamp, trackingContext, ChangeType.DELETE_ALL));
-        }
-      });
-
-      return deletedAspects.stream()
-          .filter(Objects::nonNull)
-          .map(x -> ModelUtils.newEntityUnion(_aspectUnionClass, x)).collect(Collectors.toList());
-    } else {
-      // TODO: delete aspects implementation can be moved here instead of in addCommon()
-      // Add common method should be used only for create and update
-      return Collections.emptyList();
-    }
-
-    //TODO: Handle post-ingestion callbacks if any
-  }
 
   /**
    * Delete asset and all its aspects atomically.
@@ -1093,9 +1045,37 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       int maxTransactionRetry,
       @Nullable IngestionTrackingContext trackingContext,
       @Nullable IngestionParams ingestionParams) {
+
     IngestionParams nonNullIngestionParams = ingestionParams == null
         ? new IngestionParams().setIngestionMode(IngestionMode.LIVE).setTestMode(false) : ingestionParams;
-    return deleteCommon(urn, aspectClasses, auditStamp, maxTransactionRetry, trackingContext, nonNullIngestionParams, true);
+
+    final Map<Class<?>, RecordTemplate> results = new HashMap<>();
+    runInTransactionWithRetry(() -> {
+      Map<Class<?>, RecordTemplate> deletedAspects = new HashMap<>();
+        aspectClasses.forEach(aspectClass -> {
+          try {
+            RecordTemplate deletedAspect = delete(urn, aspectClass, auditStamp, maxTransactionRetry, trackingContext);
+            results.put(aspectClass, deletedAspect);
+          } catch (NullPointerException e) {
+            log.warn("Aspect {} for urn {} does not exist", aspectClass.getName(), urn);
+          }
+        });
+
+      permanentDelete(urn, nonNullIngestionParams.isTestMode());
+      return results;
+      }, maxTransactionRetry);
+
+
+    Collection<RecordTemplate> deletedAspects = new ArrayList<>();
+    results.forEach((key, value) -> {
+      // Check if aspect value present to avoid null pointer exception
+      DeleteResult deleteResult = new DeleteResult(value, key);
+      deletedAspects.add(unwrapDeleteResult(urn, deleteResult, auditStamp, trackingContext, ChangeType.DELETE_ALL));
+    });
+
+    return deletedAspects.stream()
+        .filter(Objects::nonNull)
+        .map(x -> ModelUtils.newEntityUnion(_aspectUnionClass, x)).collect(Collectors.toList());
   }
 
   /**
@@ -1353,24 +1333,20 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nullable ASPECT newEntry, @Nonnull AuditStamp newAuditStamp, boolean isSoftDeleted,
       @Nullable IngestionTrackingContext trackingContext, boolean isTestMode);
 
-  protected abstract <ASPECT_UNION extends RecordTemplate> int createNewAspect(@NonNull URN urn,
+  protected abstract <ASPECT_UNION extends RecordTemplate> int createNewAssetWithAspects(@NonNull URN urn,
       @Nonnull List<AspectCreateLambda<? extends RecordTemplate>> aspectCreateLambdas,
       @Nonnull List<? extends RecordTemplate> aspectValues, @Nonnull AuditStamp newAuditStamp,
       @Nullable IngestionTrackingContext trackingContext, boolean isTestMode);
 
   /**
    * Permanently deletes the entity from the table.
-   * @param urn the URN for the entity the aspect is attached to
-   * @param aspectClasses Aspect Classes of the aspects being deleted, must be supported aspect types in {@code ASPECT_UNION}
-   * @param auditStamp the audit stamp of this action
-   * @param maxTransactionRetry maximum number of transaction retries before throwing an exception
-   * @param trackingContext the tracking context for the operation
+   *
+   * @param urn        the URN for the entity the aspect is attached to
    * @param isTestMode whether the test mode is enabled or not
-   * @return a map of the deleted aspects (their value before deletion), each wrapped in an instance of {@link ASPECT_UNION}
+   * @return a map of the deleted aspects (their value before deletion), each wrapped in an instance of
+   * {@link ASPECT_UNION}
    */
-  protected abstract Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> permanentDelete(@Nonnull URN urn,
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nullable AuditStamp auditStamp,
-      int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext, boolean isTestMode);
+  protected abstract int permanentDelete(@Nonnull URN urn, boolean isTestMode);
 
   /**
    * Saves the new value of an aspect to entity tables. This is used when backfilling metadata from the old schema to
@@ -1585,13 +1561,13 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * Update an aspect for an entity with specific version and {@link AuditStamp} with optimistic locking.
    *
-   * @param urn {@link Urn} for the entity
-   * @param value the aspect to update
-   * @param aspectClass the type of aspect to update
+   * @param urn           {@link Urn} for the entity
+   * @param value         the aspect to update
+   * @param aspectClass   the type of aspect to update
    * @param newAuditStamp the {@link AuditStamp} for the new aspect
-   * @param version the version for the aspect
-   * @param oldTimestamp the timestamp for the old aspect
-   * @param isTestMode whether the test mode is enabled or not
+   * @param version       the version for the aspect
+   * @param oldTimestamp  the timestamp for the old aspect
+   * @param isTestMode    whether the test mode is enabled or not
    */
   protected abstract <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull URN urn,
       @Nullable RecordTemplate value, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp newAuditStamp,

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1051,7 +1051,6 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     final Map<Class<?>, RecordTemplate> results = new HashMap<>();
     runInTransactionWithRetry(() -> {
-      Map<Class<?>, RecordTemplate> deletedAspects = new HashMap<>();
         aspectClasses.forEach(aspectClass -> {
           try {
             RecordTemplate deletedAspect = delete(urn, aspectClass, auditStamp, maxTransactionRetry, trackingContext);

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -16,7 +16,6 @@ import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
-import com.linkedin.metadata.events.ChangeType;
 import com.linkedin.metadata.events.IngestionMode;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import com.linkedin.metadata.internal.IngestionParams;
@@ -35,10 +34,8 @@ import java.net.URISyntaxException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -95,7 +92,7 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected <ASPECT_UNION extends RecordTemplate> int createNewAspect(@Nonnull FooUrn urn,
+    protected <ASPECT_UNION extends RecordTemplate> int createNewAssetWithAspects(@Nonnull FooUrn urn,
         @Nonnull List<AspectCreateLambda<? extends RecordTemplate>> aspectCreateLambdas,
         @Nonnull List<? extends RecordTemplate> aspectValues, @Nonnull AuditStamp newAuditStamp,
         @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
@@ -103,13 +100,9 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> permanentDelete(@Nonnull FooUrn urn,
-        @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nullable AuditStamp auditStamp,
-        int maxTransactionRetry, @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
-      Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> result = new HashMap<>();
-      result.put(AspectFoo.class, Optional.of(new AspectFoo().setValue("foo")));
-      result.put(AspectBar.class, Optional.of(new AspectBar().setValue("bar")));
-      return result;
+    protected int permanentDelete(@Nonnull FooUrn urn, boolean isTestMode) {
+      // 1 aspect is deleted: 1 row in table
+      return 1;
     }
 
     @Override
@@ -738,30 +731,6 @@ public class BaseLocalDAOTest {
         .produceAspectSpecificMetadataAuditEvent(urn, null, bar, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
     verify(_mockEventProducer, times(1))
         .produceAspectSpecificMetadataAuditEvent(urn, null, bar, AspectBar.class, _dummyAuditStamp, IngestionMode.LIVE);
-    verifyNoMoreInteractions(_mockEventProducer);
-  }
-
-  @Test
-  public void testDeleteAll() throws URISyntaxException {
-    // Set-up test data
-    FooUrn urn = new FooUrn(1);
-    RecordTemplate foo = new AspectFoo().setValue("foo");
-    RecordTemplate bar = new AspectBar().setValue("bar");
-
-    Set<Class<? extends RecordTemplate>> aspectsClasses = new HashSet<>();
-    aspectsClasses.add(AspectFoo.class);
-    aspectsClasses.add(AspectBar.class);
-
-    Collection<EntityAspectUnion> results = _dummyLocalDAO.deleteAll(urn, aspectsClasses, _dummyAuditStamp);
-    assertEquals(results.size(), 2);
-    results.forEach(result -> {
-      assertNotNull(result);
-      assertTrue(result.isAspectBar() || result.isAspectFoo());
-    });
-    verify(_mockEventProducer, times(1))
-        .produceAspectSpecificMetadataAuditEvent(urn, foo, null, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE, ChangeType.DELETE_ALL);
-    verify(_mockEventProducer, times(1))
-        .produceAspectSpecificMetadataAuditEvent(urn, bar, null, AspectBar.class, _dummyAuditStamp, IngestionMode.LIVE, ChangeType.DELETE_ALL);
     verifyNoMoreInteractions(_mockEventProducer);
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -661,7 +661,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       @Nonnull List<? extends RecordTemplate> aspectValues, @Nonnull AuditStamp newAuditStamp,
       @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
     return runInTransactionWithRetry(() ->
-        // do a get to ensure the urn does not already exist
+        // behavior of create: do a get to ensure the urn does not already exist
         // if exists and deletedTs is null, then throw an exception
         // if exists and deletedTs is not null, then update the deletedTs to null and create records
         _localAccess.create(urn, aspectValues, aspectCreateLambdas, newAuditStamp, trackingContext, isTestMode), 1);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -47,11 +47,12 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param oldTimestamp             old time stamp for optimistic lock checking
    * @param ingestionTrackingContext the ingestionTrackingContext of the MCE responsible for calling this update
    * @param isTestMode               whether the test mode is enabled or not
+   * @param softDeleteOverwrite      whether to overwrite soft deleted aspects marked with $gma_deleted
    * @return number of rows inserted or updated
    */
   <ASPECT extends RecordTemplate> int addWithOptimisticLocking(@Nonnull URN urn, @Nullable ASPECT newValue,
       @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp, @Nullable Timestamp oldTimestamp,
-      @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode);
+      @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode, boolean softDeleteOverwrite);
 
   /**
    * Create aspect from entity table.
@@ -87,11 +88,12 @@ public interface IEbeanLocalAccess<URN extends Urn> {
 
   /**
    * Delete all aspects + urn for the given urn.
-   * @param urn {@link Urn} for the entity
+   *
+   * @param urn        {@link Urn} for the entity
    * @param isTestMode whether the operation is in test mode or not
    * @return number of rows deleted
    */
-  int deleteAll(@Nonnull URN urn, boolean isTestMode);
+  int softDeleteAsset(@Nonnull URN urn, boolean isTestMode);
 
   /**
    * Returns list of urns that satisfy the given filter conditions.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -47,7 +47,9 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param oldTimestamp             old time stamp for optimistic lock checking
    * @param ingestionTrackingContext the ingestionTrackingContext of the MCE responsible for calling this update
    * @param isTestMode               whether the test mode is enabled or not
-   * @param softDeleteOverwrite      whether to overwrite soft deleted aspects marked with $gma_deleted
+   * @param softDeleteOverwrite      whether to overwrite soft deleted aspects marked with $gma_deleted.
+   *                                 Will always be false for old schema code path since those tables do not contain
+   *                                 deleted_ts column.
    * @return number of rows inserted or updated
    */
   <ASPECT extends RecordTemplate> int addWithOptimisticLocking(@Nonnull URN urn, @Nullable ASPECT newValue,
@@ -87,7 +89,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
       int keysCount, int position, boolean includeSoftDeleted, boolean isTestMode);
 
   /**
-   * Delete all aspects + urn for the given urn.
+   * Soft delete all aspects + urn for the given urn by setting deleted_ts=NOW().
    *
    * @param urn        {@link Urn} for the entity
    * @param isTestMode whether the operation is in test mode or not

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -83,7 +83,7 @@ public class SQLStatementUtils {
   // deleted_ts check on create Statement SQL. This is used to set the deleted_ts to a non-null value
   // If a record that is NOT marked for deletion is attempted to be created again, an exception will be thrown
   public static final String DELETED_TS_DUPLICATE_KEY_CHECK = "ON DUPLICATE KEY UPDATE ";
-  public static final String DELETED_TS_CONDITIONAL_VALUE_SET = ", deleted_ts = IF(deleted_ts IS NULL, CAST('DuplicateKeyException' AS UNSIGNED), NULL);";
+  public static final String DELETED_TS_SET_VALUE_CONDITIONALLY = ", deleted_ts = IF(deleted_ts IS NULL, CAST('DuplicateKeyException' AS UNSIGNED), NULL);";
   // "JSON_EXTRACT(%s, '$.gma_deleted') IS NOT NULL" is used to exclude soft-deleted entity which has no lastmodifiedon.
   // for details, see the known limitations on https://github.com/linkedin/datahub-gma/pull/311. Same reason for
   // SQL_UPDATE_ASPECT_WITH_URN_TEMPLATE

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -22,7 +22,6 @@ import com.linkedin.testing.AspectBaz;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
-import io.ebean.DuplicateKeyException;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.SqlRow;
@@ -358,8 +357,6 @@ public class EbeanLocalAccessTest {
   }
 
 
-
-
   @Test
   public void testEscapeSpecialCharInUrn() {
     AspectFoo aspectFoo = new AspectFoo().setValue("test");
@@ -476,7 +473,7 @@ public class EbeanLocalAccessTest {
   }
 
   @Test
-  public void testCreateDuplicateAspect() {
+  public void testCreateDuplicateAsset() {
     FooUrn fooUrn = makeFooUrn(102);
     AspectFoo aspectFoo = new AspectFoo().setValue("foo");
     AuditStamp auditStamp = makeAuditStamp("actor", _now);
@@ -487,8 +484,8 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessFoo.create(fooUrn, aspectValues, aspectCreateLambdas, auditStamp, null, false);
     try {
       _ebeanLocalAccessFoo.create(fooUrn, aspectValues, aspectCreateLambdas, auditStamp, null, false);
-    } catch (DuplicateKeyException duplicateKeyException) {
-      assert (duplicateKeyException.getMessage().contains("Duplicate entry"));
+    } catch (Exception duplicateKeyException) {
+      assert (duplicateKeyException.getMessage().contains("DuplicateKeyException"));
     }
   }
 
@@ -520,7 +517,7 @@ public class EbeanLocalAccessTest {
     aspectCreateLambdas.add(new BaseLocalDAO.AspectCreateLambda(aspectFoo));
     int createResult = _ebeanLocalAccessFoo.create(fooUrn, aspectValues, aspectCreateLambdas, auditStamp, null, false);
     assertEquals(createResult, 1);
-    int numRowsDeleted = _ebeanLocalAccessFoo.deleteAll(fooUrn, false);
+    int numRowsDeleted = _ebeanLocalAccessFoo.softDeleteAsset(fooUrn, false);
     assertEquals(numRowsDeleted, 1);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -513,11 +513,12 @@ public class EbeanLocalDAOTest {
       EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
       FooUrn urn = makeFooUrn(1000);
       RecordTemplate foo = new AspectFoo().setValue("foo_testing_create_after_soft_delete");
+      RecordTemplate bar = new AspectBar().setValue("bar_testing_create_after_soft_delete");
       IngestionParams ingestionParams = new IngestionParams().setTestMode(false);
       dao.setAlwaysEmitAuditEvent(false);
       dao.setAlwaysEmitAspectSpecificAuditEvent(false);
       // At this time, there was no previous record for this urn, so we can create the asset with aspect foo
-      FooUrn createdUrn = dao.create(urn, ImmutableList.of(foo), _dummyAuditStamp, null, ingestionParams);
+      FooUrn createdUrn = dao.create(urn, ImmutableList.of(foo, bar), _dummyAuditStamp, null, ingestionParams);
       assertEquals(createdUrn, urn);
 
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-create-all-with-non-dollar-virtual-column-names.sql
@@ -127,6 +127,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_foo (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts DATETIME(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_foo PRIMARY KEY (urn)
     );
 
@@ -136,6 +137,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts DATETIME(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
     );
 

--- a/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
+++ b/dao-impl/ebean-dao/src/test/resources/ebean-local-relationship-dao-create-all.sql
@@ -152,6 +152,7 @@ CREATE TABLE IF NOT EXISTS metadata_entity_bar (
     lastmodifiedon TIMESTAMP NOT NULL,
     lastmodifiedby VARCHAR(255) NOT NULL,
     createdfor VARCHAR(255),
+    deleted_ts DATETIME(6) DEFAULT NULL,
     CONSTRAINT pk_metadata_entity_bar PRIMARY KEY (urn)
 );
 


### PR DESCRIPTION
This is PR#3 in a series of PRs which will contain code changes to support usage of deleted_ts column in DAO methods for read and write paths.
Prev:
PR#1 - https://github.com/linkedin/datahub-gma/pull/539
PR#2 - https://github.com/linkedin/datahub-gma/pull/544

## Summary

1. Updated create implementation
    * Update the SQL for create to follow a pattern like so:
```
INSERT INTO metadata_entity_foo (urn, a_urn, lastmodifiedon, lastmodifiedby,a_aspectfoo) 
VALUES (:urn, :a_urn, :lastmodifiedon, :lastmodifiedby,:aspect0) 
ON DUPLICATE KEY UPDATE a_aspectfoo= :aspect0,  deleted_ts = IF(deleted_ts IS NULL, CAST('DuplicateKeyException' AS UNSIGNED), deleted_ts);
```

3. Updated update implementation
    * If this asset was previously marked for deletion and still not purged, updating the new aspect values and update delete_ts will be set to NULL. ref: [updated SQL](https://github.com/linkedin/datahub-gma/compare/master...kotkar-pallavi:datahub-gma:pkotkar/deletedTsInCreate?expand=1#diff-56020705a401d66f63fe0a2b1afd740f431e55a0ecc2a08fbb4c1ed65da3f559R68)
4. Updated delete implementation
    * Instead of doing a hard delete, [deleting all aspects](https://github.com/linkedin/datahub-gma/compare/master...kotkar-pallavi:datahub-gma:pkotkar/deletedTsInCreate?expand=1#diff-405225dbfafc2466d678987c2f9be431e45b5e04aff5d6d37be3c1118539655aR1053) and then [setting deleted_ts=NULL](https://github.com/linkedin/datahub-gma/compare/master...kotkar-pallavi:datahub-gma:pkotkar/deletedTsInCreate?expand=1#diff-405225dbfafc2466d678987c2f9be431e45b5e04aff5d6d37be3c1118539655aR1053) in same transaction


## Testing Done
- Added unit tests 
- Modified unit tests
- ./gradlew build

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
