### PR TITLE
[EGG Migration] NPE fix for dual read

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -590,7 +590,8 @@ public abstract class BaseAspectRoutingResource<
    * @param keys Aspect keys to be retrieved from shadow DAO
    * @return A list of internal aspects.
    */
-  private List<INTERNAL_ASPECT_UNION> getInternalAspectsWithShadowComparison(Set<AspectKey<URN, ? extends RecordTemplate>> keys, BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> shadowReadLocalDAO) {
+  private List<INTERNAL_ASPECT_UNION> getInternalAspectsWithShadowComparison(
+      Set<AspectKey<URN, ? extends RecordTemplate>> keys, BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> shadowReadLocalDAO) {
 
     Map<AspectKey<URN, ? extends RecordTemplate>, java.util.Optional<? extends RecordTemplate>> localResults =
         getLocalDAO().get(keys);

--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseAspectRoutingResource.java
@@ -119,8 +119,9 @@ public abstract class BaseAspectRoutingResource<
       // The assumption is main GMS must have this entity.
       // If entity only has routing aspect, resourceNotFoundException will be thrown.
       final URN urn = toUrn(id);
+      BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> shadowReadLocalDAO = getShadowReadLocalDAO();
       if (!getLocalDAO().exists(urn)) {
-        if (getShadowReadLocalDAO() != null && getShadowReadLocalDAO().exists(urn)) {
+        if (shadowReadLocalDAO != null && shadowReadLocalDAO.exists(urn)) {
           // If the entity exists in shadow DAO, we can return an empty value.
           log.warn("Entity {} exists in shadow DAO but not in local DAO. Ignoring shadow-only data.", urn);
         }
@@ -571,7 +572,8 @@ public abstract class BaseAspectRoutingResource<
         .map(aspectClass -> new AspectKey<>(aspectClass, urn, LATEST_VERSION))
         .collect(Collectors.toSet());
 
-    if (getShadowReadLocalDAO() == null) {
+    BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> shadowReadLocalDAO = getShadowReadLocalDAO();
+    if (shadowReadLocalDAO == null) {
       return getLocalDAO().get(keys)
           .values()
           .stream()
@@ -579,7 +581,7 @@ public abstract class BaseAspectRoutingResource<
           .map(aspect -> ModelUtils.newAspectUnion(_internalAspectUnionClass, aspect.get()))
           .collect(Collectors.toList());
     }
-    return getInternalAspectsWithShadowComparison(keys);
+    return getInternalAspectsWithShadowComparison(keys, shadowReadLocalDAO);
   }
 
   /**
@@ -588,12 +590,12 @@ public abstract class BaseAspectRoutingResource<
    * @param keys Aspect keys to be retrieved from shadow DAO
    * @return A list of internal aspects.
    */
-  private List<INTERNAL_ASPECT_UNION> getInternalAspectsWithShadowComparison(Set<AspectKey<URN, ? extends RecordTemplate>> keys) {
+  private List<INTERNAL_ASPECT_UNION> getInternalAspectsWithShadowComparison(Set<AspectKey<URN, ? extends RecordTemplate>> keys, BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> shadowReadLocalDAO) {
 
     Map<AspectKey<URN, ? extends RecordTemplate>, java.util.Optional<? extends RecordTemplate>> localResults =
         getLocalDAO().get(keys);
     Map<AspectKey<URN, ? extends RecordTemplate>, java.util.Optional<? extends RecordTemplate>> shadowResults =
-        getShadowReadLocalDAO().get(keys);
+        shadowReadLocalDAO.get(keys);
 
     return keys.stream()
         .map(key -> {


### PR DESCRIPTION
## Summary

This PR addresses a bug where repeated calls to getShadowReadLocalDAO() within a single method invocation could yield inconsistent results due to dynamic evaluation of a LiX flag. This caused a NullPointerException when getShadowReadLocalDAO() returned null during an internal method call, despite being non-null earlier in the execution.

### Root cause
The logic in getInternalAspectsFromLocalDao(...) conditionally calls getInternalAspectsWithShadowComparison(...) based on whether getShadowReadLocalDAO() is null. However, getShadowReadLocalDAO() is backed by a LiX flag that may evaluate differently between calls. If the LiX value flips mid-execution, it results in the inner method dereferencing a null DAO.

### Fix
We now cache the result of getShadowReadLocalDAO() in a local variable at the beginning of getInternalAspectsFromLocalDao(...) and pass it explicitly to getInternalAspectsWithShadowComparison(...). This ensures consistent behavior within the scope of a single call and prevents unexpected null dereferencing.

### Why it matters
This change prevents a production-facing 500 Internal Server Error caused by an NPE and improves the reliability of aspect reads under dual-read mode with LiX gating.

## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
