### PR TITLE
[EGG Migration]: Bug fix for dual read

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -235,6 +235,9 @@ public abstract class BaseEntityResource<
     return RestliUtils.toTask(() -> {
       final URN urn = toUrn(id);
       if (!getLocalDAO().exists(urn)) {
+        if (getShadowReadLocalDAO() != null && getShadowReadLocalDAO().exists(urn)) {
+          log.warn("Entity {} exists in shadow DAO but not in local DAO. Ignoring shadow-only data.", urn);
+        }
         throw RestliUtils.resourceNotFoundException();
       }
       final VALUE value =

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -598,22 +598,18 @@ public abstract class BaseEntityResource<
 
   /**
    * Retrieves an asset by comparing aspect values from both the local and shadow DAOs.
-   * <p>
    * This method first checks for the existence of the entity in the local DAO. If it exists,
    * it fetches the specified aspects from both local and shadow sources. For each aspect:
-   * <ul>
-   *   <li>If both local and shadow values exist and match, the shadow value is used.</li>
-   *   <li>If both exist but differ, the local value is preferred and a warning is logged.</li>
-   *   <li>If only the local value exists, it is used.</li>
-   *   <li>If only the shadow value exists, it is skipped and a warning is logged.</li>
-   * </ul>
+   *   If both local and shadow values exist and match, the shadow value is used.
+   *   If both exist but differ, the local value is preferred and a warning is logged.
+   *   If only the local value exists, it is used.
+   *   If only the shadow value exists, it is skipped and a warning is logged.
    *
    * @param urn the URN of the entity
    * @param aspectNames the aspect names to retrieve; if null, all aspects are fetched
    * @return an asset assembled from the resolved aspects
    * @throws RestLiServiceException if the entity does not exist in the local DAO
    */
-
   private ASSET getAssetWithShadowComparison(@Nonnull URN urn, @Nullable String[] aspectNames) {
 
     if (!getLocalDAO().exists(urn)) {
@@ -648,8 +644,7 @@ public abstract class BaseEntityResource<
           log.warn("Aspect mismatch for URN {} and aspect {}: local = {}, shadow = {}", urn,
               key.getAspectClass().getSimpleName(), local.get(), shadow.get());
           valueToUse = local.get();  // Mismatch → prefer local
-        }
-        else {
+        } else {
           valueToUse = shadow.get(); // match → prefer shadow
         }
       } else if (shadow.isPresent()) {


### PR DESCRIPTION
This pull request enhances the handling of data discrepancies between the local DAO and the shadow DAO in the `BaseEntityResource` class. The most significant changes include adding logic to log warnings for shadow-only data, implementing a new method to compare and resolve aspect values between the two DAOs, and refining the logic for handling mismatched or missing aspect values.

### Improvements to data consistency handling:

* **Shadow DAO existence check and logging**: Added a check in the `get` method to log a warning if an entity exists in the shadow DAO but not in the local DAO, and to ignore shadow-only data. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.javaR238-R240](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R238-R240))

* **New method for aspect comparison**: Introduced the `getAssetWithShadowComparison` method to retrieve and resolve aspect values by comparing data from both the local and shadow DAOs. This includes detailed documentation explaining the resolution rules. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.javaR599-R616](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R599-R616))

### Refinements to aspect resolution logic:

* **Aspect key generation and data fetching**: Added logic to generate aspect keys and fetch results from both DAOs for comparison. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.javaR626-R637](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R626-R637))

* **Mismatch handling**: Updated logic to prefer local aspect values in case of mismatches, while logging warnings for such scenarios. (`restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java`, [restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.javaR650-R654](diffhunk://#diff-ef2014126659a7045b6b1d4c97c7ae54d5fa9d61142c8093ccce3aca8da7c9e3R650-R654))

These changes improve data integrity and provide greater transparency when resolving discrepancies between the local and shadow DAOs.## Summary
Logging entity not found in service-gms but in EGG db
## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
