### PR TITLE
[feat] support START_WITH condition in EbeanLocalRelationshipQueryDAO

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -89,6 +89,7 @@ public class EbeanLocalRelationshipQueryDAO {
           put(Condition.IN, "IN");
           put(Condition.LESS_THAN, "<");
           put(Condition.LESS_THAN_OR_EQUAL_TO, "<=");
+          put(Condition.START_WITH, "LIKE");
         }
       });
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -536,6 +536,8 @@ public class SQLStatementUtils {
         throw new IllegalArgumentException("IN condition must be paired with array value");
       }
       return field + " IN " + parseLocalRelationshipValue(value);
+    } else if (condition == Condition.START_WITH) {
+      return field + " LIKE '" + parseLocalRelationshipValue(value) + "%'";
     } else {
       return field + supportedConditions.get(condition) + "'" + parseLocalRelationshipValue(value) + "'";
     }
@@ -570,9 +572,16 @@ public class SQLStatementUtils {
     for (LocalRelationshipCriterion criterion : criteria) {
       String field = "rt." + whichNode;
       String condition = supportedConditions.get(criterion.getCondition());
-      String value = criterion.getCondition() == Condition.IN
-          ? parseLocalRelationshipValue(criterion.getValue())
-          : "'" + parseLocalRelationshipValue(criterion.getValue()) + "'";
+      String value;
+
+      if (criterion.getCondition() == Condition.IN) {
+        value = parseLocalRelationshipValue(criterion.getValue());
+      } else if (criterion.getCondition() == Condition.START_WITH) {
+        value = "'" + parseLocalRelationshipValue(criterion.getValue()) + "%'";
+      } else {
+        value = "'" + parseLocalRelationshipValue(criterion.getValue()) + "'";
+      }
+
       sb.append(String.format(" AND %s %s %s", field, condition, value));
     }
     return sb.toString();


### PR DESCRIPTION
## Summary
using MySQL 'LIKE' key word to fulfill 'START_WITH' condition.

## Testing Done
./gradlew build
unit tests

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
