### PR TITLE
Fix backfill gaps for soft-deleted aspects

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -510,24 +510,32 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     final boolean isBackfillEvent = trackingContext != null
         && trackingContext.hasBackfill() && trackingContext.isBackfill();
     if (isBackfillEvent) {
-      boolean shouldBackfill =
-          // new value is being inserted. We should backfill
-          oldValue == null
-              || (
-              // tracking context should ideally always have emitTime. If it's not present, we will skip backfilling
-              trackingContext.hasEmitTime()
-                  && (
-                  // old emit time is available so we'll use it for comparison
-                  // if new event emit time > old event emit time, we'll backfill
-                  (oldEmitTime != null && trackingContext.getEmitTime() > oldEmitTime)
-                      // old emit time is not available, so we'll fall back to comparing new emit time against old audit time
-                      // old audit time represents the last modified time of the aspect
-                      || (oldEmitTime == null && oldAuditStamp != null && oldAuditStamp.hasTime() && trackingContext.getEmitTime() > oldAuditStamp.getTime())));
+      boolean shouldBackfill;
+      if (oldValue == null && !latest.isSoftDeleted) {
+        // Aspect has never existed — safe to backfill unconditionally
+        shouldBackfill = true;
+      } else if (oldValue == null && latest.isSoftDeleted) {
+        // Aspect/entity was soft-deleted (oldValue is null but deletion occurred).
+        // Compare emitTime against the deletion timestamp (oldAuditStamp.time) to prevent
+        // stale backfill events from resurrecting soft-deleted entities.
+        shouldBackfill = trackingContext.hasEmitTime()
+            && oldAuditStamp != null && oldAuditStamp.hasTime()
+            && trackingContext.getEmitTime() >= oldAuditStamp.getTime();
+      } else {
+        // oldValue exists (not soft-deleted) — normal emitTime comparison
+        shouldBackfill =
+            trackingContext.hasEmitTime()
+                && (
+                (oldEmitTime != null && trackingContext.getEmitTime() > oldEmitTime)
+                    || (oldEmitTime == null && oldAuditStamp != null && oldAuditStamp.hasTime()
+                    && trackingContext.getEmitTime() > oldAuditStamp.getTime()));
+      }
 
-      log.info("Encounter backfill event. Old value = null: {}. Tracking context: {}. Urn: {}. Aspect class: {}. Old audit stamp: {}. "
-              + "Old emit time: {}. "
+      log.info("Encounter backfill event. Old value = null: {}. isSoftDeleted: {}. Tracking context: {}. Urn: {}. "
+              + "Aspect class: {}. Old audit stamp: {}. Old emit time: {}. "
               + "Based on this information, shouldBackfill = {}.",
-          oldValue == null, trackingContext, urn, aspectClass, oldAuditStamp, oldEmitTime, shouldBackfill);
+          oldValue == null, latest.isSoftDeleted, trackingContext, urn, aspectClass, oldAuditStamp, oldEmitTime,
+          shouldBackfill);
 
       if (!shouldBackfill) {
         return new AddResult<>(oldValue, oldValue, aspectClass);
@@ -629,7 +637,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     } else {
       // no atomic multiple updates: run each in its own transaction. This is the same as repeated calls to add
       results = aspectUpdateLambdas.stream().map(x -> runInTransactionWithRetry(() ->
-              aspectUpdateHelper(urn, x, auditStamp, trackingContext), maxTransactionRetry)).collect(Collectors.toList());
+          aspectUpdateHelper(urn, x, auditStamp, trackingContext), maxTransactionRetry)).collect(Collectors.toList());
     }
 
     // send the audit events etc
@@ -960,8 +968,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     // create aspects and process callbacks in a single transaction
     return runInTransactionWithRetry(() -> {
-      return createAspectsWithCallbacks(urn, aspectValues, aspectCreateLambdas, auditStamp, trackingContext);
-      }, maxTransactionRetry
+          return createAspectsWithCallbacks(urn, aspectValues, aspectCreateLambdas, auditStamp, trackingContext);
+        }, maxTransactionRetry
     );
   }
 
@@ -1037,18 +1045,18 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     final Map<Class<?>, RecordTemplate> results = new HashMap<>();
     runInTransactionWithRetry(() -> {
-        aspectClasses.forEach(aspectClass -> {
-          try {
-            RecordTemplate deletedAspect = delete(urn, aspectClass, auditStamp, maxTransactionRetry, trackingContext);
-            results.put(aspectClass, deletedAspect);
-          } catch (NullPointerException e) {
-            log.warn("Aspect {} for urn {} does not exist", aspectClass.getName(), urn);
-          }
-        });
+      aspectClasses.forEach(aspectClass -> {
+        try {
+          RecordTemplate deletedAspect = delete(urn, aspectClass, auditStamp, maxTransactionRetry, trackingContext);
+          results.put(aspectClass, deletedAspect);
+        } catch (NullPointerException e) {
+          log.warn("Aspect {} for urn {} does not exist", aspectClass.getName(), urn);
+        }
+      });
 
       permanentDelete(urn, nonNullIngestionParams.isTestMode());
       return results;
-      }, maxTransactionRetry);
+    }, maxTransactionRetry);
 
 
     Collection<RecordTemplate> deletedAspects = new ArrayList<>();

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -514,8 +514,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       if (oldValue == null && !latest.isSoftDeleted) {
         // Aspect has never existed — safe to backfill unconditionally
         shouldBackfill = true;
-      } else if (oldValue == null && latest.isSoftDeleted) {
-        // Aspect/entity was soft-deleted (oldValue is null but deletion occurred).
+      } else if (oldValue == null) {
+        // Soft-deleted (isSoftDeleted is necessarily true here since !isSoftDeleted was checked above).
         // Compare emitTime against the deletion timestamp (oldAuditStamp.time) to prevent
         // stale backfill events from resurrecting soft-deleted entities.
         shouldBackfill = trackingContext.hasEmitTime()

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -518,9 +518,16 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         // Soft-deleted (isSoftDeleted is necessarily true here since !isSoftDeleted was checked above).
         // Compare emitTime against the deletion timestamp (oldAuditStamp.time) to prevent
         // stale backfill events from resurrecting soft-deleted entities.
+        // Uses strict > (not >=) for consistency with the non-deleted branch: an event at the exact
+        // same millisecond as the deletion is treated as stale (likely in-flight when delete occurred).
+        if (trackingContext.hasEmitTime() && (oldAuditStamp == null || !oldAuditStamp.hasTime())) {
+          log.warn("Soft-deleted entity has valid emitTime but missing/invalid deletion timestamp. "
+              + "Backfill will be rejected. Urn: {}. Aspect: {}. emitTime: {}. oldAuditStamp: {}.",
+              urn, aspectClass, trackingContext.getEmitTime(), oldAuditStamp);
+        }
         shouldBackfill = trackingContext.hasEmitTime()
             && oldAuditStamp != null && oldAuditStamp.hasTime()
-            && trackingContext.getEmitTime() >= oldAuditStamp.getTime();
+            && trackingContext.getEmitTime() > oldAuditStamp.getTime();
       } else {
         // oldValue exists (not soft-deleted) — normal emitTime comparison
         shouldBackfill =

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -573,11 +573,12 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     }
     long emitTime = trackingContext.getEmitTime();
     // 3. Aspect was soft-deleted (oldValue is null because the aspect was deleted, not because it never existed).
-    // Compare emitTime against the deletion timestamp to prevent stale DLQ replays from resurrecting deleted entities.
+    // Compare emitTime against the per-aspect deletion timestamp (from SoftDeletedAspect.deleted_timestamp,
+    // surfaced via oldAuditStamp) to prevent stale DLQ replays from resurrecting deleted aspects.
     // Uses strict > (not >=) — an event at the exact same millisecond as the deletion is treated as stale,
     // since it was likely in-flight when delete occurred.
     if (oldValue == null) {
-      // If the deletion timestamp is missing or invalid, we can't safely compare — reject and warn
+      // If the deletion timestamp is missing or invalid, we can't safely compare — reject and warn.
       if (oldAuditStamp == null || !oldAuditStamp.hasTime()) {
         log.warn("Soft-deleted entity has valid emitTime but missing/invalid deletion timestamp. Backfill will be rejected. Urn: {}. Aspect: {}. "
             + "emitTime: {}. oldAuditStamp: {}.", urn, aspectClass, emitTime, oldAuditStamp);

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -514,7 +514,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       log.info("Encounter backfill event. Old value = null: {}. isSoftDeleted: {}. Tracking context: {}. Urn: {}. "
               + "Aspect class: {}. Old audit stamp: {}. Old emit time: {}. "
               + "Based on this information, shouldBackfill = {}.",
-          oldValue == null, latest.isSoftDeleted, trackingContext, urn, aspectClass, oldAuditStamp, oldEmitTime, shouldBackfill);
+          oldValue == null, latest.isSoftDeleted(), trackingContext, urn, aspectClass, oldAuditStamp, oldEmitTime, shouldBackfill);
       if (!shouldBackfill) {
         return new AddResult<>(oldValue, oldValue, aspectClass);
       }
@@ -540,7 +540,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     long largestVersion =
         saveLatest(urn, aspectClass, oldValue,
             optimisticLockAuditStamp != null ? optimisticLockAuditStamp : oldAuditStamp,
-            newValue, auditStamp, latest.isSoftDeleted, trackingContext, ingestionParams.isTestMode());
+            newValue, auditStamp, latest.isSoftDeleted(), trackingContext, ingestionParams.isTestMode());
 
     // Apply retention policy
     applyRetention(urn, aspectClass, getRetention(aspectClass), largestVersion);
@@ -563,7 +563,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     // 1. Aspect has never existed (no value, not soft-deleted) — safe to backfill unconditionally.
     // This is the only case where we allow backfill without an emitTime comparison.
-    if (oldValue == null && !latest.isSoftDeleted) {
+    if (oldValue == null && !latest.isSoftDeleted()) {
       return true;
     }
 

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -503,52 +503,22 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull AuditStamp auditStamp, @Nonnull EqualityTester<ASPECT> equalityTester,
       @Nullable IngestionTrackingContext trackingContext, @Nonnull IngestionParams ingestionParams) {
 
-    final ASPECT oldValue = latest.getAspect() == null ? null : latest.getAspect();
+    final ASPECT oldValue = latest.getAspect();
     final AuditStamp oldAuditStamp = latest.getExtraInfo() == null ? null : latest.getExtraInfo().getAudit();
     final Long oldEmitTime = latest.getExtraInfo() == null ? null : latest.getExtraInfo().getEmitTime();
 
     final boolean isBackfillEvent = trackingContext != null
         && trackingContext.hasBackfill() && trackingContext.isBackfill();
     if (isBackfillEvent) {
-      boolean shouldBackfill;
-      if (oldValue == null && !latest.isSoftDeleted) {
-        // Aspect has never existed — safe to backfill unconditionally
-        shouldBackfill = true;
-      } else if (oldValue == null) {
-        // Soft-deleted (isSoftDeleted is necessarily true here since !isSoftDeleted was checked above).
-        // Compare emitTime against the deletion timestamp (oldAuditStamp.time) to prevent
-        // stale backfill events from resurrecting soft-deleted entities.
-        // Uses strict > (not >=) for consistency with the non-deleted branch: an event at the exact
-        // same millisecond as the deletion is treated as stale (likely in-flight when delete occurred).
-        if (trackingContext.hasEmitTime() && (oldAuditStamp == null || !oldAuditStamp.hasTime())) {
-          log.warn("Soft-deleted entity has valid emitTime but missing/invalid deletion timestamp. "
-              + "Backfill will be rejected. Urn: {}. Aspect: {}. emitTime: {}. oldAuditStamp: {}.",
-              urn, aspectClass, trackingContext.getEmitTime(), oldAuditStamp);
-        }
-        shouldBackfill = trackingContext.hasEmitTime()
-            && oldAuditStamp != null && oldAuditStamp.hasTime()
-            && trackingContext.getEmitTime() > oldAuditStamp.getTime();
-      } else {
-        // oldValue exists (not soft-deleted) — normal emitTime comparison
-        shouldBackfill =
-            trackingContext.hasEmitTime()
-                && (
-                (oldEmitTime != null && trackingContext.getEmitTime() > oldEmitTime)
-                    || (oldEmitTime == null && oldAuditStamp != null && oldAuditStamp.hasTime()
-                    && trackingContext.getEmitTime() > oldAuditStamp.getTime()));
-      }
-
+      boolean shouldBackfill = shouldBackfill(urn, latest, aspectClass, trackingContext);
       log.info("Encounter backfill event. Old value = null: {}. isSoftDeleted: {}. Tracking context: {}. Urn: {}. "
               + "Aspect class: {}. Old audit stamp: {}. Old emit time: {}. "
               + "Based on this information, shouldBackfill = {}.",
-          oldValue == null, latest.isSoftDeleted, trackingContext, urn, aspectClass, oldAuditStamp, oldEmitTime,
-          shouldBackfill);
-
+          oldValue == null, latest.isSoftDeleted, trackingContext, urn, aspectClass, oldAuditStamp, oldEmitTime, shouldBackfill);
       if (!shouldBackfill) {
         return new AddResult<>(oldValue, oldValue, aspectClass);
       }
     }
-
     // TODO(yanyang) added for job-gms duplicity debug, throwaway afterwards
     if (log.isDebugEnabled()) {
       if ("AzkabanFlowInfo".equals(aspectClass.getSimpleName())) {
@@ -576,6 +546,51 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     applyRetention(urn, aspectClass, getRetention(aspectClass), largestVersion);
 
     return new AddResult<>(oldValue, newValue, aspectClass);
+  }
+
+  /**
+   * Determines whether a backfill event should be applied.
+   */
+  private <ASPECT extends RecordTemplate> boolean shouldBackfill(
+      @Nonnull URN urn,
+      @Nonnull AspectEntry<ASPECT> latest,
+      @Nonnull Class<ASPECT> aspectClass,
+      @Nonnull IngestionTrackingContext trackingContext) {
+
+    final ASPECT oldValue = latest.getAspect();
+    final AuditStamp oldAuditStamp = latest.getExtraInfo() == null ? null : latest.getExtraInfo().getAudit();
+    final Long oldEmitTime = latest.getExtraInfo() == null ? null : latest.getExtraInfo().getEmitTime();
+
+    // 1. Aspect has never existed (no value, not soft-deleted) — safe to backfill unconditionally.
+    // This is the only case where we allow backfill without an emitTime comparison.
+    if (oldValue == null && !latest.isSoftDeleted) {
+      return true;
+    }
+
+    // 2. All remaining cases require emitTime to determine staleness. Without emitTime we cannot safely compare, so reject the backfill.
+    if (!trackingContext.hasEmitTime()) {
+      return false;
+    }
+    long emitTime = trackingContext.getEmitTime();
+    // 3. Aspect was soft-deleted (oldValue is null because the aspect was deleted, not because it never existed).
+    // Compare emitTime against the deletion timestamp to prevent stale DLQ replays from resurrecting deleted entities.
+    // Uses strict > (not >=) — an event at the exact same millisecond as the deletion is treated as stale,
+    // since it was likely in-flight when delete occurred.
+    if (oldValue == null) {
+      // If the deletion timestamp is missing or invalid, we can't safely compare — reject and warn
+      if (oldAuditStamp == null || !oldAuditStamp.hasTime()) {
+        log.warn("Soft-deleted entity has valid emitTime but missing/invalid deletion timestamp. Backfill will be rejected. Urn: {}. Aspect: {}. "
+            + "emitTime: {}. oldAuditStamp: {}.", urn, aspectClass, emitTime, oldAuditStamp);
+        return false;
+      }
+      return emitTime > oldAuditStamp.getTime();
+    }
+    // 4. Aspect exists with a current value — standard staleness check. Prefer comparing against the old event's emitTime (most accurate).
+    if (oldEmitTime != null) {
+      return emitTime > oldEmitTime;
+    }
+    // 5. Old emitTime unavailable — fall back to the aspect's last-modified audit timestamp. This is less precise but the best available signal.
+    return oldAuditStamp != null && oldAuditStamp.hasTime() && emitTime > oldAuditStamp.getTime();
   }
 
   /**

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -929,7 +929,7 @@ public class BaseLocalDAOTest {
 
     IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
     ingestionTrackingContext.setBackfill(true);
-    ingestionTrackingContext.setEmitTime(200L); // newer: 200 >= 100 (deletion time)
+    ingestionTrackingContext.setEmitTime(200L); // newer: 200 > 100 (deletion time)
 
     dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
 
@@ -970,6 +970,42 @@ public class BaseLocalDAOTest {
     dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
 
     // Should NOT backfill — audit events emitted with old==new==null (no-op pattern)
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, null, null, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  @Test(description = "Backfill should be a no-op when soft-deleted and emitTime equals deletion timestamp (boundary)")
+  public void testBackfillNoopWhenSoftDeletedAndEmitTimeEqualsDeletionTime() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo newFoo = new AspectFoo().setValue("newFoo");
+
+    // Simulate soft-deleted aspect: deletion at time=100
+    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
+    ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
+    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
+        .aspect(null)
+        .extraInfo(extraInfo)
+        .isSoftDeleted(true)
+        .build();
+
+    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
+        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
+        _dummyLocalDAO._transactionRunner);
+    dummyLocalDAO.setEmitAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
+    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
+
+    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
+    ingestionTrackingContext.setBackfill(true);
+    ingestionTrackingContext.setEmitTime(100L); // exact boundary: 100 == 100 (deletion time) → no-op
+
+    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
+
+    // Should NOT backfill — event at same ms as deletion is treated as stale (strict >)
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
         urn, null, null, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -866,149 +866,252 @@ public class BaseLocalDAOTest {
     assertEquals(_dummyLocalDAO.aspectTimestampSkipWrite(null, null), false);
   }
 
-  // --- Backfill soft-delete bug fix tests ---
+  // --- Backfill test helpers ---
 
-  @Test(description = "Backfill should be a no-op when aspect is soft-deleted and emitTime is stale")
-  public void testBackfillNoopWhenSoftDeletedAndEmitTimeIsStale() throws URISyntaxException {
-    FooUrn urn = new FooUrn(1);
-    AspectFoo newFoo = new AspectFoo().setValue("newFoo");
+  private DummyLocalDAO<EntityAspectUnion> createBackfillTestDAO() {
+    DummyLocalDAO<EntityAspectUnion> dao = new DummyLocalDAO<>(EntityAspectUnion.class,
+        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
+        _dummyLocalDAO._transactionRunner);
+    dao.setEmitAuditEvent(true);
+    dao.setAlwaysEmitAuditEvent(true);
+    dao.setEmitAspectSpecificAuditEvent(true);
+    dao.setAlwaysEmitAspectSpecificAuditEvent(true);
+    return dao;
+  }
 
-    // Simulate soft-deleted aspect: oldValue=null, isSoftDeleted=true, deletion at time=100
-    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
+  private BaseLocalDAO.AspectEntry<AspectFoo> createSoftDeletedEntry(long deletionTime) {
+    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", deletionTime);
     ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
-    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
+    return BaseLocalDAO.AspectEntry.<AspectFoo>builder()
         .aspect(null)
         .extraInfo(extraInfo)
         .isSoftDeleted(true)
         .build();
+  }
 
-    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
-        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
-        _dummyLocalDAO._transactionRunner);
-    dummyLocalDAO.setEmitAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
-    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
-    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
+  private BaseLocalDAO.AspectEntry<AspectFoo> createExistingEntry(AspectFoo aspect, long auditTime, Long emitTime) {
+    AuditStamp auditStamp = makeAuditStamp("creator", auditTime);
+    ExtraInfo extraInfo = new ExtraInfo().setAudit(auditStamp);
+    if (emitTime != null) {
+      extraInfo.setEmitTime(emitTime);
+    }
+    return new BaseLocalDAO.AspectEntry<>(aspect, extraInfo);
+  }
 
-    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
-    ingestionTrackingContext.setBackfill(true);
-    ingestionTrackingContext.setEmitTime(50L); // stale: 50 < 100 (deletion time)
-
-    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
-
-    // Should NOT backfill — audit events emitted with old==new==null (no-op pattern)
+  private void verifyBackfillNoop(FooUrn urn, IngestionTrackingContext ctx) {
     verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
-        urn, null, null, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+        urn, null, null, AspectFoo.class, _dummyAuditStamp, ctx, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 
-  @Test(description = "Backfill should succeed when aspect is soft-deleted but emitTime is newer (intentional resurrection)")
+  private void verifyBackfillSucceeded(FooUrn urn, AspectFoo newValue, IngestionTrackingContext ctx) {
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, newValue);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, null, newValue, AspectFoo.class, _dummyAuditStamp, ctx, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  // --- Backfill soft-delete bug fix tests ---
+
+  @Test(description = "Backfill no-op: soft-deleted aspect with stale emitTime (step 3)")
+  public void testBackfillNoopWhenSoftDeletedAndEmitTimeIsStale() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(createSoftDeletedEntry(100L)));
+
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(50L); // stale: 50 < 100
+
+    dao.add(urn, new AspectFoo().setValue("newFoo"), _dummyAuditStamp, ctx, null);
+    verifyBackfillNoop(urn, ctx);
+  }
+
+  @Test(description = "Backfill succeeds: soft-deleted aspect with newer emitTime (step 3)")
   public void testBackfillSucceedsWhenSoftDeletedAndEmitTimeIsNewer() throws URISyntaxException {
     FooUrn urn = new FooUrn(1);
     AspectFoo newFoo = new AspectFoo().setValue("resurrectedFoo");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(createSoftDeletedEntry(100L)));
 
-    // Simulate soft-deleted aspect: deletion at time=100
-    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
-    ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
-    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
-        .aspect(null)
-        .extraInfo(extraInfo)
-        .isSoftDeleted(true)
-        .build();
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(200L); // newer: 200 > 100
 
-    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
-        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
-        _dummyLocalDAO._transactionRunner);
-    dummyLocalDAO.setEmitAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
-    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
-    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
-
-    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
-    ingestionTrackingContext.setBackfill(true);
-    ingestionTrackingContext.setEmitTime(200L); // newer: 200 > 100 (deletion time)
-
-    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
-
-    // SHOULD backfill — intentional resurrection
-    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, newFoo);
-    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
-        urn, null, newFoo, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
-    verifyNoMoreInteractions(_mockTrackingEventProducer);
+    dao.add(urn, newFoo, _dummyAuditStamp, ctx, null);
+    verifyBackfillSucceeded(urn, newFoo, ctx);
   }
 
-  @Test(description = "Backfill should be a no-op when soft-deleted and no emitTime provided")
+  @Test(description = "Backfill no-op: soft-deleted aspect with no emitTime (step 2)")
   public void testBackfillNoopWhenSoftDeletedAndNoEmitTime() throws URISyntaxException {
     FooUrn urn = new FooUrn(1);
-    AspectFoo newFoo = new AspectFoo().setValue("newFoo");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(createSoftDeletedEntry(100L)));
 
-    // Simulate soft-deleted aspect: deletion at time=100
-    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
-    ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
-    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    // No emitTime set
+
+    dao.add(urn, new AspectFoo().setValue("newFoo"), _dummyAuditStamp, ctx, null);
+    verifyBackfillNoop(urn, ctx);
+  }
+
+  @Test(description = "Backfill no-op: soft-deleted aspect with emitTime == deletion time (step 3 boundary)")
+  public void testBackfillNoopWhenSoftDeletedAndEmitTimeEqualsDeletionTime() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(createSoftDeletedEntry(100L)));
+
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(100L); // boundary: 100 == 100
+
+    dao.add(urn, new AspectFoo().setValue("newFoo"), _dummyAuditStamp, ctx, null);
+    verifyBackfillNoop(urn, ctx);
+  }
+
+  // Step 1: Aspect never existed — unconditional backfill
+  @Test(description = "Backfill succeeds: aspect never existed (step 1)")
+  public void testBackfillSucceedsWhenAspectNeverExisted() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo newFoo = new AspectFoo().setValue("brandNew");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(makeAspectEntry(null, null)));
+
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    // No emitTime needed — step 1 backfills unconditionally
+
+    dao.add(urn, newFoo, _dummyAuditStamp, ctx, null);
+    verifyBackfillSucceeded(urn, newFoo, ctx);
+  }
+
+  // Step 3: Soft-deleted with missing deletion timestamp — reject with warning
+  @Test(description = "Backfill no-op: soft-deleted aspect with missing deletion timestamp (step 3)")
+  public void testBackfillNoopWhenSoftDeletedAndMissingDeletionTimestamp() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    // Soft-deleted entry with no audit stamp (missing deletion timestamp)
+    BaseLocalDAO.AspectEntry<AspectFoo> entry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
         .aspect(null)
-        .extraInfo(extraInfo)
+        .extraInfo(null)
         .isSoftDeleted(true)
         .build();
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(entry));
 
-    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
-        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
-        _dummyLocalDAO._transactionRunner);
-    dummyLocalDAO.setEmitAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
-    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
-    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(200L);
 
-    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
-    ingestionTrackingContext.setBackfill(true);
-    // No emitTime set — should NOT backfill when soft-deleted
+    dao.add(urn, new AspectFoo().setValue("newFoo"), _dummyAuditStamp, ctx, null);
+    verifyBackfillNoop(urn, ctx);
+  }
 
-    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
+  // Step 4: Existing aspect, oldEmitTime available, stale → reject
+  @Test(description = "Backfill no-op: existing aspect with stale emitTime vs oldEmitTime (step 4)")
+  public void testBackfillNoopWhenExistingAspectAndEmitTimeIsStale() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo existingFoo = new AspectFoo().setValue("existing");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class,
+        Collections.singletonList(createExistingEntry(existingFoo, 100L, 150L)));
 
-    // Should NOT backfill — audit events emitted with old==new==null (no-op pattern)
-    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(50L); // stale: 50 < 150 (oldEmitTime)
+
+    dao.add(urn, new AspectFoo().setValue("newFoo"), _dummyAuditStamp, ctx, null);
+    // No-op: old==new==existingFoo (unchanged)
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, existingFoo, existingFoo);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
-        urn, null, null, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+        urn, existingFoo, existingFoo, AspectFoo.class, _dummyAuditStamp, ctx, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 
-  @Test(description = "Backfill should be a no-op when soft-deleted and emitTime equals deletion timestamp (boundary)")
-  public void testBackfillNoopWhenSoftDeletedAndEmitTimeEqualsDeletionTime() throws URISyntaxException {
+  // Step 4: Existing aspect, oldEmitTime available, newer → backfill
+  @Test(description = "Backfill succeeds: existing aspect with newer emitTime vs oldEmitTime (step 4)")
+  public void testBackfillSucceedsWhenExistingAspectAndEmitTimeIsNewer() throws URISyntaxException {
     FooUrn urn = new FooUrn(1);
-    AspectFoo newFoo = new AspectFoo().setValue("newFoo");
+    AspectFoo existingFoo = new AspectFoo().setValue("existing");
+    AspectFoo newFoo = new AspectFoo().setValue("updated");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class,
+        Collections.singletonList(createExistingEntry(existingFoo, 100L, 150L)));
 
-    // Simulate soft-deleted aspect: deletion at time=100
-    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
-    ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
-    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
-        .aspect(null)
-        .extraInfo(extraInfo)
-        .isSoftDeleted(true)
-        .build();
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(200L); // newer: 200 > 150 (oldEmitTime)
 
-    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
-        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
-        _dummyLocalDAO._transactionRunner);
-    dummyLocalDAO.setEmitAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
-    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
-    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
-    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
-
-    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
-    ingestionTrackingContext.setBackfill(true);
-    ingestionTrackingContext.setEmitTime(100L); // exact boundary: 100 == 100 (deletion time) → no-op
-
-    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
-
-    // Should NOT backfill — event at same ms as deletion is treated as stale (strict >)
-    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
+    dao.add(urn, newFoo, _dummyAuditStamp, ctx, null);
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, existingFoo, newFoo);
     verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
-        urn, null, null, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+        urn, existingFoo, newFoo, AspectFoo.class, _dummyAuditStamp, ctx, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  // Step 5: Existing aspect, no oldEmitTime, fallback to audit stamp, stale → reject
+  @Test(description = "Backfill no-op: existing aspect with stale emitTime vs audit stamp fallback (step 5)")
+  public void testBackfillNoopWhenExistingAspectAndFallbackAuditStampIsNewer() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo existingFoo = new AspectFoo().setValue("existing");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    // No emitTime on the existing entry — forces fallback to audit stamp
+    expectGetLatest(urn, AspectFoo.class,
+        Collections.singletonList(createExistingEntry(existingFoo, 150L, null)));
+
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(50L); // stale: 50 < 150 (audit stamp time)
+
+    dao.add(urn, new AspectFoo().setValue("newFoo"), _dummyAuditStamp, ctx, null);
+    // No-op: old==new==existingFoo (unchanged)
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, existingFoo, existingFoo);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, existingFoo, existingFoo, AspectFoo.class, _dummyAuditStamp, ctx, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  // Step 5: Existing aspect, no oldEmitTime, fallback to audit stamp, newer → backfill
+  @Test(description = "Backfill succeeds: existing aspect with newer emitTime vs audit stamp fallback (step 5)")
+  public void testBackfillSucceedsWhenExistingAspectAndFallbackAuditStampIsOlder() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo existingFoo = new AspectFoo().setValue("existing");
+    AspectFoo newFoo = new AspectFoo().setValue("updated");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    expectGetLatest(urn, AspectFoo.class,
+        Collections.singletonList(createExistingEntry(existingFoo, 100L, null)));
+
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(200L); // newer: 200 > 100 (audit stamp time)
+
+    dao.add(urn, newFoo, _dummyAuditStamp, ctx, null);
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, existingFoo, newFoo);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, existingFoo, newFoo, AspectFoo.class, _dummyAuditStamp, ctx, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  // Step 5: Existing aspect, no oldEmitTime, no audit stamp → reject
+  @Test(description = "Backfill no-op: existing aspect with no oldEmitTime and no audit stamp (step 5)")
+  public void testBackfillNoopWhenExistingAspectAndNoTimestampsAvailable() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo existingFoo = new AspectFoo().setValue("existing");
+    DummyLocalDAO<EntityAspectUnion> dao = createBackfillTestDAO();
+    // No extraInfo at all — no emitTime, no audit stamp
+    expectGetLatest(urn, AspectFoo.class,
+        Collections.singletonList(new BaseLocalDAO.AspectEntry<>(existingFoo, null)));
+
+    IngestionTrackingContext ctx = new IngestionTrackingContext();
+    ctx.setBackfill(true);
+    ctx.setEmitTime(200L);
+
+    dao.add(urn, new AspectFoo().setValue("newFoo"), _dummyAuditStamp, ctx, null);
+    // No-op: old==new==existingFoo (unchanged)
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, existingFoo, existingFoo);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, existingFoo, existingFoo, AspectFoo.class, _dummyAuditStamp, ctx, IngestionMode.LIVE);
     verifyNoMoreInteractions(_mockTrackingEventProducer);
   }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -865,4 +865,114 @@ public class BaseLocalDAOTest {
     // invalid, should skip
     assertEquals(_dummyLocalDAO.aspectTimestampSkipWrite(null, null), false);
   }
+
+  // --- Backfill soft-delete bug fix tests ---
+
+  @Test(description = "Backfill should be a no-op when aspect is soft-deleted and emitTime is stale")
+  public void testBackfillNoopWhenSoftDeletedAndEmitTimeIsStale() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo newFoo = new AspectFoo().setValue("newFoo");
+
+    // Simulate soft-deleted aspect: oldValue=null, isSoftDeleted=true, deletion at time=100
+    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
+    ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
+    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
+        .aspect(null)
+        .extraInfo(extraInfo)
+        .isSoftDeleted(true)
+        .build();
+
+    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
+        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
+        _dummyLocalDAO._transactionRunner);
+    dummyLocalDAO.setEmitAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
+    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
+
+    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
+    ingestionTrackingContext.setBackfill(true);
+    ingestionTrackingContext.setEmitTime(50L); // stale: 50 < 100 (deletion time)
+
+    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
+
+    // Should NOT backfill — audit events emitted with old==new==null (no-op pattern)
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, null, null, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  @Test(description = "Backfill should succeed when aspect is soft-deleted but emitTime is newer (intentional resurrection)")
+  public void testBackfillSucceedsWhenSoftDeletedAndEmitTimeIsNewer() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo newFoo = new AspectFoo().setValue("resurrectedFoo");
+
+    // Simulate soft-deleted aspect: deletion at time=100
+    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
+    ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
+    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
+        .aspect(null)
+        .extraInfo(extraInfo)
+        .isSoftDeleted(true)
+        .build();
+
+    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
+        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
+        _dummyLocalDAO._transactionRunner);
+    dummyLocalDAO.setEmitAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
+    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
+
+    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
+    ingestionTrackingContext.setBackfill(true);
+    ingestionTrackingContext.setEmitTime(200L); // newer: 200 >= 100 (deletion time)
+
+    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
+
+    // SHOULD backfill — intentional resurrection
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, newFoo);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, null, newFoo, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
+
+  @Test(description = "Backfill should be a no-op when soft-deleted and no emitTime provided")
+  public void testBackfillNoopWhenSoftDeletedAndNoEmitTime() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo newFoo = new AspectFoo().setValue("newFoo");
+
+    // Simulate soft-deleted aspect: deletion at time=100
+    AuditStamp deletionAuditStamp = makeAuditStamp("deleter", 100L);
+    ExtraInfo extraInfo = new ExtraInfo().setAudit(deletionAuditStamp);
+    BaseLocalDAO.AspectEntry<AspectFoo> softDeletedEntry = BaseLocalDAO.AspectEntry.<AspectFoo>builder()
+        .aspect(null)
+        .extraInfo(extraInfo)
+        .isSoftDeleted(true)
+        .build();
+
+    DummyLocalDAO<EntityAspectUnion> dummyLocalDAO = new DummyLocalDAO<>(EntityAspectUnion.class,
+        _mockGetLatestFunction, _mockTrackingEventProducer, _mockTrackingManager,
+        _dummyLocalDAO._transactionRunner);
+    dummyLocalDAO.setEmitAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAuditEvent(true);
+    dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
+    dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
+    expectGetLatest(urn, AspectFoo.class, Collections.singletonList(softDeletedEntry));
+
+    IngestionTrackingContext ingestionTrackingContext = new IngestionTrackingContext();
+    ingestionTrackingContext.setBackfill(true);
+    // No emitTime set — should NOT backfill when soft-deleted
+
+    dummyLocalDAO.add(urn, newFoo, _dummyAuditStamp, ingestionTrackingContext, null);
+
+    // Should NOT backfill — audit events emitted with old==new==null (no-op pattern)
+    verify(_mockTrackingEventProducer, times(1)).produceMetadataAuditEvent(urn, null, null);
+    verify(_mockTrackingEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        urn, null, null, AspectFoo.class, _dummyAuditStamp, ingestionTrackingContext, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockTrackingEventProducer);
+  }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -147,7 +147,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
     // newValue is null if aspect is to be soft-deleted.
     if (newValue == null) {
-      String deletedValue = EBeanDAOUtils.buildDeletedValue(utcTimestamp, actor);
+      String deletedValue = EBeanDAOUtils.buildDeletedValue(timestamp, actor);
       return sqlUpdate.setParameter("metadata", deletedValue).execute();
     }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -147,7 +147,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
     // newValue is null if aspect is to be soft-deleted.
     if (newValue == null) {
-      return sqlUpdate.setParameter("metadata", DELETED_VALUE).execute();
+      String deletedValue = EBeanDAOUtils.buildDeletedValue(utcTimestamp, actor);
+      return sqlUpdate.setParameter("metadata", deletedValue).execute();
     }
 
     AuditedAspect auditedAspect = new AuditedAspect()

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -65,17 +65,24 @@ public class EBeanDAOUtils {
       .toFormatter();
   public static final String DIFFERENT_RESULTS_TEMPLATE = "The results of %s from the new schema table and old schema table are not equal. Reason: %s. "
       + "Defaulting to using the value(s) from the old schema table.";
-  // Bare soft-delete marker (legacy format, used only for detection/filtering of old rows)
+  /**
+   * @deprecated Use {@link #isSoftDeletedMetadata(String)} for detection and {@link #buildDeletedValue(long, String)} for writing.
+   */
+  @Deprecated
   private static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
+  /**
+   * @deprecated Use {@link #isSoftDeletedMetadata(String)} for detection and {@link #buildDeletedValue(long, String)} for writing.
+   */
+  @Deprecated
   public static final String DELETED_VALUE = RecordUtils.toJsonString(DELETED_METADATA);
 
   /**
    * Build an enriched soft-delete marker JSON with deletion audit metadata.
-   * @param deletedTimestamp the deletion timestamp string (DB lastmodifiedon format, e.g. "2026-03-06 18:41:59.000")
+   * @param deletedTimestamp the deletion timestamp in epoch millis
    * @param deletedBy who deleted the aspect (corpuser URN or "backfill")
-   * @return JSON string like {"gma_deleted":true,"deleted_timestamp":"...","deleted_by":"..."}
+   * @return JSON string like {"gma_deleted":true,"deleted_timestamp":1741286519000,"deleted_by":"..."}
    */
-  public static String buildDeletedValue(@Nonnull String deletedTimestamp, @Nonnull String deletedBy) {
+  public static String buildDeletedValue(long deletedTimestamp, @Nonnull String deletedBy) {
     SoftDeletedAspect softDeletedAspect = new SoftDeletedAspect().setGma_deleted(true);
     softDeletedAspect.setDeleted_timestamp(deletedTimestamp);
     softDeletedAspect.setDeleted_by(deletedBy);
@@ -94,6 +101,7 @@ public class EBeanDAOUtils {
       SoftDeletedAspect aspect = RecordUtils.toRecordTemplate(SoftDeletedAspect.class, metadata);
       return aspect.hasGma_deleted() && aspect.isGma_deleted();
     } catch (Exception e) {
+      log.debug("Failed to parse metadata as SoftDeletedAspect: {}", metadata, e);
       return false;
     }
   }
@@ -309,15 +317,15 @@ public class EBeanDAOUtils {
       // Try to extract per-aspect deletion timestamp from the enriched soft-delete JSON.
       // Fall back to entity-level lastmodifiedon for legacy rows that only have {"gma_deleted":true}.
       SoftDeletedAspect softDeletedAspect = RecordUtils.toRecordTemplate(SoftDeletedAspect.class, sqlRow.getString(columnName));
-      String deletionTimestamp = softDeletedAspect.hasDeleted_timestamp()
-          ? softDeletedAspect.getDeleted_timestamp()
-          : sqlRow.getString("lastmodifiedon");
+      Timestamp deletionTimestamp = softDeletedAspect.hasDeleted_timestamp()
+          ? new Timestamp(softDeletedAspect.getDeleted_timestamp())
+          : timeStampStringToTimeStamp(sqlRow.getString("lastmodifiedon"));
       String deletedBy = softDeletedAspect.hasDeleted_by()
           ? softDeletedAspect.getDeleted_by()
           : sqlRow.getString("lastmodifiedby");
 
       ebeanMetadataAspect.setCreatedBy(deletedBy);
-      ebeanMetadataAspect.setCreatedOn(timeStampStringToTimeStamp(deletionTimestamp));
+      ebeanMetadataAspect.setCreatedOn(deletionTimestamp);
       ebeanMetadataAspect.setCreatedFor(sqlRow.getString("createdfor"));
       ebeanMetadataAspect.setMetadata(sqlRow.getString(columnName));
     } else {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -65,9 +65,38 @@ public class EBeanDAOUtils {
       .toFormatter();
   public static final String DIFFERENT_RESULTS_TEMPLATE = "The results of %s from the new schema table and old schema table are not equal. Reason: %s. "
       + "Defaulting to using the value(s) from the old schema table.";
-  // String stored in metadata_aspect table for soft deleted aspect
+  // Bare soft-delete marker (legacy format, used only for detection/filtering of old rows)
   private static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
   public static final String DELETED_VALUE = RecordUtils.toJsonString(DELETED_METADATA);
+
+  /**
+   * Build an enriched soft-delete marker JSON with deletion audit metadata.
+   * @param deletedTimestamp the deletion timestamp string (DB lastmodifiedon format, e.g. "2026-03-06 18:41:59.000")
+   * @param deletedBy who deleted the aspect (corpuser URN or "backfill")
+   * @return JSON string like {"gma_deleted":true,"deleted_timestamp":"...","deleted_by":"..."}
+   */
+  public static String buildDeletedValue(@Nonnull String deletedTimestamp, @Nonnull String deletedBy) {
+    SoftDeletedAspect softDeletedAspect = new SoftDeletedAspect().setGma_deleted(true);
+    softDeletedAspect.setDeleted_timestamp(deletedTimestamp);
+    softDeletedAspect.setDeleted_by(deletedBy);
+    return RecordUtils.toJsonString(softDeletedAspect);
+  }
+
+  /**
+   * Check if a metadata JSON string represents a soft-deleted aspect.
+   * Handles both legacy format {"gma_deleted":true} and enriched format with extra fields.
+   */
+  public static boolean isSoftDeletedMetadata(@Nullable String metadata) {
+    if (metadata == null) {
+      return false;
+    }
+    try {
+      SoftDeletedAspect aspect = RecordUtils.toRecordTemplate(SoftDeletedAspect.class, metadata);
+      return aspect.hasGma_deleted() && aspect.isGma_deleted();
+    } catch (Exception e) {
+      return false;
+    }
+  }
   private static final long LATEST_VERSION = 0L;
 
   private EBeanDAOUtils() {
@@ -202,9 +231,7 @@ public class EBeanDAOUtils {
    */
   public static <ASPECT extends RecordTemplate> boolean isSoftDeletedAspect(@Nonnull EbeanMetadataAspect aspect,
       @Nonnull Class<ASPECT> aspectClass) {
-    // Convert metadata string to record template object
-    final RecordTemplate metadataRecord = RecordUtils.toRecordTemplate(aspectClass, aspect.getMetadata());
-    return metadataRecord.equals(DELETED_METADATA);
+    return isSoftDeletedMetadata(aspect.getMetadata());
   }
 
 
@@ -278,12 +305,21 @@ public class EBeanDAOUtils {
     }
     if (isSoftDeletedAspect(sqlRow, columnName)) {
       primaryKey = new EbeanMetadataAspect.PrimaryKey(urn, aspectClass.getCanonicalName(), LATEST_VERSION);
-      ebeanMetadataAspect.setCreatedBy(sqlRow.getString("lastmodifiedby"));
 
-      ebeanMetadataAspect.setCreatedOn(timeStampStringToTimeStamp(sqlRow.getString("lastmodifiedon")));
+      // Try to extract per-aspect deletion timestamp from the enriched soft-delete JSON.
+      // Fall back to entity-level lastmodifiedon for legacy rows that only have {"gma_deleted":true}.
+      SoftDeletedAspect softDeletedAspect = RecordUtils.toRecordTemplate(SoftDeletedAspect.class, sqlRow.getString(columnName));
+      String deletionTimestamp = softDeletedAspect.hasDeleted_timestamp()
+          ? softDeletedAspect.getDeleted_timestamp()
+          : sqlRow.getString("lastmodifiedon");
+      String deletedBy = softDeletedAspect.hasDeleted_by()
+          ? softDeletedAspect.getDeleted_by()
+          : sqlRow.getString("lastmodifiedby");
 
+      ebeanMetadataAspect.setCreatedBy(deletedBy);
+      ebeanMetadataAspect.setCreatedOn(timeStampStringToTimeStamp(deletionTimestamp));
       ebeanMetadataAspect.setCreatedFor(sqlRow.getString("createdfor"));
-      ebeanMetadataAspect.setMetadata(DELETED_VALUE);
+      ebeanMetadataAspect.setMetadata(sqlRow.getString(columnName));
     } else {
       AuditedAspect auditedAspect = RecordUtils.toRecordTemplate(AuditedAspect.class, sqlRow.getString(columnName));
       primaryKey = new EbeanMetadataAspect.PrimaryKey(urn, auditedAspect.getCanonicalName(), LATEST_VERSION);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -66,11 +66,13 @@ public class EBeanDAOUtils {
   public static final String DIFFERENT_RESULTS_TEMPLATE = "The results of %s from the new schema table and old schema table are not equal. Reason: %s. "
       + "Defaulting to using the value(s) from the old schema table.";
   /**
+   * Bare soft-delete marker (legacy format).
    * @deprecated Use {@link #isSoftDeletedMetadata(String)} for detection and {@link #buildDeletedValue(long, String)} for writing.
    */
   @Deprecated
   private static final RecordTemplate DELETED_METADATA = new SoftDeletedAspect().setGma_deleted(true);
   /**
+   * Bare soft-delete marker JSON (legacy format).
    * @deprecated Use {@link #isSoftDeletedMetadata(String)} for detection and {@link #buildDeletedValue(long, String)} for writing.
    */
   @Deprecated

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -520,4 +520,33 @@ public class EbeanLocalAccessTest {
     int numRowsDeleted = _ebeanLocalAccessFoo.softDeleteAsset(fooUrn, false);
     assertEquals(numRowsDeleted, 1);
   }
+
+  @Test
+  public void testSoftDeleteWritesEnrichedJson() {
+    // Given: an existing aspect
+    FooUrn fooUrn = makeFooUrn(300);
+    AspectFoo aspectFoo = new AspectFoo().setValue("toBeDeleted");
+    long deleteTime = System.currentTimeMillis();
+    AuditStamp auditStamp = makeAuditStamp("urn:li:corpuser:deleter", deleteTime);
+    _ebeanLocalAccessFoo.add(fooUrn, aspectFoo, AspectFoo.class, auditStamp, null, false);
+
+    // When: soft-delete the aspect (newValue = null)
+    _ebeanLocalAccessFoo.add(fooUrn, null, AspectFoo.class, auditStamp, null, false);
+
+    // Then: the stored JSON should contain deleted_timestamp and deleted_by
+    String aspectColumn = com.linkedin.metadata.dao.utils.SQLSchemaUtils.getAspectColumnName("foo", AspectFoo.class);
+    String query = String.format("SELECT %s FROM metadata_entity_foo WHERE urn = '%s'", aspectColumn, fooUrn);
+    SqlRow row = _server.createSqlQuery(query).findOne();
+    assertNotNull(row);
+    String metadata = row.getString(aspectColumn);
+    assertNotNull(metadata);
+
+    // Verify it's detected as soft-deleted
+    assertTrue(com.linkedin.metadata.dao.utils.EBeanDAOUtils.isSoftDeletedMetadata(metadata));
+
+    // Verify it contains the enriched fields
+    assertTrue(metadata.contains("deleted_timestamp"));
+    assertTrue(metadata.contains("deleted_by"));
+    assertTrue(metadata.contains("deleter"));
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -4,10 +4,12 @@ import com.google.common.io.Resources;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
+import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
 import com.linkedin.metadata.dao.utils.EmbeddedMariaInstance;
 import com.linkedin.metadata.dao.utils.FooUrnPathExtractor;
 import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.dao.utils.SQLIndexFilterUtils;
+import com.linkedin.metadata.dao.utils.SQLSchemaUtils;
 import com.linkedin.metadata.dao.utils.SchemaValidatorUtil;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.IndexCriterion;
@@ -534,7 +536,7 @@ public class EbeanLocalAccessTest {
     _ebeanLocalAccessFoo.add(fooUrn, null, AspectFoo.class, auditStamp, null, false);
 
     // Then: the stored JSON should contain deleted_timestamp and deleted_by
-    String aspectColumn = com.linkedin.metadata.dao.utils.SQLSchemaUtils.getAspectColumnName("foo", AspectFoo.class);
+    String aspectColumn = SQLSchemaUtils.getAspectColumnName("foo", AspectFoo.class);
     String query = String.format("SELECT %s FROM metadata_entity_foo WHERE urn = '%s'", aspectColumn, fooUrn);
     SqlRow row = _server.createSqlQuery(query).findOne();
     assertNotNull(row);
@@ -542,7 +544,7 @@ public class EbeanLocalAccessTest {
     assertNotNull(metadata);
 
     // Verify it's detected as soft-deleted
-    assertTrue(com.linkedin.metadata.dao.utils.EBeanDAOUtils.isSoftDeletedMetadata(metadata));
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(metadata));
 
     // Verify it contains the enriched fields
     assertTrue(metadata.contains("deleted_timestamp"));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -579,7 +579,7 @@ public class EBeanDAOUtilsTest {
   public void testIsSoftDeletedAspectWithEnrichedJson() {
     // Enriched format with deleted_timestamp and deleted_by should also be detected as soft-deleted
     SqlRow sqlRow = mock(SqlRow.class);
-    String enrichedJson = "{\"gma_deleted\": true, \"deleted_timestamp\": \"2026-03-06 18:41:59.000\", \"deleted_by\": \"urn:li:corpuser:testuser\"}";
+    String enrichedJson = "{\"gma_deleted\": true, \"deleted_timestamp\": 1741286519000, \"deleted_by\": \"urn:li:corpuser:testuser\"}";
     when(sqlRow.getString("a_aspectfoo")).thenReturn(enrichedJson);
     assertTrue(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, "a_aspectfoo"));
   }
@@ -595,7 +595,7 @@ public class EBeanDAOUtilsTest {
     assertTrue(EBeanDAOUtils.isSoftDeletedAspect(aspect, AspectFoo.class));
 
     // Enriched format
-    aspect.setMetadata("{\"gma_deleted\":true,\"deleted_timestamp\":\"2026-03-06 18:41:59.000\",\"deleted_by\":\"urn:li:corpuser:testuser\"}");
+    aspect.setMetadata("{\"gma_deleted\":true,\"deleted_timestamp\":1741286519000,\"deleted_by\":\"urn:li:corpuser:testuser\"}");
     assertTrue(EBeanDAOUtils.isSoftDeletedAspect(aspect, AspectFoo.class));
 
     // Non-deleted aspect
@@ -605,12 +605,12 @@ public class EBeanDAOUtilsTest {
 
   @Test
   public void testBuildDeletedValue() {
-    String result = EBeanDAOUtils.buildDeletedValue("2026-03-06 18:41:59.000", "urn:li:corpuser:testuser");
+    String result = EBeanDAOUtils.buildDeletedValue(1741286519000L, "urn:li:corpuser:testuser");
     assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(result));
 
     // Verify the enriched fields are in the JSON
     assertTrue(result.contains("gma_deleted"));
-    assertTrue(result.contains("2026-03-06 18:41:59.000"));
+    assertTrue(result.contains("1741286519000"));
     assertTrue(result.contains("urn:li:corpuser:testuser"));
   }
 
@@ -621,7 +621,7 @@ public class EBeanDAOUtilsTest {
 
     // Enriched format
     assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(
-        "{\"gma_deleted\":true,\"deleted_timestamp\":\"2026-03-06 18:41:59.000\",\"deleted_by\":\"urn:li:corpuser:testuser\"}"));
+        "{\"gma_deleted\":true,\"deleted_timestamp\":1741286519000,\"deleted_by\":\"urn:li:corpuser:testuser\"}"));
 
     // Not soft-deleted
     assertFalse(EBeanDAOUtils.isSoftDeletedMetadata("{\"value\":\"foo\"}"));

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -576,6 +576,60 @@ public class EBeanDAOUtilsTest {
   }
 
   @Test
+  public void testIsSoftDeletedAspectWithEnrichedJson() {
+    // Enriched format with deleted_timestamp and deleted_by should also be detected as soft-deleted
+    SqlRow sqlRow = mock(SqlRow.class);
+    String enrichedJson = "{\"gma_deleted\": true, \"deleted_timestamp\": \"2026-03-06 18:41:59.000\", \"deleted_by\": \"urn:li:corpuser:testuser\"}";
+    when(sqlRow.getString("a_aspectfoo")).thenReturn(enrichedJson);
+    assertTrue(EBeanDAOUtils.isSoftDeletedAspect(sqlRow, "a_aspectfoo"));
+  }
+
+  @Test
+  public void testIsSoftDeletedAspectOnEbeanMetadataAspectWithEnrichedJson() {
+    // isSoftDeletedAspect(EbeanMetadataAspect, Class) should detect enriched JSON
+    EbeanMetadataAspect aspect = new EbeanMetadataAspect();
+    aspect.setKey(new EbeanMetadataAspect.PrimaryKey("urn:li:foo:1", AspectFoo.class.getCanonicalName(), 0));
+
+    // Legacy format
+    aspect.setMetadata("{\"gma_deleted\":true}");
+    assertTrue(EBeanDAOUtils.isSoftDeletedAspect(aspect, AspectFoo.class));
+
+    // Enriched format
+    aspect.setMetadata("{\"gma_deleted\":true,\"deleted_timestamp\":\"2026-03-06 18:41:59.000\",\"deleted_by\":\"urn:li:corpuser:testuser\"}");
+    assertTrue(EBeanDAOUtils.isSoftDeletedAspect(aspect, AspectFoo.class));
+
+    // Non-deleted aspect
+    aspect.setMetadata("{\"value\":\"foo\"}");
+    assertFalse(EBeanDAOUtils.isSoftDeletedAspect(aspect, AspectFoo.class));
+  }
+
+  @Test
+  public void testBuildDeletedValue() {
+    String result = EBeanDAOUtils.buildDeletedValue("2026-03-06 18:41:59.000", "urn:li:corpuser:testuser");
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(result));
+
+    // Verify the enriched fields are in the JSON
+    assertTrue(result.contains("gma_deleted"));
+    assertTrue(result.contains("2026-03-06 18:41:59.000"));
+    assertTrue(result.contains("urn:li:corpuser:testuser"));
+  }
+
+  @Test
+  public void testIsSoftDeletedMetadata() {
+    // Legacy format
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata("{\"gma_deleted\":true}"));
+
+    // Enriched format
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(
+        "{\"gma_deleted\":true,\"deleted_timestamp\":\"2026-03-06 18:41:59.000\",\"deleted_by\":\"urn:li:corpuser:testuser\"}"));
+
+    // Not soft-deleted
+    assertFalse(EBeanDAOUtils.isSoftDeletedMetadata("{\"value\":\"foo\"}"));
+    assertFalse(EBeanDAOUtils.isSoftDeletedMetadata(null));
+    assertFalse(EBeanDAOUtils.isSoftDeletedMetadata(""));
+  }
+
+  @Test
   public void testBuildRelationshipFieldCriterionWithAspectField() {
     LocalRelationshipValue localRelationshipValue = LocalRelationshipValue.create(new StringArray("bar"));
     Condition condition = Condition.IN;

--- a/docs/backfill-soft-deleted-aspects.md
+++ b/docs/backfill-soft-deleted-aspects.md
@@ -1,0 +1,67 @@
+# Backfill Logic for Soft-Deleted Aspects
+
+## Overview
+
+GMA's backfill path now fully accounts for soft-deleted aspects. Previously, the backfill logic only distinguished
+between "aspect exists" and "aspect does not exist." A soft-deleted aspect appeared identical to one that had never been
+written, so backfill events would unconditionally overwrite the soft-delete marker and silently resurrect deleted data.
+The updated logic treats soft-deleted aspects as a distinct state with its own staleness rules.
+
+## How Backfill Decisions Work
+
+When a backfill event arrives, `BaseLocalDAO.shouldBackfill()` evaluates the current state of the aspect through a
+series of checks:
+
+1. **Aspect has never existed** — If there is no value and the aspect is not soft-deleted, the backfill is accepted
+   unconditionally. This is the only scenario where emitTime is not required, since there is nothing to compare against.
+
+2. **No emitTime on the backfill event** — All remaining scenarios (soft-deleted or existing value) require the backfill
+   event to carry an `emitTime` for staleness comparison. If emitTime is absent, the backfill is rejected to avoid
+   blindly overwriting current state.
+
+3. **Aspect is soft-deleted** — The backfill's emitTime is compared against the per-aspect deletion timestamp (stored in
+   `SoftDeletedAspect.deleted_timestamp` and surfaced via `oldAuditStamp.getTime()`). The comparison uses strict
+   greater-than (`>`): an event at the exact same millisecond as the deletion is treated as stale, since it was likely
+   in-flight when the delete occurred. If the deletion timestamp is missing or invalid, the backfill is rejected with a
+   warning log.
+
+4. **Aspect exists with a current value** — Standard staleness check. The backfill's emitTime is compared against the
+   existing event's emitTime (preferred) or, if unavailable, the aspect's last-modified audit timestamp as a fallback.
+
+## Enriched Soft-Delete Metadata
+
+To support per-aspect staleness comparisons, soft-delete markers now carry audit metadata beyond the original
+`{"gma_deleted": true}` flag:
+
+- `deleted_timestamp` (long, epoch millis) — when the aspect was soft-deleted
+- `deleted_by` (string) — who deleted the aspect (corpuser URN or "backfill")
+
+This is modeled via `SoftDeletedAspect.pdl` and serialized as JSON in the aspect column. The enriched format eliminates
+the previous `long → String → Timestamp → long` conversion chain by storing the deletion timestamp directly as epoch
+millis.
+
+## Backward Compatibility
+
+The system handles both legacy and enriched soft-delete formats transparently:
+
+- **Legacy format** (`{"gma_deleted": true}`) — Still recognized as soft-deleted. When reading legacy rows, the system
+  falls back to the entity-level `lastmodifiedon` column for the deletion timestamp and `lastmodifiedby` for the actor.
+- **Enriched format**
+  (`{"gma_deleted": true, "deleted_timestamp": 1741286519000, "deleted_by": "urn:li:corpuser:actor"}`) — Per-aspect
+  deletion metadata is used directly.
+
+No database migration is required. New soft-delete writes produce the enriched format, while reads handle both formats.
+
+## Version History Preservation
+
+When a backfill event passes the staleness check and overwrites a soft-deleted aspect, the soft-delete marker is saved
+as a historical version via `saveLatest`. This preserves the full audit trail — the version history shows the deletion
+event followed by the backfill restoration, rather than the deletion being silently lost.
+
+## Key Files
+
+- `BaseLocalDAO.java` — `shouldBackfill()` with the five-step decision logic described above
+- `EBeanDAOUtils.java` — `buildDeletedValue()` for writing enriched markers, `isSoftDeletedMetadata()` for detection
+- `EbeanLocalAccess.java` — Writes enriched soft-delete JSON when an aspect is deleted
+- `SoftDeletedAspect.pdl` — PDL schema for the soft-delete marker with audit fields
+- `AspectEntry.java` — Carries `isSoftDeleted` state through the DAO layer

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
@@ -9,4 +9,14 @@ record SoftDeletedAspectCopy {
    * flag to indicate if the aspect is soft deleted in GMA
    */
   gma_deleted: boolean
+
+  /**
+   * Timestamp of when the aspect was soft deleted
+   */
+  deleted_timestamp: optional string
+
+  /**
+   * Identity of who deleted the aspect
+   */
+  deleted_by: optional string
 }

--- a/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
+++ b/testing/test-models/src/main/pegasus/com/linkedin/testing/SoftDeletedAspectCopy.pdl
@@ -13,7 +13,7 @@ record SoftDeletedAspectCopy {
   /**
    * Timestamp of when the aspect was soft deleted
    */
-  deleted_timestamp: optional string
+  deleted_timestamp: optional long
 
   /**
    * Identity of who deleted the aspect

--- a/validators/src/main/pegasus/com/linkedin/metadata/aspect/SoftDeletedAspect.pdl
+++ b/validators/src/main/pegasus/com/linkedin/metadata/aspect/SoftDeletedAspect.pdl
@@ -11,9 +11,9 @@ record SoftDeletedAspect {
   gma_deleted: boolean
 
   /**
-   * Timestamp of when the aspect was soft deleted (string format matching DB lastmodifiedon column, e.g. "2026-03-06 18:41:59.000")
+   * Timestamp of when the aspect was soft deleted (epoch millis)
    */
-  deleted_timestamp: optional string
+  deleted_timestamp: optional long
 
   /**
    * Identity of who deleted the aspect (corpuser URN or "backfill" for backfilled rows)

--- a/validators/src/main/pegasus/com/linkedin/metadata/aspect/SoftDeletedAspect.pdl
+++ b/validators/src/main/pegasus/com/linkedin/metadata/aspect/SoftDeletedAspect.pdl
@@ -9,4 +9,14 @@ record SoftDeletedAspect {
    * Flag to indicate if the aspect is soft deleted in GMA
    */
   gma_deleted: boolean
+
+  /**
+   * Timestamp of when the aspect was soft deleted (string format matching DB lastmodifiedon column, e.g. "2026-03-06 18:41:59.000")
+   */
+  deleted_timestamp: optional string
+
+  /**
+   * Identity of who deleted the aspect (corpuser URN or "backfill" for backfilled rows)
+   */
+  deleted_by: optional string
 }


### PR DESCRIPTION
## Summary
Fix two backfill logic gaps that allow stale events to resurrect soft-deleted aspects.

**RFC:** https://docs.google.com/document/d/1zOKrxbm_zGxTpMwJ7Wer7owY-YcI0nXDvY6DWRGXj0M/edit?tab=t.0

**Scope:** Aspect-level soft deletion on new schema only. Old schema and asset-level deletion (`deleted_ts`) are out of scope for this PR.

### Problem
All these gaps are reproduced in EI and captured in this doc: [Backfill Gaps in EI ](https://docs.google.com/document/d/17XNuwhBBanPuT5w5Bo-40ozN5bhTSSqyHxSTYaiXybs/edit?tab=t.0)
### Gap 1: `shouldBackfill()` treats soft-deleted aspects as "never existed"

**Problem:** When a backfill event arrives for a soft-deleted aspect, `oldValue == null` caused the code to short-circuit to `shouldBackfill=true` without checking `isSoftDeleted`. Stale DLQ replays could silently resurrect deleted aspects.

**Fix:** Replace the single boolean expression with a three-way branch in `shouldBackfill()`:

  | Condition | Behavior |
  |-----------|----------|
  | `oldValue == null && !isSoftDeleted` | Aspect never existed — allow backfill unconditionally |
  | `oldValue == null && isSoftDeleted` | Compare `emitTime > deletionTimestamp`; only allow if newer |
  | `oldValue != null` | Existing emitTime comparison(unchanged) |


Additionally: reject backfill if `emitTime` is missing (cannot assess staleness), and log a warning if deletion timestamp is missing/invalid.

### Gap 2: Entity-level `lastmodifiedon` used as deletion timestamp (timestamp corruption)

  **Problem:** The entity table has a single `lastmodifiedon` column shared across ALL aspects. When aspect A is deleted at T1, then aspect B is updated at T2, the `lastmodifiedon` bumps to T2. The Gap 1 fix compares `emitTime > oldAuditStamp.getTime()`, but `oldAuditStamp` was reading from this shared column — returning T2 instead of T1.
The soft-delete marker `{"gma_deleted":true}` had no embedded timestamp, so there was no per-aspect deletion time to compare against.

**Fix:** Enrich the soft-delete marker JSON with per-aspect deletion metadata:

  ```json
  // Before (legacy)
  {"gma_deleted": true}

  // After (enriched)
  {"gma_deleted": true, "deleted_timestamp": "2026-03-06 18:41:59.000", "deleted_by": "urn:li:corpuser:actor"}

```

  Write side (EbeanLocalAccess.addWithOptimisticLocking): When soft-deleting, build enriched JSON with deleted_timestamp and deleted_by instead of the bare marker.

  Read side (EBeanDAOUtils.readSqlRow): For soft-deleted aspects, extract deleted_timestamp from the enriched JSON. Falls back to entity-level lastmodifiedon for legacy rows that only have {"gma_deleted":true}.

  Detection (EBeanDAOUtils.isSoftDeletedAspect): Changed from exact string equals to parsing-based check (gma_deleted == true), so enriched JSON with extra fields is still correctly identified as soft-deleted.
 
Backward Compatibility

  - Legacy rows with {"gma_deleted":true} continue to work — detection falls back to entity-level lastmodifiedon (same behavior as before)
  - New fields in SoftDeletedAspect.pdl are optional — no schema migration required
  - Old schema paths (metadata_aspect table, .ne(METADATA_COLUMN, DELETED_VALUE) filters) are unchanged
  
### Testing Done

<img width="1155" height="147" alt="Screenshot 2026-03-06 at 4 11 28 PM" src="https://github.com/user-attachments/assets/88a320a9-325e-4cab-945d-ea8b41ff8e28" />


  Unit tests added:
  - testIsSoftDeletedAspectWithEnrichedJson — enriched JSON detected by SqlRow-based check
  - testIsSoftDeletedAspectOnEbeanMetadataAspectWithEnrichedJson — both legacy and enriched detected
  - testBuildDeletedValue — enriched JSON contains timestamp and actor
  - testIsSoftDeletedMetadata — handles legacy, enriched, non-deleted, null, empty
  - testSoftDeleteWritesEnrichedJson — end-to-end: soft-delete writes enriched JSON to DB

  Existing tests (from prior commits):
  - testBackfillNoopWhenSoftDeletedAndEmitTimeIsStale
  - testBackfillSucceedsWhenSoftDeletedAndEmitTimeIsNewer
  - testBackfillNoopWhenSoftDeletedAndNoEmitTime
  - testBackfillNoopWhenSoftDeletedAndEmitTimeEqualsDeletionTime
  - testBackfillNoopWhenSoftDeletedAndMissingDeletionTimestamp



### Tested snapshot in MGA

All the gaps are fixed, tested by locally deploying MGA with this snapshot version. All results captured in this doc:
[Backfill gaps fixed](https://docs.google.com/document/d/17XNuwhBBanPuT5w5Bo-40ozN5bhTSSqyHxSTYaiXybs/edit?tab=t.0)

 ### Known Remaining Gap: Asset-Level Delete (follow-up PR)

  Entity-level deletes (deleteAll → softDeleteAsset) set deleted_ts=NOW() on the entity row. batchGetUnion() filters deleted_ts
  IS NULL, hiding these rows entirely — making them indistinguishable from "never existed" and bypassing the isSoftDeleted
  check. Will be addressed in a separate PR.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
