### PR TITLE
feat(filter): add ARRAY_CONTAINS condition for filtering

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/Condition.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/Condition.pdl
@@ -49,4 +49,9 @@ enum Condition {
    * Represent the relation: String field starts with value, e.g. name starts with PageView
    */
   START_WITH
+
+  /**
+   * Represent the relation: array field contains string value, e.g. labels{["abc", "def"]} contains "abc"
+   */
+  ARRAY_CONTAINS
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -179,19 +179,6 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     public Object value;
   }
 
-  private static final Map<Condition, String> CONDITION_STRING_MAP =
-      Collections.unmodifiableMap(new HashMap<Condition, String>() {
-        {
-          put(Condition.EQUAL, "=");
-          put(Condition.GREATER_THAN, ">");
-          put(Condition.GREATER_THAN_OR_EQUAL_TO, ">=");
-          put(Condition.IN, "IN");
-          put(Condition.LESS_THAN, "<");
-          put(Condition.LESS_THAN_OR_EQUAL_TO, "<=");
-          put(Condition.START_WITH, "LIKE");
-        }
-      });
-
   /**
    * Constructor for EbeanLocalDAO.
    *

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -143,6 +143,8 @@ public class SQLIndexFilterUtils {
    */
   private static String parseSqlFilter(String indexColumn, Condition condition, IndexValue indexValue) {
     switch (condition) {
+      case ARRAY_CONTAINS:
+        return String.format("'%s' MEMBER OF(%s)", parseIndexValue(indexValue), indexColumn);
       case CONTAIN:
         return String.format("JSON_SEARCH(%s, 'one', '%s') IS NOT NULL", indexColumn, parseIndexValue(indexValue));
       case IN:
@@ -204,7 +206,7 @@ public class SQLIndexFilterUtils {
     final Condition condition = criterion.getPathParams().getCondition();
     final IndexValue indexValue = criterion.getPathParams().getValue();
 
-    if (condition == Condition.IN && (!indexValue.isArray() || indexValue.getArray().size() == 0)) {
+    if (condition == Condition.IN && (!indexValue.isArray() || indexValue.getArray().isEmpty())) {
       throw new IllegalArgumentException("Invalid condition " + condition + " for index value " + indexValue);
     }
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLIndexFilterUtils.java
@@ -11,6 +11,7 @@ import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.metadata.query.IndexValue;
 import com.linkedin.metadata.query.SortOrder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -143,6 +144,7 @@ public class SQLIndexFilterUtils {
    */
   private static String parseSqlFilter(String indexColumn, Condition condition, IndexValue indexValue) {
     switch (condition) {
+      // TODO: add validation to check that the index column value is an array type
       case ARRAY_CONTAINS:
         return String.format("'%s' MEMBER OF(%s)", parseIndexValue(indexValue), indexColumn);
       case CONTAIN:
@@ -207,7 +209,12 @@ public class SQLIndexFilterUtils {
     final IndexValue indexValue = criterion.getPathParams().getValue();
 
     if (condition == Condition.IN && (!indexValue.isArray() || indexValue.getArray().isEmpty())) {
-      throw new IllegalArgumentException("Invalid condition " + condition + " for index value " + indexValue);
+      throw new IllegalArgumentException("Invalid condition IN for index value " + indexValue);
+    }
+
+    if (condition == Condition.ARRAY_CONTAINS && indexValue.isArray()) {
+      throw new IllegalArgumentException(String.format("Array values are not allowed for the target of the condition ARRAY_CONTAINS."
+          + " Please split the array of elements into different criteria. Index value: %s", Arrays.toString(indexValue.getArray().toArray())));
     }
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -166,7 +166,7 @@ public class SQLStatementUtilsTest {
     assertEquals(sql2, expectedSql2);
   }
 
-  @Test
+
   public void testCreateFilterSqlWithArrayContainsCondition() {
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
@@ -183,7 +183,7 @@ public class SQLStatementUtilsTest {
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n"
         + "AND deleted_ts IS NULL)" + " as _total_count FROM metadata_entity_foo\n"
         + "WHERE a_aspectfoobar IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n"
-        + "AND bars1 MEMBER OF(i_aspectfoobar$bars)\n" + "AND deleted_ts IS NULL";
+        + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n" + "AND deleted_ts IS NULL";
 
     assertEquals(sql1, expectedSql1);
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -19,6 +19,7 @@ import com.linkedin.metadata.query.UrnField;
 import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.BarAsset;
+import com.linkedin.testing.localrelationship.AspectFooBar;
 import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.testing.urn.FooUrn;
 import java.net.URISyntaxException;
@@ -163,6 +164,28 @@ public class SQLStatementUtilsTest {
         + "AND i_aspectfoo0value < 50\n" + "AND deleted_ts IS NULL";
 
     assertEquals(sql2, expectedSql2);
+  }
+
+  @Test
+  public void testCreateFilterSqlWithArrayContainsCondition() {
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+
+    IndexCriterion indexCriterion1 =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFooBar.class, "bars", Condition.ARRAY_CONTAINS,
+            IndexValue.create("bar1"));
+
+    indexCriterionArray.add(indexCriterion1);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    String sql1 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false, mockValidator);
+    String expectedSql1 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n"
+        + "AND deleted_ts IS NULL)" + " as _total_count FROM metadata_entity_foo\n"
+        + "WHERE a_aspectfoobar IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n"
+        + "AND bars1 MEMBER OF(i_aspectfoobar$bars)\n" + "AND deleted_ts IS NULL";
+
+    assertEquals(sql1, expectedSql1);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Add ARRAY_CONTAINS condition to support the filtering case where you want to find if an aspect's array field contains the value you provide. This will be useful for labeling where the labels will be stored as an array of strings and the user is looking for all assets which have a particular label.

## Testing Done
Add unit test and check the generated sql statement.

Unfortunately this cannot be properly tested since MariaDB (used for local testing) does not support the MEMBER OF function. Similar behavior can be achieved with JSON_CONTAINS but it is also slower than MEMBER OF. Further testing will happen at the service integration layer instead of here in the DAO library.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
