### PR TITLE
(feat) Add support for Hikari Datasource

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ project.ext.externalDependency = [
     'flywayCore': 'org.flywaydb:flyway-core:7.15.0',
     'guava': 'com.google.guava:guava:32.0.0-jre',
     'h2': 'com.h2database:h2:1.4.196',
+    'hikariCP': 'com.zaxxer:HikariCP:5.0.1',
     'jacksonCore': 'com.fasterxml.jackson.core:jackson-core:2.17.2',
     'jacksonDataBind': 'com.fasterxml.jackson.core:jackson-databind:2.17.2',
     'javatuples': 'org.javatuples:javatuples:1.2',

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ project.ext.externalDependency = [
     'flywayCore': 'org.flywaydb:flyway-core:7.15.0',
     'guava': 'com.google.guava:guava:32.0.0-jre',
     'h2': 'com.h2database:h2:1.4.196',
-    'hikariCP': 'com.zaxxer:HikariCP:5.0.1',
+    'hikariCP': 'com.zaxxer:HikariCP:4.0.3',
     'jacksonCore': 'com.fasterxml.jackson.core:jackson-core:2.17.2',
     'jacksonDataBind': 'com.fasterxml.jackson.core:jackson-databind:2.17.2',
     'javatuples': 'org.javatuples:javatuples:1.2',

--- a/dao-impl/ebean-dao/build.gradle
+++ b/dao-impl/ebean-dao/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile externalDependency.guava
   compile externalDependency.jsonSimple
   compile externalDependency.log4j
+  compile externalDependency.hikariCP
 
   compileOnly externalDependency.ebeanAgent
   compileOnly externalDependency.lombok


### PR DESCRIPTION
## Summary
This pull request introduces support for the HikariCP connection pool in the Ebean DAO implementation. The most significant changes are the addition of the HikariCP dependency and logic to handle HikariCP data sources when creating the schema evolution manager configuration.

**Dependency management:**

* Added `externalDependency.hikariCP` to the `dao-impl/ebean-dao/build.gradle` dependencies to enable HikariCP support.

**Schema evolution manager initialization:**

* Updated `EbeanLocalAccess.java` to import `HikariDataSource` for type checking and extraction of connection details.
* Modified the `createSchemaEvolutionManager` method in `EbeanLocalAccess.java` to detect if the Ebean server is using a HikariCP data source and extract the JDBC URL, username, and password accordingly. Falls back to the existing logic if HikariCP is not used.

## Testing Done
./gradlew build
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
