### PR TITLE
Splitting filter queries

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -391,6 +391,11 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    * @return Resolved totalCount that accounts for potential concurrent insertions/deletions
    */
   protected int resolveTotalCount(int valuesSize, int totalCount, int start, int pageSize) {
+    // If requesting beyond available data, preserve original totalCount
+    if (start >= totalCount) {
+      return totalCount;
+    }
+    
     if (valuesSize < pageSize && start + valuesSize < totalCount) {
       // Deletion race condition detected: hit end early due to records being deleted between queries
       // Adjust totalCount to reflect the actual end position

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -391,8 +391,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    * @return Resolved totalCount that accounts for potential concurrent insertions/deletions
    */
   protected int resolveTotalCount(int valuesSize, int totalCount, int start, int pageSize) {
-    // If requesting beyond available data, preserve original totalCount
-    if (start >= totalCount) {
+    // If requesting beyond available data with no results, preserve original totalCount
+    if (start >= totalCount && valuesSize == 0) {
       return totalCount;
     }
     

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -72,9 +72,6 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   private static final String DEFAULT_ACTOR = "urn:li:principal:UNKNOWN";
   private static final String EBEAN_SERVER_CONFIG = "EbeanServerConfig";
 
-  // key: table_name,
-  // value: Set(column1, column2, column3 ...)
-  private final Map<String, Set<String>> tableColumns = new ConcurrentHashMap<>();
   private final SchemaValidatorUtil validator;
 
   public EbeanLocalAccess(EbeanServer server, ServerConfig serverConfig, @Nonnull Class<URN> urnClass,

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -404,7 +404,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     final List<URN> values = sqlRows.stream()
         .map(sqlRow -> getUrn(sqlRow.getString("urn"), _urnClass))
         .collect(Collectors.toList());
-    return  toListResult(values, sqlRows, null, start, pageSize);
+    return toListResult(values, sqlRows, null, start, pageSize);
   }
 
   @Nonnull
@@ -608,8 +608,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    * @return {@link ListResult} which contains paging metadata information
    */
   @Nonnull
-  protected <T> ListResult<T> toListResult(@Nonnull List<T> values, @Nonnull List<SqlRow> sqlRows,
-      @Nullable ListResultMetadata listResultMetadata, int start, int pageSize) {
+  protected <T> ListResult<T> toListResult(@Nonnull List<T> values, @Nonnull List<SqlRow> sqlRows, @Nullable ListResultMetadata listResultMetadata,
+      int start, int pageSize) {
     if (pageSize == 0) {
       pageSize = DEFAULT_PAGE_SIZE;
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -53,7 +53,6 @@ import static com.linkedin.metadata.dao.utils.SQLIndexFilterUtils.*;
 import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
 import static com.linkedin.metadata.dao.utils.SQLStatementUtils.*;
 
-
 /**
  * EBeanLocalAccess provides model agnostic data access (read / write) to MySQL database.
  */
@@ -72,6 +71,9 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   private static final String DEFAULT_ACTOR = "urn:li:principal:UNKNOWN";
   private static final String EBEAN_SERVER_CONFIG = "EbeanServerConfig";
 
+  // key: table_name,
+  // value: Set(column1, column2, column3 ...)
+  private final Map<String, Set<String>> tableColumns = new ConcurrentHashMap<>();
   private final SchemaValidatorUtil validator;
 
   public EbeanLocalAccess(EbeanServer server, ServerConfig serverConfig, @Nonnull Class<URN> urnClass,
@@ -338,18 +340,44 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     return sqlRows.stream().map(sqlRow -> getUrn(sqlRow.getString("urn"), _urnClass)).collect(Collectors.toList());
   }
 
+  /**
+   * Retrieves a paginated list of URNs matching the provided filter and sort criteria.
+   * This method performs two queries:
+   * <ul>
+   *   <li>A count query to determine the total number of matching URNs.</li>
+   *   <li>A paginated query to fetch the URNs for the requested page.</li>
+   * </ul>
+   * The results are returned as a {@link ListResult} containing the page of URNs, total count, and pagination metadata.
+   *
+   * @param indexFilter The filter criteria to apply to the URNs (nullable).
+   * @param indexSortCriterion The sort criteria for ordering the URNs (nullable).
+   * @param start The starting offset (zero-based) of the page.
+   * @param pageSize The maximum number of URNs to return in the page.
+   * @return A {@link ListResult} containing the page of URNs, total count, and pagination metadata.
+   */
   @Override
   public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize) {
-    final SqlQuery sqlQuery = createFilterSqlQuery(indexFilter, indexSortCriterion, start, pageSize);
-    final List<SqlRow> sqlRows = sqlQuery.findList();
-    if (sqlRows.isEmpty()) {
-      final List<SqlRow> totalCountResults = createFilterSqlQuery(indexFilter, indexSortCriterion, 0, DEFAULT_PAGE_SIZE).findList();
-      final int actualTotalCount = totalCountResults.isEmpty() ? 0 : totalCountResults.get(0).getInteger("_total_count");
-      return toListResult(actualTotalCount, start, pageSize);
+    // 1. Run the count query to get total count of matching rows
+    final SqlQuery countQuery = createCountSqlQuery(indexFilter);
+    final SqlRow countRow = countQuery.findOne();
+    final int totalCount = (countRow == null) ? 0 : countRow.getInteger("total_count");
+
+    // If there are no matching rows, return an empty result immediately
+    if (totalCount == 0) {
+      return toListResult(0, start, pageSize);
     }
-    final List<URN> values = sqlRows.stream().map(sqlRow -> getUrn(sqlRow.getString("urn"), _urnClass)).collect(Collectors.toList());
-    return toListResult(values, sqlRows, null, start, pageSize);
+
+    // 2. Run the paginated URN query for the current page
+    final SqlQuery pageQuery = createFilterSqlQuery(indexFilter, indexSortCriterion, start, pageSize);
+    final List<SqlRow> sqlRows = pageQuery.findList();
+
+    // Map the SQL rows to URN objects
+    final List<URN> values =
+        sqlRows.stream().map(sqlRow -> getUrn(sqlRow.getString("urn"), _urnClass)).collect(Collectors.toList());
+
+    // 3. Build and return the ListResult with values, total count, and pagination metadata
+    return toListResult(values, totalCount, start, pageSize);
   }
 
   @Override
@@ -376,7 +404,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     final List<URN> values = sqlRows.stream()
         .map(sqlRow -> getUrn(sqlRow.getString("urn"), _urnClass))
         .collect(Collectors.toList());
-    return toListResult(values, sqlRows, null, start, pageSize);
+    return  toListResult(values, sqlRows, null, start, pageSize);
   }
 
   @Nonnull
@@ -470,20 +498,39 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   }
 
   /**
-   * Produce {@link SqlQuery} for list urn by offset (start) and limit (pageSize).
-   * @param indexFilter index filter conditions
-   * @param indexSortCriterion sorting criterion, default ACS
-   * @return SqlQuery a SQL query which can be executed by ebean server.
+   * Builds a {@link SqlQuery} for fetching a paginated list of URNs matching the provided filter and sort criteria.
+   * Generates a query like:
+   *   SELECT urn FROM table WHERE filters ORDER BY sort LIMIT pageSize OFFSET offset
+   * Uses the provided IndexFilter and IndexSortCriterion to construct the WHERE and ORDER BY clauses.
+   *
+   * @param indexFilter The filter criteria to apply (nullable).
+   * @param indexSortCriterion The sort criteria to apply (nullable).
+   * @param offset The starting offset for pagination.
+   * @param pageSize The maximum number of results to return.
+   * @return A parametrized SqlQuery for fetching the paginated URNs.
    */
   private SqlQuery createFilterSqlQuery(@Nullable IndexFilter indexFilter,
       @Nullable IndexSortCriterion indexSortCriterion, int offset, int pageSize) {
-    StringBuilder filterSql = new StringBuilder();
-    filterSql.append(SQLStatementUtils.createFilterSql(_entityType, indexFilter, true, _nonDollarVirtualColumnsEnabled, validator));
-    filterSql.append("\n");
-    filterSql.append(parseSortCriteria(_entityType, indexSortCriterion, _nonDollarVirtualColumnsEnabled));
-    filterSql.append(String.format(" LIMIT %d", Math.max(pageSize, 0)));
-    filterSql.append(String.format(" OFFSET %d", Math.max(offset, 0)));
-    return _server.createSqlQuery(filterSql.toString());
+    String filterSql =
+        SQLStatementUtils.createFilterSql(_entityType, indexFilter, false, _nonDollarVirtualColumnsEnabled, validator)
+            + "\n" + parseSortCriteria(_entityType, indexSortCriterion, _nonDollarVirtualColumnsEnabled)
+            + String.format(" LIMIT %d", Math.max(pageSize, 0)) + String.format(" OFFSET %d", Math.max(offset, 0));
+    return _server.createSqlQuery(filterSql);
+  }
+
+  /**
+   * Builds a {@link SqlQuery} for counting the number of rows matching the provided filter.
+   * Generates a query like:
+   *   SELECT COUNT(urn) AS total_count FROM table WHERE filters ...
+   * Uses the provided IndexFilter and schema validator to construct the WHERE clause.
+   *
+   * @param indexFilter The filter criteria to apply (nullable).
+   * @return A parametrized SqlQuery for counting matching rows.
+   */
+  private SqlQuery createCountSqlQuery(@Nullable IndexFilter indexFilter) {
+    String countSql = SQLStatementUtils.createFilterSql(
+        _entityType, indexFilter, true, _nonDollarVirtualColumnsEnabled, validator);
+    return _server.createSqlQuery(countSql);
   }
 
   /**
@@ -561,8 +608,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    * @return {@link ListResult} which contains paging metadata information
    */
   @Nonnull
-  protected <T> ListResult<T> toListResult(@Nonnull List<T> values, @Nonnull List<SqlRow> sqlRows, @Nullable ListResultMetadata listResultMetadata,
-      int start, int pageSize) {
+  protected <T> ListResult<T> toListResult(@Nonnull List<T> values, @Nonnull List<SqlRow> sqlRows,
+      @Nullable ListResultMetadata listResultMetadata, int start, int pageSize) {
     if (pageSize == 0) {
       pageSize = DEFAULT_PAGE_SIZE;
     }
@@ -591,6 +638,51 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
         .pageSize(pageSize)
         .build();
   }
+
+  /**
+   * Convert values + totalCount into {@link ListResult}.
+   * This is used when totalCount comes from a separate COUNT query,
+   * not from an embedded _total_count in the SqlRow.
+   *
+   * @param values the page of results
+   * @param totalCount the total number of results matching the filter
+   * @param start starting offset
+   * @param pageSize number of rows in this page
+   * @param <T> type of query response
+   * @return {@link ListResult} containing results and pagination metadata
+   */
+  @Nonnull
+  protected <T> ListResult<T> toListResult(@Nonnull List<T> values,
+      int totalCount,
+      int start,
+      int pageSize) {
+    if (pageSize == 0) {
+      pageSize = DEFAULT_PAGE_SIZE;
+    }
+    final int totalPageCount = ceilDiv(totalCount, pageSize);
+
+    boolean hasNext;
+    int nextStart;
+
+    if (start + values.size() < totalCount) {
+      hasNext = true;
+      nextStart = start + values.size();
+    } else {
+      hasNext = false;
+      nextStart = ListResult.INVALID_NEXT_START;
+    }
+
+    return ListResult.<T>builder()
+        .values(values)
+        .metadata(null) // or construct ListResultMetadata if needed
+        .nextStart(nextStart)
+        .havingMore(hasNext)
+        .totalCount(totalCount)
+        .totalPageCount(totalPageCount)
+        .pageSize(pageSize)
+        .build();
+  }
+
 
   /**
    * Given an AuditedAspect object, serialize it into a json string in a format that will be saved in DB.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -377,7 +377,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
         sqlRows.stream().map(sqlRow -> getUrn(sqlRow.getString("urn"), _urnClass)).collect(Collectors.toList());
 
     // 3. Build and return the ListResult with values, total count, and pagination metadata
-    return toListResult(values, totalCount, start, pageSize);
+    // Use max to handle race condition where rows might be inserted between count and data queries
+    return toListResult(values, Math.max(totalCount, values.size()), start, pageSize);
   }
 
   @Override

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -321,35 +321,6 @@ public class SQLStatementUtils {
           columnName, columnName, columnName);
     }
   }
-
-  /**
-   * Creates an SQL statement for fetching URNs or counting rows from an entity table, applying the provided filter.
-   * If isCountQuery is true, generates a count query:
-   *   SELECT COUNT(urn) AS total_count FROM table WHERE ...
-   * If isCountQuery is false, generates a URN fetch query:
-   *   SELECT urn FROM table WHERE ...
-   *
-   * @param entityType The entity type (table) to query.
-   * @param indexFilter The filter criteria to apply (can be null).
-   * @param isCountQuery If true, generate a count query; if false, generate a URN fetch query.
-   * @param nonDollarVirtualColumnsEnabled True if virtual columns do not contain '$', false otherwise.
-   * @param schemaValidator Validator to check column existence and schema.
-   * @return The generated SQL query string.
-   */
-  public static String createFilterSql(String entityType, @Nullable IndexFilter indexFilter, boolean isCountQuery, boolean nonDollarVirtualColumnsEnabled,
-      @Nonnull SchemaValidatorUtil schemaValidator) {
-    final String tableName = getTableName(entityType);
-    String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
-
-    if (isCountQuery) {
-      // Build count query
-      return String.format(SQL_COUNT_TEMPLATE, tableName, whereClause);
-    } else {
-      // Build urn fetch query
-      return String.format(SQL_SELECT_URN_WHERE_TEMPLATE, tableName, whereClause);
-    }
-  }
-
   /**
    * Create index group by SQL statement.
    * @param entityType entity type

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -33,7 +33,6 @@ import static com.linkedin.metadata.dao.utils.LogicalExpressionLocalRelationship
 import static com.linkedin.metadata.dao.utils.SQLIndexFilterUtils.*;
 import static com.linkedin.metadata.dao.utils.SQLSchemaUtils.*;
 
-
 /**
  * SQL statement util class to generate executable SQL query / execution statements.
  */
@@ -151,16 +150,6 @@ public class SQLStatementUtils {
 
   private static final String DELETE_BY_SOURCE_AND_ASPECT = "UPDATE %s SET deleted_ts=NOW() "
       + "WHERE source = :source AND (aspect = :aspect OR aspect = :pegasus_aspect) AND deleted_ts IS NULL";
-
-  /**
-   *  Filter query has pagination params in the existing APIs. To accommodate this, we use subquery to include total result counts in the query response.
-   *  For example, we will build the following filter query statement:
-   *
-   *  <p>SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE i_aspectfoo$value >= 25\n"
-   *  AND i_aspectfoo$value < 50 AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL) as _total_count FROM metadata_entity_foo\n"
-   *  WHERE i_aspectfoo$value >= 25 AND i_aspectfoo$value < 50 AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL;
-   */
-  private static final String SQL_FILTER_TEMPLATE = "SELECT *, (%s) as _total_count FROM %s";
 
   private static final String SQL_COUNT_TEMPLATE =
       "SELECT COUNT(urn) AS total_count FROM %s %s";
@@ -403,6 +392,28 @@ public class SQLStatementUtils {
     final String columnName = getAspectColumnName(entityType, aspectClass);
     return String.format(SQL_BROWSE_ASPECT_TEMPLATE, columnName, tableName, tableName, columnName,
         Math.max(pageSize, 0), Math.max(offset, 0));
+  }
+
+  /**
+   * Creates an SQL statement for fetching URNs from an entity table, applying the provided filter.
+   */
+  public static String createSelectFilterSql(String entityType, @Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled,
+      @Nonnull SchemaValidatorUtil schemaValidator) {
+    final String tableName = getTableName(entityType);
+    String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
+    // Build select query
+    return String.format(SQL_SELECT_URN_WHERE_TEMPLATE, tableName, whereClause);
+  }
+
+  /**
+   * Creates an SQL statement for counting rows from an entity table, applying the provided filter.
+   */
+  public static String createCountFilterSql(String entityType, @Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled,
+      @Nonnull SchemaValidatorUtil schemaValidator) {
+    final String tableName = getTableName(entityType);
+    String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
+    // Build count query
+    return String.format(SQL_COUNT_TEMPLATE, tableName, whereClause);
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -180,11 +180,38 @@ public class EbeanLocalAccessTest {
 
     ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 5, 5);
 
-    assertEquals(5, listUrns.getValues().size());
-    assertEquals(5, listUrns.getPageSize());
+    assertEquals(listUrns.getValues().size(), 5);
+    assertEquals(listUrns.getPageSize(), 5);
     assertEquals(10, listUrns.getNextStart());
     assertEquals(25, listUrns.getTotalCount());
     assertEquals(5, listUrns.getTotalPageCount());
+  }
+
+  @Test
+  public void testListUrnsReturnsEmptyWhenNoResults() {
+    // Given: An IndexFilter that matches no rows
+    IndexFilter indexFilter = new IndexFilter();
+    // (Optionally set up filter to something impossible, e.g. value < 0)
+    IndexCriterionArray criteria = new IndexCriterionArray();
+    IndexCriterion impossibleCriterion = SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.LESS_THAN, IndexValue.create(-1));
+    criteria.add(impossibleCriterion);
+    indexFilter.setCriteria(criteria);
+
+    int start = 0;
+    int pageSize = 10;
+
+    // When: listUrns is called
+    ListResult<FooUrn> result = _ebeanLocalAccessFoo.listUrns(indexFilter, null, start, pageSize);
+
+    // Then: The result should be empty and pagination metadata should be correct
+    assertNotNull(result);
+    assertEquals(result.getValues().size(), 0);
+    assertEquals(result.getTotalCount(), 0);
+    assertFalse(result.isHavingMore());
+    assertEquals(result.getNextStart(), ListResult.INVALID_NEXT_START);
+    assertEquals(result.getNextStart(), -1);
+    assertEquals(pageSize, result.getPageSize());
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -298,7 +298,7 @@ public class EbeanLocalAccessTest {
     // Scenario 6: Insertion with larger insertion count
     int adjustedCount6 = _ebeanLocalAccessFoo.resolveTotalCount(15, 50, 40, 10);
     assertEquals(adjustedCount6, 55, "Large insertion: Math.max(50, 55) → should expand totalCount");
-    
+
     // Scenario 7: Request beyond available data (start >= totalCount)
     int adjustedCount7 = _ebeanLocalAccessFoo.resolveTotalCount(0, 3, 4, 2);
     assertEquals(adjustedCount7, 3, "Beyond available data: start >= totalCount → should preserve totalCount");
@@ -327,7 +327,6 @@ public class EbeanLocalAccessTest {
     assertEquals(result.getTotalCount(), 0);
     assertFalse(result.isHavingMore());
     assertEquals(result.getNextStart(), ListResult.INVALID_NEXT_START);
-    assertEquals(result.getNextStart(), -1);
     assertEquals(pageSize, result.getPageSize());
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -298,6 +298,10 @@ public class EbeanLocalAccessTest {
     // Scenario 6: Insertion with larger insertion count
     int adjustedCount6 = _ebeanLocalAccessFoo.resolveTotalCount(15, 50, 40, 10);
     assertEquals(adjustedCount6, 55, "Large insertion: Math.max(50, 55) → should expand totalCount");
+    
+    // Scenario 7: Request beyond available data (start >= totalCount)
+    int adjustedCount7 = _ebeanLocalAccessFoo.resolveTotalCount(0, 3, 4, 2);
+    assertEquals(adjustedCount7, 3, "Beyond available data: start >= totalCount → should preserve totalCount");
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -31,7 +31,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +189,7 @@ public class EbeanLocalAccessTest {
 
   // Test Case 1: Normal last page behavior using existing 100 records from @BeforeMethod
   @Test
-  public void testListUrns_NormalLastPagePagination() {
+  public void testListUrnsNormalLastPagePagination() {
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName());
     indexFilter.setCriteria(new IndexCriterionArray(Collections.singleton(criterion)));
@@ -207,7 +206,7 @@ public class EbeanLocalAccessTest {
 
   // Test Case 2: Test normal pagination with soft deleted records
   @Test
-  public void testListUrns_SoftDeletedRecordsHandling() throws URISyntaxException {
+  public void testListUrnsSoftDeletedRecordsHandling() throws URISyntaxException {
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName());
     indexFilter.setCriteria(new IndexCriterionArray(Collections.singleton(criterion)));
@@ -236,7 +235,7 @@ public class EbeanLocalAccessTest {
 
   // Test Case 3: Normal pagination behavior with full pages using existing 100 records
   @Test
-  public void testListUrns_InsertionRaceConditionHandling() {
+  public void testListUrnsInsertionRaceConditionHandling() {
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName());
     indexFilter.setCriteria(new IndexCriterionArray(Collections.singleton(criterion)));
@@ -253,7 +252,7 @@ public class EbeanLocalAccessTest {
 
   // Test Case 4: Boundary conditions for race condition detection using existing 100 records
   @Test
-  public void testListUrns_BoundaryConditions() {
+  public void testListUrnsBoundaryConditions() {
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName());
     indexFilter.setCriteria(new IndexCriterionArray(Collections.singleton(criterion)));
@@ -275,27 +274,27 @@ public class EbeanLocalAccessTest {
   @Test
   public void testResolveTotalCount() {
     // Test the extracted race condition detection method directly
-    
+
     // Scenario 1: Deletion race condition detection
     int adjustedCount1 = _ebeanLocalAccessFoo.resolveTotalCount(3, 100, 50, 10);
     assertEquals(adjustedCount1, 53, "Deletion race condition: 3 < 10 AND 53 < 100 → should adjust to start + valuesSize");
-    
+
     // Scenario 2: Insertion race condition (Math.max logic)
     int adjustedCount2 = _ebeanLocalAccessFoo.resolveTotalCount(10, 45, 40, 10);
     assertEquals(adjustedCount2, 50, "Insertion race condition: Math.max(45, 50) → should use Math.max logic");
-    
+
     // Scenario 3: Normal pagination - no race condition
     int adjustedCount3 = _ebeanLocalAccessFoo.resolveTotalCount(10, 100, 20, 10);
     assertEquals(adjustedCount3, 100, "Normal pagination: 10 == 10 → should preserve original totalCount");
-    
+
     // Scenario 4: Edge case - empty results due to deletion race condition
     int adjustedCount4 = _ebeanLocalAccessFoo.resolveTotalCount(0, 100, 90, 10);
     assertEquals(adjustedCount4, 90, "Empty results at end: 0 < 10 AND 90 < 100 → should adjust to start + valuesSize");
-    
+
     // Scenario 5: Last page boundary - full page size but at exact end
     int adjustedCount5 = _ebeanLocalAccessFoo.resolveTotalCount(10, 100, 90, 10);
     assertEquals(adjustedCount5, 100, "Last page with full results: Math.max(100, 100) → should preserve totalCount");
-    
+
     // Scenario 6: Insertion with larger insertion count
     int adjustedCount6 = _ebeanLocalAccessFoo.resolveTotalCount(15, 50, 40, 10);
     assertEquals(adjustedCount6, 55, "Large insertion: Math.max(50, 55) → should expand totalCount");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -182,9 +182,9 @@ public class EbeanLocalAccessTest {
 
     assertEquals(listUrns.getValues().size(), 5);
     assertEquals(listUrns.getPageSize(), 5);
-    assertEquals(10, listUrns.getNextStart());
-    assertEquals(25, listUrns.getTotalCount());
-    assertEquals(5, listUrns.getTotalPageCount());
+    assertEquals(listUrns.getNextStart(), 10);
+    assertEquals(listUrns.getTotalCount(), 25);
+    assertEquals(listUrns.getTotalPageCount(), 5);
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -299,9 +299,13 @@ public class EbeanLocalAccessTest {
     int adjustedCount6 = _ebeanLocalAccessFoo.resolveTotalCount(15, 50, 40, 10);
     assertEquals(adjustedCount6, 55, "Large insertion: Math.max(50, 55) → should expand totalCount");
 
-    // Scenario 7: Request beyond available data (start >= totalCount)
+    // Scenario 7: Request beyond available data with no results (start >= totalCount && valuesSize == 0)
     int adjustedCount7 = _ebeanLocalAccessFoo.resolveTotalCount(0, 3, 4, 2);
-    assertEquals(adjustedCount7, 3, "Beyond available data: start >= totalCount → should preserve totalCount");
+    assertEquals(adjustedCount7, 3, "Beyond available data with no results: start >= totalCount && valuesSize == 0 → should preserve totalCount");
+    
+    // Scenario 8: Insertion race condition at boundary (start >= totalCount but got results)
+    int adjustedCount8 = _ebeanLocalAccessFoo.resolveTotalCount(2, 3, 3, 2);
+    assertEquals(adjustedCount8, 5, "Insertion at boundary: start >= totalCount but valuesSize > 0 → should use Math.max(3, 3+2)");
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -146,7 +146,7 @@ public class SQLStatementUtilsTest {
     indexFilter.setCriteria(indexCriterionArray);
 
     // count query with dollar sign
-    String sql1 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false, mockValidator);
+    String sql1 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, true, mockValidator);
     String expectedSql1 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
@@ -154,7 +154,7 @@ public class SQLStatementUtilsTest {
     assertEquals(expectedSql1, sql1);
 
     // count query with no dollar sign
-    String sql2 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, true, mockValidator);
+    String sql2 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, true, mockValidator);
     String expectedSql2 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
@@ -162,7 +162,7 @@ public class SQLStatementUtilsTest {
     assertEquals(expectedSql2, sql2);
 
     //get urn query with dollar sign
-    String sql3 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, false, mockValidator);
+    String sql3 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, false, mockValidator);
     String expectedSql3 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
@@ -170,7 +170,7 @@ public class SQLStatementUtilsTest {
     assertEquals(expectedSql3, sql3);
 
     //get urn query with no dollar sign
-    String sql4 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, true, mockValidator);
+    String sql4 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, false, mockValidator);
     String expectedSql4 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
@@ -190,28 +190,28 @@ public class SQLStatementUtilsTest {
     indexCriterionArray.add(indexCriterion1);
     indexFilter.setCriteria(indexCriterionArray);
     // count query with dollar sign
-    String sql1 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false, mockValidator);
+    String sql1 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, true, mockValidator);
     String expectedSql1 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n"
         + "AND deleted_ts IS NULL";
     assertEquals(expectedSql1, sql1);
 
     // count query with no dollar sign
-    String sql2 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, true, mockValidator);
+    String sql2 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, true, mockValidator);
     String expectedSql2 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar0bars)\n"
         + "AND deleted_ts IS NULL";
     assertEquals(expectedSql2, sql2);
 
     //get urn query with dollar sign
-    String sql3 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, false, mockValidator);
+    String sql3 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, false, mockValidator);
     String expectedSql3 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n"
         + "AND deleted_ts IS NULL";
     assertEquals(expectedSql3, sql3);
 
     //get urn query with no dollar sign
-    String sql4 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, true, mockValidator);
+    String sql4 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, false, mockValidator);
     String expectedSql4 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar0bars)\n"
         + "AND deleted_ts IS NULL";
@@ -777,7 +777,7 @@ public class SQLStatementUtilsTest {
         SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "invalid", Condition.EQUAL, IndexValue.create("val2"))
     ));
 
-    String sql = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false, mockValidator1);
+    String sql = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, true, mockValidator1);
     assertTrue(sql.contains("i_aspectfoo$value = 'val'"), "Should contain valid column condition");
     assertFalse(sql.contains("invalid"), "Should skip invalid column");
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -777,9 +777,7 @@ public class SQLStatementUtilsTest {
         SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "invalid", Condition.EQUAL, IndexValue.create("val2"))
     ));
 
-
-
-    String sql = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, true, mockValidator1);
+    String sql = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, false, mockValidator1);
     assertTrue(sql.contains("i_aspectfoo$value = 'val'"), "Should contain valid column condition");
     assertFalse(sql.contains("invalid"), "Should skip invalid column");
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -146,7 +146,7 @@ public class SQLStatementUtilsTest {
     indexFilter.setCriteria(indexCriterionArray);
 
     // count query with dollar sign
-    String sql1 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, true, mockValidator);
+    String sql1 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, false, mockValidator);
     String expectedSql1 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
@@ -170,7 +170,7 @@ public class SQLStatementUtilsTest {
     assertEquals(expectedSql3, sql3);
 
     //get urn query with no dollar sign
-    String sql4 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, false, mockValidator);
+    String sql4 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, true, mockValidator);
     String expectedSql4 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
@@ -190,7 +190,7 @@ public class SQLStatementUtilsTest {
     indexCriterionArray.add(indexCriterion1);
     indexFilter.setCriteria(indexCriterionArray);
     // count query with dollar sign
-    String sql1 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, true, mockValidator);
+    String sql1 = SQLStatementUtils.createCountFilterSql("foo", indexFilter, false, mockValidator);
     String expectedSql1 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n"
         + "AND deleted_ts IS NULL";
@@ -211,7 +211,7 @@ public class SQLStatementUtilsTest {
     assertEquals(expectedSql3, sql3);
 
     //get urn query with no dollar sign
-    String sql4 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, false, mockValidator);
+    String sql4 = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, true, mockValidator);
     String expectedSql4 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar0bars)\n"
         + "AND deleted_ts IS NULL";
@@ -776,6 +776,8 @@ public class SQLStatementUtilsTest {
         SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.EQUAL, IndexValue.create("val")),
         SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "invalid", Condition.EQUAL, IndexValue.create("val2"))
     ));
+
+
 
     String sql = SQLStatementUtils.createSelectFilterSql("foo", indexFilter, true, mockValidator1);
     assertTrue(sql.contains("i_aspectfoo$value = 'val'"), "Should contain valid column condition");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -44,7 +44,9 @@ import static com.linkedin.testing.TestUtils.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
-
+/**
+ * Tests for {@link SQLStatementUtils}.
+ */
 public class SQLStatementUtilsTest {
 
   private static SchemaValidatorUtil mockValidator;
@@ -143,29 +145,37 @@ public class SQLStatementUtilsTest {
     indexCriterionArray.add(indexCriterion2);
     indexFilter.setCriteria(indexCriterionArray);
 
+    // count query with dollar sign
     String sql1 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false, mockValidator);
-    String expectedSql1 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
+    String expectedSql1 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo$value < 50\n" + "AND deleted_ts IS NULL)" + " as _total_count FROM metadata_entity_foo\n"
-        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo$value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
-        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo$value < 50\n" + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql1, sql1);
 
-    assertEquals(sql1, expectedSql1);
-
+    // count query with no dollar sign
     String sql2 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, true, mockValidator);
-    String expectedSql2 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
+    String expectedSql2 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
         + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo0value < 50\n" + "AND deleted_ts IS NULL)" + " as _total_count FROM metadata_entity_foo\n"
-        + "WHERE a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
-        + "AND i_aspectfoo0value >= 25\n" + "AND a_aspectfoo IS NOT NULL\n"
-        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
         + "AND i_aspectfoo0value < 50\n" + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql2, sql2);
 
-    assertEquals(sql2, expectedSql2);
+    //get urn query with dollar sign
+    String sql3 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, false, mockValidator);
+    String expectedSql3 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo$value >= 25\n"
+        + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "AND i_aspectfoo$value < 50\n" + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql3, sql3);
+
+    //get urn query with no dollar sign
+    String sql4 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, true, mockValidator);
+    String expectedSql4 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoo IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n" + "AND i_aspectfoo0value >= 25\n"
+        + "AND a_aspectfoo IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoo, '$.gma_deleted') IS NULL\n"
+        + "AND i_aspectfoo0value < 50\n" + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql4, sql4);
   }
 
   @Test
@@ -179,15 +189,33 @@ public class SQLStatementUtilsTest {
 
     indexCriterionArray.add(indexCriterion1);
     indexFilter.setCriteria(indexCriterionArray);
-
+    // count query with dollar sign
     String sql1 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, false, mockValidator);
-    String expectedSql1 = "SELECT *, (SELECT COUNT(urn) FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
+    String expectedSql1 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
         + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n"
-        + "AND deleted_ts IS NULL)" + " as _total_count FROM metadata_entity_foo\n"
-        + "WHERE a_aspectfoobar IS NOT NULL\n" + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n"
-        + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n" + "AND deleted_ts IS NULL";
+        + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql1, sql1);
 
-    assertEquals(sql1, expectedSql1);
+    // count query with no dollar sign
+    String sql2 = SQLStatementUtils.createFilterSql("foo", indexFilter, true, true, mockValidator);
+    String expectedSql2 = "SELECT COUNT(urn) AS total_count FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar0bars)\n"
+        + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql2, sql2);
+
+    //get urn query with dollar sign
+    String sql3 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, false, mockValidator);
+    String expectedSql3 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar$bars)\n"
+        + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql3, sql3);
+
+    //get urn query with no dollar sign
+    String sql4 = SQLStatementUtils.createFilterSql("foo", indexFilter, false, true, mockValidator);
+    String expectedSql4 = "SELECT urn FROM metadata_entity_foo WHERE a_aspectfoobar IS NOT NULL\n"
+        + "AND JSON_EXTRACT(a_aspectfoobar, '$.gma_deleted') IS NULL\n" + "AND 'bar1' MEMBER OF(i_aspectfoobar0bars)\n"
+        + "AND deleted_ts IS NULL";
+    assertEquals(expectedSql4, sql4);
   }
 
   @Test


### PR DESCRIPTION
## Summary

### **Problem**

The existing listUrns query used a single SQL statement with `SELECT * , (SELECT COUNT(..)) AS _total_count`. This design caused MySQL to:
- Perform large in-memory sorts (filesort), especially when downstream passed `Integer.MAX_VALUE` as the page size.

- Fetch unnecessary columns (`SELECT *`) when only `urn` was needed.

Result: frequent Out of sort memory errors and inefficient queries.

### **Solution**

- Split queries:
-- Run a dedicated `COUNT(*)` query to compute totalCount (no sort, no limit).
-- Run a separate page query (`SELECT urn … ORDER BY urn LIMIT :pageSize OFFSET :start`) for values.

- Removed `SELECT *`:
-- Only fetch urn in page queries.

- Updated toListResult:
-- Added a new overload that accepts (values, totalCount, start, pageSize).
-- No longer depends on _total_count embedded in each SqlRow.

## Testing Done
./gradlew build
Fixed the unit tests
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
