### PR TITLE
fix string literal parsing issue

### DIFF
--- a/dao-api/src/main/pegasus/com/linkedin/metadata/query/Condition.pdl
+++ b/dao-api/src/main/pegasus/com/linkedin/metadata/query/Condition.pdl
@@ -51,7 +51,7 @@ enum Condition {
   START_WITH
 
   /**
-   * Represent the relation: array field contains string value, e.g. labels{["abc", "def"]} contains "abc"
+   * Represent the relation: array field contains string value, e.g. labels{["abc", "def"]} contains abc
    */
   ARRAY_CONTAINS
 }


### PR DESCRIPTION
## Summary
seems restli-python cannot compile the quotes in this comment. remove the quotes.

`[2025-08-23, 21:01:38 UTC] {process_utils.py:187} INFO -     """Represent the relation: array field contains string value, e.g. labels{["abc", "def"]} contains "abc""""`
## Testing Done
N/A
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
