### PR TITLE
fix(ingestion): reduce relationship insertion batch size from 1000 to 100

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipWriterDAO.java
@@ -43,7 +43,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
     private static final String LAST_MODIFIED_ON = "lastmodifiedon";
     private static final String LAST_MODIFIED_BY = "lastmodifiedby";
   }
-  private static final int INSERT_BATCH_SIZE = 1000;
+  private static final int INSERT_BATCH_SIZE = 100;
   private static final int DELETE_BATCH_SIZE = 10000; // Process deletes in batches of 10,000 rows
   private static final int MAX_BATCHES = 1000; // Maximum number of batches to process
   private static final String LIMIT = " LIMIT ";
@@ -185,7 +185,7 @@ public class EbeanLocalRelationshipWriterDAO extends BaseGraphWriterDAO {
 
     long now = Instant.now().toEpochMilli();
 
-    // Insert in batches with 1000 values per insert statement
+    // Insert in batches with 100 values per insert statement
     int numBatches = (relationshipGroup.size() + INSERT_BATCH_SIZE - 1) / INSERT_BATCH_SIZE;
     for (int i = 0; i < numBatches; i++) {
       int numRelationships = Math.min(INSERT_BATCH_SIZE, relationshipGroup.size() - i * INSERT_BATCH_SIZE);


### PR DESCRIPTION
## Summary
metagalaxy has a max_allowed_packet size of `419430400` bytes (400 MB).
job_gms_corp: 1073741824 (~1 GB)
mg_db_1_corp: 1073741824 (~1 GB)
ai_metadata_prod: 419430400 (~400 MB)

Now that relationship ingestions are grouped into insert statements containing batches of relationships, there is a risk of hitting the max which will result in a stack overflow error.

Here is the SQL statement template:
```
INSERT INTO tableName (metadata, source, destination, source_type, destination_type, lastmodifiedon, lastmodifiedby, {aspect}) VALUES
    (:metadata0, :source0, :destination0, :source_type0, :destination_type0, :lastmodifiedon, :lastmodifiedby, {:aspect}),
    (:metadata1, :source1, :destination1, :source_type1, :destination_type1, :lastmodifiedon, :lastmodifiedby, {:aspect}),
    ...
```

Size estimates in bytes (worst case):
tableName = 50
INSERT INTO ... statement without tableName = 150
TOTAL EXCLUDING ACTUAL VALUES = 200 (can ignore this constant overhead with respect to the size of the rest of the statement which grows with the num of relationships)

each line:
- metadata = ???
- source = 400
- destination = 400
- source_type = 100
- destination_type = 100
- lastmodifiedon = 8
- lastmodifiedby = 100
- aspect = 100
- TOTAL EXCLUDING metadata ~ 1200

metadata can vary. using the metadata_relationship_produces table from job_gms_corp as a reference, the longest metadata in that table is 1402 characters long ~1400 bytes.

```
select length(metadata), metadata from u_wherehow.metadata_relationship_produces order by length(metadata) desc limit 5;
```

Thus, each line in the (current) worst case is 2600 bytes or ~2.5MB. Even with 1 GB max_packet_size, there can only be ~400 lines i.e. 400 relationships added in a single statement. For the databases with 400 MB max_packet_size, it's even less at ~160 relationships per statement.


To resolve this and provide more protection against stack overflows, lower the insert batch size from 1000 to 100, which should be much safer.
## Testing Done
N/A
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
