### PR TITLE
build: upgrade Java source/target compatibility from 8 to 11

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -7,10 +7,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
     - id: get-tag
       run: echo "::set-output name=tag::$(./gradlew -q getVersion)"
       shell: bash

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -7,6 +7,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
     - id: get-tag
       run: echo "::set-output name=tag::$(./gradlew -q getVersion)"
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,10 +20,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: '11'
+          distribution: 'temurin'
       - name: Install lib
         run: sudo apt-get install libncurses5
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ platform. It provides type-safe, schema-driven metadata management with event-dr
 storage backends (SQL via Ebean, Elasticsearch for search). Built on LinkedIn's Pegasus data framework and Rest.li for
 REST APIs.
 
-**Java version**: 1.8 (Java 8) — required, newer versions will cause build failures.
+**Java version**: 11 (Java 11) — minimum required version.
 
 ## Build Commands
 

--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,8 @@ subprojects { sp ->
 
   afterEvaluate {
     if (project.plugins.hasPlugin('java')) {
-      sourceCompatibility = 1.8
-      targetCompatibility = 1.8
+      sourceCompatibility = 11
+      targetCompatibility = 11
     }
   }
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -56,20 +56,13 @@ For consistency please import and auto format the code using
 
 ### Getting `Unsupported class file major version 57`
 
-You're probably using a Java version that's too new for gradle. Run the following command to check your Java version
+You're probably using a Java version that's too new for Gradle. Gradle 6.9.4 supports up to JDK 16. Run the following
+command to check your Java version
 
 ```
 java --version
 ```
 
-While it may be possible to build and run DataHub using newer versions of Java, we currently only support
-[Java 1.8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html) (aka Java 8). Plan for Java 11
-migration is being discussed in [this issue](https://github.com/linkedin/datahub/issues/1699).
-
-### Getting `cannot find symbol` error for `javax.annotation.Generated`
-
-Similar to the previous issue, please use Java 1.8 to build the project.
-
-You can install multiple version of Java on a single machine and switch between them using the `JAVA_HOME` environment
-variable. See [this document](https://docs.oracle.com/cd/E21454_01/html/821-2531/inst_jdk_javahome_t.html) for more
-details.
+This project requires [Java 11](https://adoptium.net/) or later to build. If you have multiple JDK versions installed,
+you can switch between them using the `JAVA_HOME` environment variable. See
+[this document](https://docs.oracle.com/cd/E21454_01/html/821-2531/inst_jdk_javahome_t.html) for more details.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,7 +39,7 @@ Status: **Draft**
 - [ ] Enable `werror` for all Java code.
 - [ ] Remove use of tuples library (not idiomatic Java - replace with helper classes / POJOs).
 - [x] Elasticsearch 7 support.
-- [ ] Java 11 support.
+- [x] Java 11 support.
 
 ---
 


### PR DESCRIPTION
## Summary

- Upgrade `sourceCompatibility` and `targetCompatibility` from Java 8 (1.8) to Java 11
- Update developer docs and roadmap to reflect the new minimum Java version

## Context

Java 11 migration has been planned since 2020 (datahub-project/datahub#1699) but was blocked because two downstream consumers were still on Java 8:

| Downstream MP | Java version (then) | Java version (now) |
|---|---|---|
| `li-elasticsearch-integration-test` | 8 (blocker) | **17** |
| `metadata-models-plugin` | 8 (blocker) | **17** |

Both blockers have since been independently upgraded to Java 17, making this upgrade safe to proceed.

Other related MPs are also well past Java 8:
- `metadata-graph-assets` → Java 17
- `asseturn-converter` → Java 17
- `metadata-models` → Java 17
- `metadata-crawlers` → Java 11

## Motivation

This upgrade also unblocks a future Elasticsearch bump from 7.17.24 to 8.x. The `elasticsearch-dao-integ-testing-7` module has been failing ELR validation since June 2025 (ELR #257515) due to known CVEs in ES 7.17.24 that are blocked by `oss-canary`. ES 8.x client libraries require Java 11+ minimum.

## Changes

| File | Change |
|---|---|
| `build.gradle` | `sourceCompatibility`/`targetCompatibility`: `1.8` → `11` |
| `CLAUDE.md` | Updated Java version description |
| `docs/developers.md` | Removed Java 8 requirement, updated troubleshooting |
| `docs/roadmap.md` | Marked "Java 11 support" as complete |

## Testing Done

- Full build (`./gradlew build -x test`) passes with JDK 11: **214 tasks, zero errors**
- No code changes required — Pegasus 29.6.9 code generation is Java 11 compatible
- All 24 submodules compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)