### PR TITLE
fix(relationship): ignore 'pegasus.' prefix when comparing aspect FQCN

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -218,7 +218,15 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     SqlUpdate deletionSQL = _server.createSqlUpdate(SQLStatementUtils.deleteLocalRelationshipSQL(tableName, _useAspectColumnForRelationshipRemoval));
     deletionSQL.setParameter(CommonColumnName.SOURCE, source.toString());
     if (_useAspectColumnForRelationshipRemoval) {
-      deletionSQL.setParameter(CommonColumnName.ASPECT, aspectClass.getCanonicalName());
+      // treat "pegasus.com.linkedin..." and "com.linkedin..." as equivalent
+      String aspectClassFQCN = aspectClass.getCanonicalName();
+      String pegasusPrefix = "pegasus.";
+      // normalize the aspect FQCN first by removing any 'pegasus.' prefix
+      if (aspectClassFQCN.startsWith(pegasusPrefix)) {
+        aspectClassFQCN = aspectClassFQCN.substring(pegasusPrefix.length());
+      }
+      deletionSQL.setParameter(CommonColumnName.ASPECT, aspectClassFQCN); // WHERE aspect = "com.linkedin..."
+      deletionSQL.setParameter("pegasus_" + CommonColumnName.ASPECT, pegasusPrefix + aspectClassFQCN); // OR aspect = "pegasus.com.linkedin..."
     }
       batchCount = 0;
       while (batchCount < MAX_BATCHES) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -133,7 +133,7 @@ public class SQLStatementUtils {
       + "WHERE source = :source AND deleted_ts IS NULL";
 
   private static final String DELETE_BY_SOURCE_AND_ASPECT = "UPDATE %s SET deleted_ts=NOW() "
-      + "WHERE source = :source AND aspect = :aspect AND deleted_ts IS NULL";
+      + "WHERE source = :source AND (aspect = :aspect OR aspect = :pegasus_aspect) AND deleted_ts IS NULL";
 
   /**
    *  Filter query has pagination params in the existing APIs. To accommodate this, we use subquery to include total result counts in the query response.


### PR DESCRIPTION
## Summary
Some aspects are ingested as "pegasus.com.linkedin..." while some are ingested as "com.linkedin...". The relationship writer dao should treat these as equivalent for the purpose of removing relationships.
## Testing Done
Added a unit test
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
