### PR TITLE
Revert "Added a method to backfill shadow relationship tables"

### DIFF
--- a/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/restli-resources/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -818,17 +818,13 @@ public abstract class BaseEntityResource<
 
   private Task<BackfillResult> backfillRelationshipTables(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
       @ActionParam(PARAM_ASPECTS) @Nonnull String[] aspectNames, boolean isInternalModelsEnabled) {
-
-    // Use the shadow DAO if it exists, otherwise use the local DAO. It's a temporary solution for EGG migration.
-    BaseLocalDAO<INTERNAL_ASPECT_UNION, URN> dao = getShadowLocalDAO() != null ? getShadowLocalDAO() : getLocalDAO();
-
     final BackfillResult backfillResult = new BackfillResult()
         .setEntities(new BackfillResultEntityArray())
         .setRelationships(new BackfillResultRelationshipArray());
 
     for (String urn : urns) {
       for (Class<? extends RecordTemplate> aspect : parseAspectsParam(aspectNames, isInternalModelsEnabled)) {
-        dao.backfillLocalRelationships(parseUrnParam(urn), aspect).forEach(relationshipUpdates -> {
+        getLocalDAO().backfillLocalRelationships(parseUrnParam(urn), aspect).forEach(relationshipUpdates -> {
           relationshipUpdates.getRelationships().forEach(relationship -> {
             try {
               Urn source = (Urn) relationship.getClass().getMethod("getSource").invoke(relationship);


### PR DESCRIPTION
Reverts linkedin/datahub-gma#546

We ended by creating a separate service to perform the [backfill of relationship tables](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/369) from current database to new database. So, we don't need this change.

