### PR TITLE
Hot fix for META-22917

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -636,14 +636,14 @@ public class SQLStatementUtils {
    * @param localRelationshipValue the local relationship value
    * @return the parsed string
    */
-  private static String parseLocalRelationshipValue(@Nonnull final LocalRelationshipValue localRelationshipValue) {
+  protected static String parseLocalRelationshipValue(@Nonnull final LocalRelationshipValue localRelationshipValue) {
     if (localRelationshipValue.isArray()) {
       return  "(" + localRelationshipValue.getArray().stream().map(s -> "'" + StringEscapeUtils.escapeSql(s) + "'")
           .collect(Collectors.joining(", ")) + ")";
     }
 
     if (localRelationshipValue.isString()) {
-      return localRelationshipValue.getString();
+      return StringEscapeUtils.escapeSql(localRelationshipValue.getString());
     }
 
     throw new IllegalArgumentException("Unrecognized field value");


### PR DESCRIPTION
## Summary

A hot fix for destination URN edge case:

BUG=[META-22981](https://linkedin.atlassian.net/browse/META-22981)
BUG=[META-22917](https://linkedin.atlassian.net/browse/META-22917)

*Note: This is not the recommended parameterized query approach, which requires significant efforts and is planned to be implemented later, but a quick fix adding sql escaping for relationship to resolve the case mentioned in the ticket.

## Testing Done

Unit tests

`./gradlew build`

Test with actual GQS flow:

- Currently without fix:
```
[chmeng@zany-earth metadata-graph-query]$ grpcurli --dv-auth SELF localhost:24572 proto.com.linkedin.metadatagraphquery.FindRelationshipsApi.get -d '{"key": {"destinationAssetFilter": {"criteria": [{"target": "proto.com.linkedin.metadata.asset.DatasetAsset", "path": "urn", "condition": "Condition_EQUAL", "value": {"stringValue": "urn:li:dataset:(urn:li:dataPlatform:hdfs,/jobs/dsotnt/lix_evaluations/premium_custom_button_acq_convoad_trex_eval_results\u0027,PROD)"}}]}, "relationshipFilter": {"criteria": [{"target": "proto.com.linkedin.metadata.relationship.DownstreamOf"}]}}}'
Password for chmeng@linkedin.biz: 
Yubikey Short Press or Okta OTP: 
ERROR:
  Code: Unknown
  Message: Error: Failed to retrieve relationships. Request key:
destinationAssetFilter {
  criteria {
    target: "proto.com.linkedin.metadata.asset.DatasetAsset"
    path: "urn"
    condition: Condition_EQUAL
    value {
      stringValue: "urn:li:dataset:(urn:li:dataPlatform:hdfs,/jobs/dsotnt/lix_evaluations/premium_custom_button_acq_convoad_trex_eval_results\',PROD)"
    }
  }
}
relationshipFilter {
  criteria {
    target: "proto.com.linkedin.metadata.relationship.DownstreamOf"
  }
}
,

Error message:
RuntimeException: Failed to execute SQL query for relationships,

Root cause:
java.lang.RuntimeException: Failed to execute SQL query for relationships
        at com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO.executeSqlWithIndexCheck(EbeanLocalRelationshipQueryDAO.java:882)
        at com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO.findRelationshipsV2V3V4Core(EbeanLocalRelationshipQueryDAO.java:326)
        at com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO.findRelationshipsV4(EbeanLocalRelationshipQueryDAO.java:400)
        at com.linkedin.metadatagraphquery.impl.FindRelationshipsServiceUtils.getAssetRelationshipsFromDAO(FindRelationshipsServiceUtils.java:85)
        at com.linkedin.metadatagraphquery.impl.SingleHopGraphQueryImpl.getAssetRelationshipsFromEbeanLocalRelationshipQueryDAO(SingleHopGraphQueryImpl.java:309)
        at com.linkedin.metadatagraphquery.impl.SingleHopGraphQueryImpl.getAssetRelationships(SingleHopGraphQueryImpl.java:98)
        at com.linkedin.metadatagraphquery.protobuf.FindRelationshipsService.get(FindRelationshipsService.java:49)
        at proto.com.linkedin.metadatagraphquery.FindRelationshipsApiGrpc$MethodHandlers.invoke(FindRelationshipsApiGrpc.java:246)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at com.linkedin.grpc.interceptor.error.ExceptionHandlingServerCallListener.onHalfClose(ExceptionHandlingServerCallListener.java:26)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at com.linkedin.grpc.interceptor.trace.OpenTelemetryServerInterceptor$2.onHalfClose(OpenTelemetryServerInterceptor.java:206)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at com.linkedin.grpc.interceptor.ic.ServerICInterceptor$2.lambda$onHalfClose$1(ServerICInterceptor.java:138)
        at com.linkedin.grpc.interceptor.ic.ServerICInterceptor.lambda$runWithExecutionContext$1(ServerICInterceptor.java:192)
        at com.linkedin.grpc.interceptor.internal.InterceptorExecutionContextPropagator.lambda$call$0(InterceptorExecutionContextPropagator.java:52)
        at com.linkedin.container.servicecall.internal.ICFilterHelperImpl.lambda$runWithExecutionContext$1(ICFilterHelperImpl.java:183)
        at com.linkedin.container.servicecall.internal.IC1ExecutionContextPropagator$IC1CallableDecorator.call(IC1ExecutionContextPropagator.java:60)
        at com.linkedin.container.servicecall.internal.IC1ExecutionContextPropagator.call(IC1ExecutionContextPropagator.java:33)
        at com.linkedin.container.servicecall.internal.ExecutionContextManagerImpl$1.call(ExecutionContextManagerImpl.java:118)
        at io.grpc.Context.call(Context.java:551)
        at com.linkedin.opentelemetry.context.IoContextPropagator$IoExecutionContext.call(IoContextPropagator.java:40)
        at com.linkedin.opentelemetry.context.IoContextPropagator.call(IoContextPropagator.java:26)
        at com.linkedin.container.servicecall.internal.ExecutionContextManagerImpl$1.call(ExecutionContextManagerImpl.java:118)
        at com.linkedin.container.servicecall.internal.DefaultExecutionContextPropagator$MDCCallableDecorator.call(DefaultExecutionContextPropagator.java:100)
        at com.linkedin.container.ic2.internal.ThreadLocalICManager.callWithIC(ThreadLocalICManager.java:120)
        at com.linkedin.container.servicecall.internal.DefaultExecutionContextPropagator.call(DefaultExecutionContextPropagator.java:45)
        at com.linkedin.container.servicecall.internal.ExecutionContextManagerImpl$1.call(ExecutionContextManagerImpl.java:118)
        at com.linkedin.container.servicecall.internal.ExecutionContextManagerImpl.call(ExecutionContextManagerImpl.java:76)
        at com.linkedin.container.servicecall.internal.ICFilterHelperImpl.runWithExecutionContext(ICFilterHelperImpl.java:182)
        at com.linkedin.grpc.interceptor.internal.InterceptorExecutionContextPropagator.call(InterceptorExecutionContextPropagator.java:57)
        at com.linkedin.grpc.interceptor.ic.ServerICInterceptor.runWithExecutionContext(ServerICInterceptor.java:190)
        at com.linkedin.grpc.interceptor.ic.ServerICInterceptor.access$300(ServerICInterceptor.java:25)
        at com.linkedin.grpc.interceptor.ic.ServerICInterceptor$2.callWithExecutionContext(ServerICInterceptor.java:170)
        at com.linkedin.grpc.interceptor.ic.ServerICInterceptor$2.onHalfClose(ServerICInterceptor.java:136)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: javax.persistence.PersistenceException: Query threw SQLException:You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ',PROD)'' at line 1 Query was:SELECT rt.* FROM metadata_relationship_downstreamof rt INNER JOIN metadata_entity_dataset dt ON dt.urn=rt.destination INNER JOIN metadata_entity_dataset st ON st.urn=rt.source WHERE rt.deleted_ts is NULL AND dt.urn='urn:li:dataset:(urn:li:dataPlatform:hdfs,/jobs/dsotnt/lix_evaluations/premium_custom_button_acq_convoad_trex_eval_results',PROD)'
        at io.ebeaninternal.server.query.DefaultRelationalQueryEngine.findList(DefaultRelationalQueryEngine.java:214)
        at io.ebeaninternal.server.core.RelationalQueryRequest.findList(RelationalQueryRequest.java:88)
        at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1642)
        at io.ebeaninternal.server.querydefn.DefaultRelationalQuery.findList(DefaultRelationalQuery.java:67)
        at com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO.executeSqlWithIndexCheck(EbeanLocalRelationshipQueryDAO.java:869)
        ... 80 more
Caused by: java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ',PROD)'' at line 1
        at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
        at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1009)
        at io.ebean.datasource.pool.ExtendedPreparedStatement.executeQuery(ExtendedPreparedStatement.java:128)
        at io.ebeaninternal.server.core.AbstractSqlQueryRequest.executeAsSql(AbstractSqlQueryRequest.java:175)
        at io.ebeaninternal.server.core.AbstractSqlQueryRequest.executeSql(AbstractSqlQueryRequest.java:147)
        at io.ebeaninternal.server.query.DefaultRelationalQueryEngine.findList(DefaultRelationalQueryEngine.java:204)
        ... 84 more
,

Stack trace:
java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ',PROD)'' at line 1

```
- With fix: Local released datahub-gma, included in metadata-models and released snapshot, then used this snapshot in metadata-graph-query (following https://linkedin-randd.slack.com/archives/C03TAMTKZ5M/p1754518889373689?thread_ts=1753906344.881659&cid=C03TAMTKZ5M).

```
chmeng@chmeng-mn6430 metadata-graph-query % grpcurli --dv-auth SELF localhost:24572 proto.com.linkedin.metadatagraphquery.FindRelationshipsApi.get -d '{"key": {"destinationAssetFilter": {"criteria": [{"target": "proto.com.linkedin.metadata.asset.DatasetAsset", "path": "urn", "condition": "Condition_EQUAL", "value": {"stringValue": "urn:li:dataset:(urn:li:dataPlatform:hdfs,/jobs/dsotnt/lix_evaluations/premium_custom_button_acq_convoad_trex_eval_results\u0027,PROD)"}}]}, "relationshipFilter": {"criteria": [{"target": "proto.com.linkedin.metadata.relationship.DownstreamOf"}]}}}'
{
  "value": {
    
  }
}
```

(The return value is empty because I did local deployment without connection to actual database.)


<details>
<summary>some detailed testing notes for potential future reference</summary>

- datahub-gma: local-release

`./gradlew build publishToMavenLocal` (it takes a VERY long time - long enough for a lunch break)

```
Building version '0.6.149'
```

- metadata-models: bump datahub-gma ver in product-spec, and modify build.gradle:

```
allprojects {
  repositories {
    mavenLocal()	// add this in build.gradle
    maven { url = System.getProperty("user.home") + "/local-repo" }
  }
}
```

(mavenLocal() references ~/.m2/repository where local release locates; e.g. ~/.m2/repository/com/linkedin/datahub-gma/ebean-dao/0.6.149/)

`mint build && mint snapshot && mint release` 

(did `--pass-through="-x checkPegasusSnapshot"` due to some compatibility issues unrelated to this change, which will be solved once corresponding changes on metadata-models in pr 1860 merged)

```
274.0.61-SNAPSHOT
```

- metadata-graph-query: bump metadata-models ver in product-spec & modify build.gradle:

```
allprojects {
  repositories {
    mavenLocal()	// add this in build.gradle
    maven { url = System.getProperty("user.home") + "/local-repo" }
  }
}
```

`mint build && mint build-cfg -f qei-ltx1 && mint deploy -f qei-ltx1`

then run the testing grpc call.


</details>

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
