### PR TITLE
feat(ebean-dao): add optional FORCE INDEX hint for filter query

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,6 @@ jobs:
           name: test-reports
           path: /home/runner/work/datahub-gma/datahub-gma/dao-impl/ebean-dao/build/reports/tests/test/**
       - name: Upload coverage reports to Codecov
-        continue-on-error: true
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,6 +38,7 @@ jobs:
           name: test-reports
           path: /home/runner/work/datahub-gma/datahub-gma/dao-impl/ebean-dao/build/reports/tests/test/**
       - name: Upload coverage reports to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -71,6 +71,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   private UrnPathExtractor<URN> _urnPathExtractor;
   private final SchemaEvolutionManager _schemaEvolutionManager;
   private final boolean _nonDollarVirtualColumnsEnabled;
+  private String _forceFilterIndexName;
 
   // TODO confirm if the default page size is 1000 in other code context.
   private static final int DEFAULT_PAGE_SIZE = 1000;
@@ -108,6 +109,11 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   public void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor) {
     _urnPathExtractor = urnPathExtractor;
+  }
+
+  @Override
+  public void setForceFilterIndexName(@Nullable String forceIndexName) {
+    _forceFilterIndexName = forceIndexName;
   }
 
   public void ensureSchemaUpToDate() {
@@ -376,7 +382,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize) {
     // Run COUNT in a separate query/transaction so neither query exceeds the 5s kill threshold.
-    final String baseSql = SQLStatementUtils.createFilterSql(_entityType, indexFilter, _nonDollarVirtualColumnsEnabled, validator);
+    final String baseSql = SQLStatementUtils.createFilterSql(_entityType, indexFilter,
+        _nonDollarVirtualColumnsEnabled, validator, _forceFilterIndexName);
     final String countSql = baseSql.replaceFirst("SELECT urn", "SELECT COUNT(urn) AS _total_count");
     final SqlRow countRow = _server.createSqlQuery(countSql).findOne();
     final int totalCount = (countRow == null) ? 0 : countRow.getInteger("_total_count");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -113,9 +113,10 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   }
 
   @Override
-  public void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
+  public void configureOptionalForceIndex(@Nullable String indexName,
+      @Nullable Class<? extends RecordTemplate> requiredAspect) {
     _forceIndexName = indexName;
-    _forceIndexRequiredAspect = requiredAspectFqcn;
+    _forceIndexRequiredAspect = (requiredAspect != null) ? requiredAspect.getCanonicalName() : null;
   }
 
   public void ensureSchemaUpToDate() {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -71,8 +71,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   private UrnPathExtractor<URN> _urnPathExtractor;
   private final SchemaEvolutionManager _schemaEvolutionManager;
   private final boolean _nonDollarVirtualColumnsEnabled;
-  private String _forceFilterIndexName;
-  private String _forceFilterIndexRequiredAspect;
+  private String _forceIndexName;
+  private String _forceIndexRequiredAspect;
 
   // TODO confirm if the default page size is 1000 in other code context.
   private static final int DEFAULT_PAGE_SIZE = 1000;
@@ -113,9 +113,9 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   }
 
   @Override
-  public void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
-    _forceFilterIndexName = indexName;
-    _forceFilterIndexRequiredAspect = requiredAspectFqcn;
+  public void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
+    _forceIndexName = indexName;
+    _forceIndexRequiredAspect = requiredAspectFqcn;
   }
 
   public void ensureSchemaUpToDate() {
@@ -530,15 +530,15 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    */
   @Nullable
   private String resolveForceIndex(@Nullable IndexFilter indexFilter) {
-    if (_forceFilterIndexName == null || _forceFilterIndexRequiredAspect == null) {
+    if (_forceIndexName == null || _forceIndexRequiredAspect == null) {
       return null;
     }
     if (indexFilter == null || !indexFilter.hasCriteria()) {
       return null;
     }
     boolean hasRequiredAspect = indexFilter.getCriteria().stream()
-        .anyMatch(c -> _forceFilterIndexRequiredAspect.equals(c.getAspect()));
-    return hasRequiredAspect ? _forceFilterIndexName : null;
+        .anyMatch(c -> _forceIndexRequiredAspect.equals(c.getAspect()));
+    return hasRequiredAspect ? _forceIndexName : null;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -113,6 +113,14 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     _urnPathExtractor = urnPathExtractor;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Converts {@code Class<?>} keys to FQCN strings at config time so that callers get
+   * compile-time safety (a renamed or removed aspect class fails the build). Internally stores
+   * the FQCN-to-path map for comparison against {@link IndexCriterion#getAspect()} at resolve
+   * time.</p>
+   */
   @Override
   public void configureOptionalForceIndex(@Nullable String indexName,
       @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -72,7 +72,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   private final SchemaEvolutionManager _schemaEvolutionManager;
   private final boolean _nonDollarVirtualColumnsEnabled;
   private String _forceIndexName;
-  private String _forceIndexRequiredAspect;
+  private Map<String, String> _forceIndexRequiredCriteria;
 
   // TODO confirm if the default page size is 1000 in other code context.
   private static final int DEFAULT_PAGE_SIZE = 1000;
@@ -114,9 +114,14 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   @Override
   public void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Class<? extends RecordTemplate> requiredAspect) {
+      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {
     _forceIndexName = indexName;
-    _forceIndexRequiredAspect = (requiredAspect != null) ? requiredAspect.getCanonicalName() : null;
+    if (requiredCriteria != null) {
+      _forceIndexRequiredCriteria = requiredCriteria.entrySet().stream()
+          .collect(Collectors.toMap(e -> e.getKey().getCanonicalName(), Map.Entry::getValue));
+    } else {
+      _forceIndexRequiredCriteria = null;
+    }
   }
 
   public void ensureSchemaUpToDate() {
@@ -142,7 +147,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
       log.error("Configured forceIndexName '{}' does not exist on table '{}'. "
           + "Disabling FORCE INDEX hint to prevent query failures.", _forceIndexName, tableName);
       _forceIndexName = null;
-      _forceIndexRequiredAspect = null;
+      _forceIndexRequiredCriteria = null;
     }
   }
 
@@ -548,20 +553,23 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   }
 
   /**
-   * Returns the configured force index name only when the IndexFilter contains a criterion
-   * matching the required aspect, null otherwise.
+   * Returns the configured force index name only when the IndexFilter contains criteria
+   * matching ALL required (aspect, path) pairs, null otherwise.
    */
   @Nullable
   private String resolveForceIndex(@Nullable IndexFilter indexFilter) {
-    if (_forceIndexName == null || _forceIndexRequiredAspect == null) {
+    if (_forceIndexName == null || _forceIndexRequiredCriteria == null || _forceIndexRequiredCriteria.isEmpty()) {
       return null;
     }
     if (indexFilter == null || !indexFilter.hasCriteria()) {
       return null;
     }
-    boolean hasRequiredAspect = indexFilter.getCriteria().stream()
-        .anyMatch(c -> _forceIndexRequiredAspect.equals(c.getAspect()));
-    return hasRequiredAspect ? _forceIndexName : null;
+    boolean allMatch = _forceIndexRequiredCriteria.entrySet().stream().allMatch(required ->
+        indexFilter.getCriteria().stream().anyMatch(c ->
+            required.getKey().equals(c.getAspect())
+                && c.hasPathParams()
+                && required.getValue().equals(c.getPathParams().getPath())));
+    return allMatch ? _forceIndexName : null;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -127,6 +127,12 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     validateForceIndex();
   }
 
+  /**
+   * Verifies that the configured FORCE INDEX name exists on the entity table. If the index is
+   * missing (e.g. dropped without updating the application config), disables the hint and logs
+   * an ERROR so queries degrade to the default plan instead of failing with
+   * {@code ER_KEY_DOES_NOT_EXIST}.
+   */
   void validateForceIndex() {
     if (_forceIndexName == null) {
       return;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -17,6 +17,7 @@ import com.linkedin.metadata.dao.utils.SharedSchemaCache;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.ExtraInfoArray;
+import com.linkedin.metadata.query.IndexCriterion;
 import com.linkedin.metadata.query.IndexFilter;
 import com.linkedin.metadata.query.IndexGroupByCriterion;
 import com.linkedin.metadata.query.IndexSortCriterion;
@@ -553,9 +554,13 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   }
 
   /**
-   * Returns the configured force index name only when the IndexFilter contains criteria
-   * matching ALL required (aspect, path) pairs, null otherwise. Path comparison strips
-   * leading '/' from both sides to tolerate convention differences between callers.
+   * Returns the configured force index name only when the IndexFilter's path-bearing criteria
+   * exactly match the required (aspect, path) pairs. Criteria without pathParams (aspect-existence
+   * checks that produce IS NOT NULL / soft-delete guards) are excluded from the comparison since
+   * they don't affect index choice. This is intentionally strict: FORCE INDEX is a hard directive
+   * that removes the optimizer's ability to choose a better index, so it should only activate for
+   * the exact query shape it was validated against. If the filter shape changes, the hint deactivates
+   * and MySQL picks its own plan.
    */
   @Nullable
   private String resolveForceIndex(@Nullable IndexFilter indexFilter) {
@@ -565,10 +570,15 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     if (indexFilter == null || !indexFilter.hasCriteria()) {
       return null;
     }
+    List<IndexCriterion> pathBearingCriteria = indexFilter.getCriteria().stream()
+        .filter(IndexCriterion::hasPathParams)
+        .collect(Collectors.toList());
+    if (pathBearingCriteria.size() != _forceIndexRequiredCriteria.size()) {
+      return null;
+    }
     boolean allMatch = _forceIndexRequiredCriteria.entrySet().stream().allMatch(required ->
-        indexFilter.getCriteria().stream().anyMatch(c ->
+        pathBearingCriteria.stream().anyMatch(c ->
             required.getKey().equals(c.getAspect())
-                && c.hasPathParams()
                 && normalizePath(required.getValue()).equals(normalizePath(c.getPathParams().getPath()))));
     return allMatch ? _forceIndexName : null;
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -554,7 +554,8 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   /**
    * Returns the configured force index name only when the IndexFilter contains criteria
-   * matching ALL required (aspect, path) pairs, null otherwise.
+   * matching ALL required (aspect, path) pairs, null otherwise. Path comparison strips
+   * leading '/' from both sides to tolerate convention differences between callers.
    */
   @Nullable
   private String resolveForceIndex(@Nullable IndexFilter indexFilter) {
@@ -568,8 +569,12 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
         indexFilter.getCriteria().stream().anyMatch(c ->
             required.getKey().equals(c.getAspect())
                 && c.hasPathParams()
-                && required.getValue().equals(c.getPathParams().getPath())));
+                && normalizePath(required.getValue()).equals(normalizePath(c.getPathParams().getPath()))));
     return allMatch ? _forceIndexName : null;
+  }
+
+  private static String normalizePath(@Nonnull String path) {
+    return path.startsWith("/") ? path.substring(1) : path;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -124,6 +124,24 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     // Pre-warm the shared cache for both the prod and test tables so the first request is never slow.
     validator.registerAndPreWarm(getTableName(_entityType));
     validator.registerAndPreWarm(getTestTableName(_entityType));
+    validateForceIndex();
+  }
+
+  void validateForceIndex() {
+    if (_forceIndexName == null) {
+      return;
+    }
+    String tableName = getTableName(_entityType);
+    String sql = String.format(
+        "SELECT 1 FROM information_schema.STATISTICS"
+            + " WHERE table_schema = DATABASE() AND table_name = '%s' AND index_name = '%s' LIMIT 1",
+        tableName, _forceIndexName);
+    if (_server.createSqlQuery(sql).findOne() == null) {
+      log.error("Configured forceIndexName '{}' does not exist on table '{}'. "
+          + "Disabling FORCE INDEX hint to prevent query failures.", _forceIndexName, tableName);
+      _forceIndexName = null;
+      _forceIndexRequiredAspect = null;
+    }
   }
 
   @Override

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -132,11 +132,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
       return;
     }
     String tableName = getTableName(_entityType);
-    String sql = String.format(
-        "SELECT 1 FROM information_schema.STATISTICS"
-            + " WHERE table_schema = DATABASE() AND table_name = '%s' AND index_name = '%s' LIMIT 1",
-        tableName, _forceIndexName);
-    if (_server.createSqlQuery(sql).findOne() == null) {
+    if (!validator.indexExists(tableName, _forceIndexName)) {
       log.error("Configured forceIndexName '{}' does not exist on table '{}'. "
           + "Disabling FORCE INDEX hint to prevent query failures.", _forceIndexName, tableName);
       _forceIndexName = null;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -402,10 +402,12 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   @Override
   public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize) {
-    // Run COUNT in a separate query/transaction so neither query exceeds the 5s kill threshold.
+    // When configured, emit FORCE INDEX to override MySQL's prefer_ordering_index heuristic
+    // which can pick a full-table PRIMARY scan instead of the composite index at small LIMITs.
     final String effectiveForceIndex = resolveForceIndex(indexFilter);
     final String baseSql = SQLStatementUtils.createFilterSql(_entityType, indexFilter,
         _nonDollarVirtualColumnsEnabled, validator, effectiveForceIndex);
+    // Run COUNT in a separate query so neither query exceeds the 5s kill threshold.
     final String countSql = baseSql.replaceFirst("SELECT urn", "SELECT COUNT(urn) AS _total_count");
     final SqlRow countRow = _server.createSqlQuery(countSql).findOne();
     final int totalCount = (countRow == null) ? 0 : countRow.getInteger("_total_count");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -72,6 +72,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   private final SchemaEvolutionManager _schemaEvolutionManager;
   private final boolean _nonDollarVirtualColumnsEnabled;
   private String _forceFilterIndexName;
+  private String _forceFilterIndexRequiredAspect;
 
   // TODO confirm if the default page size is 1000 in other code context.
   private static final int DEFAULT_PAGE_SIZE = 1000;
@@ -112,8 +113,9 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   }
 
   @Override
-  public void setForceFilterIndexName(@Nullable String forceIndexName) {
-    _forceFilterIndexName = forceIndexName;
+  public void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
+    _forceFilterIndexName = indexName;
+    _forceFilterIndexRequiredAspect = requiredAspectFqcn;
   }
 
   public void ensureSchemaUpToDate() {
@@ -382,8 +384,9 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
       int start, int pageSize) {
     // Run COUNT in a separate query/transaction so neither query exceeds the 5s kill threshold.
+    final String effectiveForceIndex = resolveForceIndex(indexFilter);
     final String baseSql = SQLStatementUtils.createFilterSql(_entityType, indexFilter,
-        _nonDollarVirtualColumnsEnabled, validator, _forceFilterIndexName);
+        _nonDollarVirtualColumnsEnabled, validator, effectiveForceIndex);
     final String countSql = baseSql.replaceFirst("SELECT urn", "SELECT COUNT(urn) AS _total_count");
     final SqlRow countRow = _server.createSqlQuery(countSql).findOne();
     final int totalCount = (countRow == null) ? 0 : countRow.getInteger("_total_count");
@@ -519,6 +522,23 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
       resultMap.put(value, count);
     }
     return resultMap;
+  }
+
+  /**
+   * Returns the configured force index name only when the IndexFilter contains a criterion
+   * matching the required aspect, null otherwise.
+   */
+  @Nullable
+  private String resolveForceIndex(@Nullable IndexFilter indexFilter) {
+    if (_forceFilterIndexName == null || _forceFilterIndexRequiredAspect == null) {
+      return null;
+    }
+    if (indexFilter == null || !indexFilter.hasCriteria()) {
+      return null;
+    }
+    boolean hasRequiredAspect = indexFilter.getCriteria().stream()
+        .anyMatch(c -> _forceFilterIndexRequiredAspect.equals(c.getAspect()));
+    return hasRequiredAspect ? _forceFilterIndexName : null;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -148,16 +148,17 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   /**
    * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
    * query. The hint is only emitted when the {@link IndexFilter} contains a criterion whose
-   * aspect matches {@code requiredAspectFqcn}. Per-asset opt-in for cases where the optimizer's
+   * aspect matches {@code requiredAspect}. Per-asset opt-in for cases where the optimizer's
    * plan choice is pathologically bad for a specific query shape.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredAspectFqcn FQCN of the aspect that must appear in the filter criteria
-   *                           for the hint to activate (e.g. {@code "com.linkedin.common.Status"})
+   * @param requiredAspect aspect class that must appear in the filter criteria for the hint
+   *                       to activate, or null to disable
    */
-  public void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
+  public void configureOptionalForceIndex(@Nullable String indexName,
+      @Nullable Class<? extends RecordTemplate> requiredAspect) {
     if (_localAccess != null) {
-      _localAccess.configureOptionalForceIndex(indexName, requiredAspectFqcn);
+      _localAccess.configureOptionalForceIndex(indexName, requiredAspect);
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -146,6 +146,20 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
+   * Configures a MySQL FORCE INDEX hint for the offset-pagination listUrns filter query.
+   * When set, generated SQL includes {@code FORCE INDEX (`indexName`)} between the table name
+   * and WHERE clause. Per-asset opt-in for cases where the optimizer's plan choice is
+   * pathologically bad and other mitigations are not viable.
+   *
+   * @param forceIndexName MySQL index name, or null to disable
+   */
+  public void setForceFilterIndexName(@Nullable String forceIndexName) {
+    if (_localAccess != null) {
+      _localAccess.setForceFilterIndexName(forceIndexName);
+    }
+  }
+
+  /**
    * Set a flag to indicate whether noisy info logs are enabled. Should only be used for debugging.
    * @param noisyLogsEnabled whether the logs are enabled
    */

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -147,18 +147,18 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   /**
    * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
-   * query. The hint is only emitted when the {@link IndexFilter} contains a criterion whose
-   * aspect matches {@code requiredAspect}. Per-asset opt-in for cases where the optimizer's
-   * plan choice is pathologically bad for a specific query shape.
+   * query. The force index is only emitted when the {@link IndexFilter} contains criteria
+   * matching ALL of the required (aspect, path) pairs. Per-asset opt-in for cases where the
+   * optimizer's plan choice is pathologically bad for a specific query shape.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredAspect aspect class that must appear in the filter criteria for the force
-   *                       index to activate, or null to disable
+   * @param requiredCriteria map of aspect class to path that must all appear in the filter
+   *                         criteria for the force index to activate, or null to disable
    */
   public void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Class<? extends RecordTemplate> requiredAspect) {
+      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {
     if (_localAccess != null) {
-      _localAccess.configureOptionalForceIndex(indexName, requiredAspect);
+      _localAccess.configureOptionalForceIndex(indexName, requiredCriteria);
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -147,15 +147,17 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   /**
    * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
-   * query. The force index is only emitted when the {@link IndexFilter} contains criteria
-   * matching ALL of the required (aspect, path) pairs. Per-asset opt-in for cases where the
-   * optimizer's plan choice is pathologically bad for a specific query shape.
+   * query. The force index is only emitted when the {@link IndexFilter}'s path-bearing criteria
+   * (those with {@code pathParams}) exactly match the configured (aspect, path) pairs -- same
+   * count, all match. Criteria without {@code pathParams} (aspect-existence checks) are excluded.
+   * This is a surgical fix for one known-bad query shape: if the filter shape changes, the hint
+   * deactivates and MySQL picks its own plan. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
    * @param requiredCriteria map of aspect class to path (e.g. {@code "/status"}, {@code "/model_urn"})
-   *                         that must all appear in the filter criteria for the force index to
-   *                         activate, or null to disable. Leading '/' in paths is optional --
-   *                         comparison is normalized.
+   *                         that must exactly match the filter's path-bearing criteria for the
+   *                         force index to activate, or null to disable. Leading '/' in paths is
+   *                         optional -- comparison is normalized.
    */
   public void configureOptionalForceIndex(@Nullable String indexName,
       @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -152,8 +152,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * plan choice is pathologically bad for a specific query shape.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredAspect aspect class that must appear in the filter criteria for the hint
-   *                       to activate, or null to disable
+   * @param requiredAspect aspect class that must appear in the filter criteria for the force
+   *                       index to activate, or null to disable
    */
   public void configureOptionalForceIndex(@Nullable String indexName,
       @Nullable Class<? extends RecordTemplate> requiredAspect) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -155,9 +155,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param requiredAspectFqcn FQCN of the aspect that must appear in the filter criteria
    *                           for the hint to activate (e.g. {@code "com.linkedin.common.Status"})
    */
-  public void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
+  public void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
     if (_localAccess != null) {
-      _localAccess.setForceFilterIndex(indexName, requiredAspectFqcn);
+      _localAccess.configureOptionalForceIndex(indexName, requiredAspectFqcn);
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -146,16 +146,18 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Configures a MySQL FORCE INDEX hint for the offset-pagination listUrns filter query.
-   * When set, generated SQL includes {@code FORCE INDEX (`indexName`)} between the table name
-   * and WHERE clause. Per-asset opt-in for cases where the optimizer's plan choice is
-   * pathologically bad and other mitigations are not viable.
+   * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
+   * query. The hint is only emitted when the {@link IndexFilter} contains a criterion whose
+   * aspect matches {@code requiredAspectFqcn}. Per-asset opt-in for cases where the optimizer's
+   * plan choice is pathologically bad for a specific query shape.
    *
-   * @param forceIndexName MySQL index name, or null to disable
+   * @param indexName MySQL index name, or null to disable
+   * @param requiredAspectFqcn FQCN of the aspect that must appear in the filter criteria
+   *                           for the hint to activate (e.g. {@code "com.linkedin.common.Status"})
    */
-  public void setForceFilterIndexName(@Nullable String forceIndexName) {
+  public void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
     if (_localAccess != null) {
-      _localAccess.setForceFilterIndexName(forceIndexName);
+      _localAccess.setForceFilterIndex(indexName, requiredAspectFqcn);
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -152,8 +152,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * optimizer's plan choice is pathologically bad for a specific query shape.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredCriteria map of aspect class to path that must all appear in the filter
-   *                         criteria for the force index to activate, or null to disable
+   * @param requiredCriteria map of aspect class to path (e.g. {@code "/status"}, {@code "/model_urn"})
+   *                         that must all appear in the filter criteria for the force index to
+   *                         activate, or null to disable. Leading '/' in paths is optional --
+   *                         comparison is normalized.
    */
   public void configureOptionalForceIndex(@Nullable String indexName,
       @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -27,8 +27,10 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * matching ALL of the required (aspect, path) pairs. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredCriteria map of aspect class to path that must all appear in the filter
-   *                         criteria for the force index to activate, or null to disable
+   * @param requiredCriteria map of aspect class to path (e.g. {@code "/status"}, {@code "/model_urn"})
+   *                         that must all appear in the filter criteria for the force index to
+   *                         activate, or null to disable. Leading '/' in paths is optional --
+   *                         comparison is normalized.
    */
   void configureOptionalForceIndex(@Nullable String indexName,
       @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -27,8 +27,8 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * aspect matches {@code requiredAspect}. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredAspect aspect class that must appear in the filter criteria for the hint
-   *                       to activate, or null to disable
+   * @param requiredAspect aspect class that must appear in the filter criteria for the force
+   *                       index to activate, or null to disable
    */
   void configureOptionalForceIndex(@Nullable String indexName,
       @Nullable Class<? extends RecordTemplate> requiredAspect);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -30,7 +30,7 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * @param requiredAspectFqcn FQCN of the aspect that must appear in the filter criteria
    *                           for the hint to activate (e.g. {@code "com.linkedin.common.Status"})
    */
-  void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn);
+  void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn);
 
   /**
    * Upsert aspect into entity table.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -22,6 +22,15 @@ public interface IEbeanLocalAccess<URN extends Urn> {
   void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor);
 
   /**
+   * Configures a MySQL FORCE INDEX hint for the offset-pagination listUrns filter query.
+   * When set, generated SQL includes {@code FORCE INDEX (`indexName`)} between the table name
+   * and WHERE clause. Default is null (no hint).
+   *
+   * @param forceIndexName MySQL index name, or null to disable
+   */
+  void setForceFilterIndexName(@Nullable String forceIndexName);
+
+  /**
    * Upsert aspect into entity table.
    *
    * @param <ASPECT>                 metadata aspect value

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -23,14 +23,17 @@ public interface IEbeanLocalAccess<URN extends Urn> {
 
   /**
    * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
-   * query. The force index is only emitted when the {@link IndexFilter} contains criteria
-   * matching ALL of the required (aspect, path) pairs. Pass {@code null} for both to disable.
+   * query. The force index is only emitted when the {@link IndexFilter}'s path-bearing criteria
+   * (those with {@code pathParams}) exactly match the configured (aspect, path) pairs -- same
+   * count, all match. Criteria without {@code pathParams} (aspect-existence checks) are excluded.
+   * This is a surgical fix for one known-bad query shape: if the filter shape changes, the hint
+   * deactivates and MySQL picks its own plan. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
    * @param requiredCriteria map of aspect class to path (e.g. {@code "/status"}, {@code "/model_urn"})
-   *                         that must all appear in the filter criteria for the force index to
-   *                         activate, or null to disable. Leading '/' in paths is optional --
-   *                         comparison is normalized.
+   *                         that must exactly match the filter's path-bearing criteria for the
+   *                         force index to activate, or null to disable. Leading '/' in paths is
+   *                         optional -- comparison is normalized.
    */
   void configureOptionalForceIndex(@Nullable String indexName,
       @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -23,15 +23,15 @@ public interface IEbeanLocalAccess<URN extends Urn> {
 
   /**
    * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
-   * query. The hint is only emitted when the {@link IndexFilter} contains a criterion whose
-   * aspect matches {@code requiredAspect}. Pass {@code null} for both to disable.
+   * query. The force index is only emitted when the {@link IndexFilter} contains criteria
+   * matching ALL of the required (aspect, path) pairs. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredAspect aspect class that must appear in the filter criteria for the force
-   *                       index to activate, or null to disable
+   * @param requiredCriteria map of aspect class to path that must all appear in the filter
+   *                         criteria for the force index to activate, or null to disable
    */
   void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Class<? extends RecordTemplate> requiredAspect);
+      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria);
 
   /**
    * Upsert aspect into entity table.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -24,13 +24,14 @@ public interface IEbeanLocalAccess<URN extends Urn> {
   /**
    * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
    * query. The hint is only emitted when the {@link IndexFilter} contains a criterion whose
-   * aspect matches {@code requiredAspectFqcn}. Pass {@code null} for both to disable.
+   * aspect matches {@code requiredAspect}. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredAspectFqcn FQCN of the aspect that must appear in the filter criteria
-   *                           for the hint to activate (e.g. {@code "com.linkedin.common.Status"})
+   * @param requiredAspect aspect class that must appear in the filter criteria for the hint
+   *                       to activate, or null to disable
    */
-  void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn);
+  void configureOptionalForceIndex(@Nullable String indexName,
+      @Nullable Class<? extends RecordTemplate> requiredAspect);
 
   /**
    * Upsert aspect into entity table.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -22,13 +22,15 @@ public interface IEbeanLocalAccess<URN extends Urn> {
   void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor);
 
   /**
-   * Configures a MySQL FORCE INDEX hint for the offset-pagination listUrns filter query.
-   * When set, generated SQL includes {@code FORCE INDEX (`indexName`)} between the table name
-   * and WHERE clause. Default is null (no hint).
+   * Configures a conditional MySQL FORCE INDEX hint for the offset-pagination listUrns filter
+   * query. The hint is only emitted when the {@link IndexFilter} contains a criterion whose
+   * aspect matches {@code requiredAspectFqcn}. Pass {@code null} for both to disable.
    *
-   * @param forceIndexName MySQL index name, or null to disable
+   * @param indexName MySQL index name, or null to disable
+   * @param requiredAspectFqcn FQCN of the aspect that must appear in the filter criteria
+   *                           for the hint to activate (e.g. {@code "com.linkedin.common.Status"})
    */
-  void setForceFilterIndexName(@Nullable String forceIndexName);
+  void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn);
 
   /**
    * Upsert aspect into entity table.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
@@ -58,8 +58,8 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
 
   @Override
   public void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Class<? extends RecordTemplate> requiredAspect) {
-    _delegate.configureOptionalForceIndex(indexName, requiredAspect);
+      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {
+    _delegate.configureOptionalForceIndex(indexName, requiredCriteria);
   }
 
   @Override

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
@@ -57,8 +57,8 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   }
 
   @Override
-  public void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
-    _delegate.setForceFilterIndex(indexName, requiredAspectFqcn);
+  public void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
+    _delegate.configureOptionalForceIndex(indexName, requiredAspectFqcn);
   }
 
   @Override

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
@@ -57,8 +57,9 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   }
 
   @Override
-  public void configureOptionalForceIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
-    _delegate.configureOptionalForceIndex(indexName, requiredAspectFqcn);
+  public void configureOptionalForceIndex(@Nullable String indexName,
+      @Nullable Class<? extends RecordTemplate> requiredAspect) {
+    _delegate.configureOptionalForceIndex(indexName, requiredAspect);
   }
 
   @Override

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
@@ -57,6 +57,11 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   }
 
   @Override
+  public void setForceFilterIndexName(@Nullable String forceIndexName) {
+    _delegate.setForceFilterIndexName(forceIndexName);
+  }
+
+  @Override
   public <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue,
       @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp,
       @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
@@ -57,8 +57,8 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   }
 
   @Override
-  public void setForceFilterIndexName(@Nullable String forceIndexName) {
-    _delegate.setForceFilterIndexName(forceIndexName);
+  public void setForceFilterIndex(@Nullable String indexName, @Nullable String requiredAspectFqcn) {
+    _delegate.setForceFilterIndex(indexName, requiredAspectFqcn);
   }
 
   @Override

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -389,9 +389,23 @@ public class SQLStatementUtils {
    */
   public static String createFilterSql(String entityType, @Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled,
       @Nonnull SchemaValidatorUtil schemaValidator) {
+    return createFilterSql(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator, null);
+  }
+
+  /**
+   * Create filter SQL statement with optional FORCE INDEX hint.
+   * @param entityType entity type from urn
+   * @param indexFilter index filter
+   * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
+   * @param forceIndexName MySQL index name for FORCE INDEX hint, or null to omit
+   * @return translated SQL where statement
+   */
+  public static String createFilterSql(String entityType, @Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled,
+      @Nonnull SchemaValidatorUtil schemaValidator, @Nullable String forceIndexName) {
     final String tableName = getTableName(entityType);
-    String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
-    return "SELECT urn FROM " + tableName + "\n" + whereClause;
+    final String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
+    final String forceClause = (forceIndexName == null) ? "" : " FORCE INDEX (`" + forceIndexName + "`)";
+    return "SELECT urn FROM " + tableName + forceClause + "\n" + whereClause;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -397,14 +397,14 @@ public class SQLStatementUtils {
    * @param entityType entity type from urn
    * @param indexFilter index filter
    * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
-   * @param forceIndexName MySQL index name for FORCE INDEX hint, or null to omit
+   * @param forceIndex MySQL index name for FORCE INDEX hint, or null to omit
    * @return translated SQL where statement
    */
   public static String createFilterSql(String entityType, @Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled,
-      @Nonnull SchemaValidatorUtil schemaValidator, @Nullable String forceIndexName) {
+      @Nonnull SchemaValidatorUtil schemaValidator, @Nullable String forceIndex) {
     final String tableName = getTableName(entityType);
     final String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
-    final String forceClause = (forceIndexName == null) ? "" : " FORCE INDEX (`" + forceIndexName + "`)";
+    final String forceClause = (forceIndex == null) ? "" : " FORCE INDEX (`" + forceIndex + "`)";
     return "SELECT urn FROM " + tableName + forceClause + "\n" + whereClause;
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -397,15 +397,15 @@ public class SQLStatementUtils {
    * @param entityType entity type from urn
    * @param indexFilter index filter
    * @param nonDollarVirtualColumnsEnabled  true if virtual column does not contain $, false otherwise
-   * @param forceIndex MySQL index name for FORCE INDEX hint, or null to omit
+   * @param forceIndexName MySQL index name for FORCE INDEX hint, or null to omit
    * @return translated SQL where statement
    */
   public static String createFilterSql(String entityType, @Nullable IndexFilter indexFilter, boolean nonDollarVirtualColumnsEnabled,
-      @Nonnull SchemaValidatorUtil schemaValidator, @Nullable String forceIndex) {
+      @Nonnull SchemaValidatorUtil schemaValidator, @Nullable String forceIndexName) {
     final String tableName = getTableName(entityType);
     final String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
-    final String forceClause = (forceIndex == null) ? "" : " FORCE INDEX (`" + forceIndex + "`)";
-    return "SELECT urn FROM " + tableName + forceClause + "\n" + whereClause;
+    final String forceIndex = (forceIndexName == null) ? "" : " FORCE INDEX (`" + forceIndexName + "`)";
+    return "SELECT urn FROM " + tableName + forceIndex + "\n" + whereClause;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -130,7 +130,7 @@ public class EbeanLocalAccessTest {
     EbeanMetadataAspect ebeanMetadataAspect = ebeanMetadataAspectList.get(0);
 
     // Expect: the content of aspect foo is returned
-    assertEquals(AspectFoo.class, ebeanMetadataAspect.getKey().getAspect());
+    assertEquals(AspectFoo.class.getCanonicalName(), ebeanMetadataAspect.getKey().getAspect());
     assertEquals(fooUrn.toString(), ebeanMetadataAspect.getKey().getUrn());
     assertEquals("{\"value\":\"0\"}", ebeanMetadataAspect.getMetadata());
     assertEquals("urn:li:testActor:foo", ebeanMetadataAspect.getCreatedBy());
@@ -614,7 +614,7 @@ public class EbeanLocalAccessTest {
     assertEquals(1, results.size());
     assertEquals("{\"value\":\"single\"}", results.get(0).getMetadata());
     assertEquals(fooUrn.toString(), results.get(0).getKey().getUrn());
-    assertEquals(AspectFoo.class, results.get(0).getKey().getAspect());
+    assertEquals(AspectFoo.class.getCanonicalName(), results.get(0).getKey().getAspect());
   }
 
   @Test(expectedExceptions = NullPointerException.class)

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1005,17 +1005,14 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testListUrnsWithOffsetAndForceIndex() {
-    // Given: metadata_entity_foo with fooUrns 0-99 and force index configured for AspectFoo.
-    // The filter contains AspectFoo criterion, so the hint should activate.
-    // MariaDB accepts FORCE INDEX syntax; this verifies the generated SQL executes without error.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+    // Filter contains (AspectFoo, "value") matching the required criteria — force index activates.
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
-    IndexCriterion indexCriterion =
-        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
-            IndexValue.create(25));
-    indexCriterionArray.add(indexCriterion);
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
     indexFilter.setCriteria(indexCriterionArray);
 
     IndexSortCriterion indexSortCriterion =
@@ -1031,16 +1028,37 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testForceIndexNotAppliedWhenFilterLacksRequiredAspect() {
-    // Force index is configured for AspectBar, but filter only contains AspectFoo criteria.
-    // The hint must NOT activate — query should still succeed with default plan.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectBar.class);
+    // Required criteria is (AspectBar, "value") but filter only has AspectFoo — must not activate.
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectBar.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
-    IndexCriterion indexCriterion =
-        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
-            IndexValue.create(25));
-    indexCriterionArray.add(indexCriterion);
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
+  }
+
+  @Test
+  public void testForceIndexNotAppliedWhenFilterLacksRequiredPath() {
+    // Required criteria is (AspectFoo, "other") but filter has (AspectFoo, "value") — path mismatch.
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "other");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
     indexFilter.setCriteria(indexCriterionArray);
 
     IndexSortCriterion indexSortCriterion =
@@ -1056,8 +1074,9 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
-    // Keyset-pagination path must NOT include FORCE INDEX even when the field is configured.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+    // Keyset-pagination path must NOT include FORCE INDEX even when configured.
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     List<FooUrn> result = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
 
@@ -1068,15 +1087,12 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testListUrnsWithOffsetAndNullForceIndex() {
-    // Verify that null config produces identical results to default behavior.
     _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
-    IndexCriterion indexCriterion =
-        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
-            IndexValue.create(25));
-    indexCriterionArray.add(indexCriterion);
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
     indexFilter.setCriteria(indexCriterionArray);
 
     IndexSortCriterion indexSortCriterion =
@@ -1090,18 +1106,14 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testValidateForceIndexDisablesHintWhenIndexMissing() {
-    // Configure a non-existent index — validation should auto-disable and log an error.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("idx_does_not_exist", AspectFoo.class);
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("idx_does_not_exist", criteria);
     _ebeanLocalAccessFoo.validateForceIndex();
 
-    // After validation, the hint should be disabled. Querying with the required aspect
-    // in the filter should still work (no FORCE INDEX emitted).
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
-    IndexCriterion indexCriterion =
-        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
-            IndexValue.create(25));
-    indexCriterionArray.add(indexCriterion);
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
     indexFilter.setCriteria(indexCriterionArray);
 
     IndexSortCriterion indexSortCriterion =
@@ -1114,16 +1126,14 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testValidateForceIndexKeepsHintWhenIndexExists() {
-    // PRIMARY always exists — validation should keep the hint active.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
     _ebeanLocalAccessFoo.validateForceIndex();
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
-    IndexCriterion indexCriterion =
-        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
-            IndexValue.create(25));
-    indexCriterionArray.add(indexCriterion);
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
     indexFilter.setCriteria(indexCriterionArray);
 
     IndexSortCriterion indexSortCriterion =
@@ -1138,8 +1148,8 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testForceIndexNotAppliedWhenFilterIsNull() {
-    // Force index configured but null IndexFilter passed — must not activate.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(null, null, 0, 10);
 
@@ -1151,11 +1161,9 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testValidateForceIndexNoOpWhenNotConfigured() {
-    // validateForceIndex with null _forceIndexName should be a no-op.
     _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
     _ebeanLocalAccessFoo.validateForceIndex();
 
-    // Queries should still work normally.
     ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(null, null, 0, 10);
     assertEquals(10, listUrns.getValues().size());
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1005,9 +1005,10 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testListUrnsWithOffsetAndForceIndex() {
-    // Given: metadata_entity_foo with fooUrns 0-99 and forceFilterIndexName configured
+    // Given: metadata_entity_foo with fooUrns 0-99 and force index configured for AspectFoo.
+    // The filter contains AspectFoo criterion, so the hint should activate.
     // MariaDB accepts FORCE INDEX syntax; this verifies the generated SQL executes without error.
-    _ebeanLocalAccessFoo.setForceFilterIndexName("PRIMARY");
+    _ebeanLocalAccessFoo.setForceFilterIndex("PRIMARY", AspectFoo.class.getCanonicalName());
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
@@ -1025,28 +1026,50 @@ public class EbeanLocalAccessTest {
     assertEquals(10, listUrns.getValues().size());
     assertEquals(75, listUrns.getTotalCount());
 
-    // Clean up: reset to null so other tests are unaffected
-    _ebeanLocalAccessFoo.setForceFilterIndexName(null);
+    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
+  }
+
+  @Test
+  public void testForceIndexNotAppliedWhenFilterLacksRequiredAspect() {
+    // Force index is configured for AspectBar, but filter only contains AspectFoo criteria.
+    // The hint must NOT activate — query should still succeed with default plan.
+    _ebeanLocalAccessFoo.setForceFilterIndex("PRIMARY", AspectBar.class.getCanonicalName());
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    IndexCriterion indexCriterion =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
+            IndexValue.create(25));
+    indexCriterionArray.add(indexCriterion);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+
+    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
   }
 
   @Test
   public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
     // Keyset-pagination path must NOT include FORCE INDEX even when the field is configured.
-    _ebeanLocalAccessFoo.setForceFilterIndexName("PRIMARY");
+    _ebeanLocalAccessFoo.setForceFilterIndex("PRIMARY", AspectFoo.class.getCanonicalName());
 
     List<FooUrn> result = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
 
-    // If FORCE INDEX leaked into the keyset path we'd get a different SQL shape,
-    // but the result count should be the same as without the hint.
     assertEquals(10, result.size());
 
-    _ebeanLocalAccessFoo.setForceFilterIndexName(null);
+    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
   }
 
   @Test
   public void testListUrnsWithOffsetAndNullForceIndex() {
-    // Verify that null forceFilterIndexName produces identical results to default behavior.
-    _ebeanLocalAccessFoo.setForceFilterIndexName(null);
+    // Verify that null config produces identical results to default behavior.
+    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1008,7 +1008,7 @@ public class EbeanLocalAccessTest {
     // Given: metadata_entity_foo with fooUrns 0-99 and force index configured for AspectFoo.
     // The filter contains AspectFoo criterion, so the hint should activate.
     // MariaDB accepts FORCE INDEX syntax; this verifies the generated SQL executes without error.
-    _ebeanLocalAccessFoo.setForceFilterIndex("PRIMARY", AspectFoo.class.getCanonicalName());
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class.getCanonicalName());
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
@@ -1026,14 +1026,14 @@ public class EbeanLocalAccessTest {
     assertEquals(10, listUrns.getValues().size());
     assertEquals(75, listUrns.getTotalCount());
 
-    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
   }
 
   @Test
   public void testForceIndexNotAppliedWhenFilterLacksRequiredAspect() {
     // Force index is configured for AspectBar, but filter only contains AspectFoo criteria.
     // The hint must NOT activate — query should still succeed with default plan.
-    _ebeanLocalAccessFoo.setForceFilterIndex("PRIMARY", AspectBar.class.getCanonicalName());
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectBar.class.getCanonicalName());
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
@@ -1051,25 +1051,25 @@ public class EbeanLocalAccessTest {
     assertEquals(10, listUrns.getValues().size());
     assertEquals(75, listUrns.getTotalCount());
 
-    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
   }
 
   @Test
   public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
     // Keyset-pagination path must NOT include FORCE INDEX even when the field is configured.
-    _ebeanLocalAccessFoo.setForceFilterIndex("PRIMARY", AspectFoo.class.getCanonicalName());
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class.getCanonicalName());
 
     List<FooUrn> result = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
 
     assertEquals(10, result.size());
 
-    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
   }
 
   @Test
   public void testListUrnsWithOffsetAndNullForceIndex() {
     // Verify that null config produces identical results to default behavior.
-    _ebeanLocalAccessFoo.setForceFilterIndex(null, null);
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1087,4 +1087,52 @@ public class EbeanLocalAccessTest {
     assertEquals(10, listUrns.getValues().size());
     assertEquals(75, listUrns.getTotalCount());
   }
+
+  @Test
+  public void testValidateForceIndexDisablesHintWhenIndexMissing() {
+    // Configure a non-existent index — validation should auto-disable and log an error.
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("idx_does_not_exist", AspectFoo.class);
+    _ebeanLocalAccessFoo.validateForceIndex();
+
+    // After validation, the hint should be disabled. Querying with the required aspect
+    // in the filter should still work (no FORCE INDEX emitted).
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    IndexCriterion indexCriterion =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
+            IndexValue.create(25));
+    indexCriterionArray.add(indexCriterion);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+  }
+
+  @Test
+  public void testValidateForceIndexKeepsHintWhenIndexExists() {
+    // PRIMARY always exists — validation should keep the hint active.
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+    _ebeanLocalAccessFoo.validateForceIndex();
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    IndexCriterion indexCriterion =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
+            IndexValue.create(25));
+    indexCriterionArray.add(indexCriterion);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1135,4 +1135,28 @@ public class EbeanLocalAccessTest {
 
     _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
   }
+
+  @Test
+  public void testForceIndexNotAppliedWhenFilterIsNull() {
+    // Force index configured but null IndexFilter passed — must not activate.
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(null, null, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(100, listUrns.getTotalCount());
+
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
+  }
+
+  @Test
+  public void testValidateForceIndexNoOpWhenNotConfigured() {
+    // validateForceIndex with null _forceIndexName should be a no-op.
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
+    _ebeanLocalAccessFoo.validateForceIndex();
+
+    // Queries should still work normally.
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(null, null, 0, 10);
+    assertEquals(10, listUrns.getValues().size());
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -130,7 +130,7 @@ public class EbeanLocalAccessTest {
     EbeanMetadataAspect ebeanMetadataAspect = ebeanMetadataAspectList.get(0);
 
     // Expect: the content of aspect foo is returned
-    assertEquals(AspectFoo.class.getCanonicalName(), ebeanMetadataAspect.getKey().getAspect());
+    assertEquals(AspectFoo.class, ebeanMetadataAspect.getKey().getAspect());
     assertEquals(fooUrn.toString(), ebeanMetadataAspect.getKey().getUrn());
     assertEquals("{\"value\":\"0\"}", ebeanMetadataAspect.getMetadata());
     assertEquals("urn:li:testActor:foo", ebeanMetadataAspect.getCreatedBy());
@@ -614,7 +614,7 @@ public class EbeanLocalAccessTest {
     assertEquals(1, results.size());
     assertEquals("{\"value\":\"single\"}", results.get(0).getMetadata());
     assertEquals(fooUrn.toString(), results.get(0).getKey().getUrn());
-    assertEquals(AspectFoo.class.getCanonicalName(), results.get(0).getKey().getAspect());
+    assertEquals(AspectFoo.class, results.get(0).getKey().getAspect());
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -1008,7 +1008,7 @@ public class EbeanLocalAccessTest {
     // Given: metadata_entity_foo with fooUrns 0-99 and force index configured for AspectFoo.
     // The filter contains AspectFoo criterion, so the hint should activate.
     // MariaDB accepts FORCE INDEX syntax; this verifies the generated SQL executes without error.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class.getCanonicalName());
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
@@ -1033,7 +1033,7 @@ public class EbeanLocalAccessTest {
   public void testForceIndexNotAppliedWhenFilterLacksRequiredAspect() {
     // Force index is configured for AspectBar, but filter only contains AspectFoo criteria.
     // The hint must NOT activate — query should still succeed with default plan.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectBar.class.getCanonicalName());
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectBar.class);
 
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
@@ -1057,7 +1057,7 @@ public class EbeanLocalAccessTest {
   @Test
   public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
     // Keyset-pagination path must NOT include FORCE INDEX even when the field is configured.
-    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class.getCanonicalName());
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
 
     List<FooUrn> result = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1097,6 +1097,58 @@ public class EbeanLocalAccessTest {
   }
 
   @Test
+  public void testForceIndexNotAppliedWhenFilterHasExtraPathCriteria() {
+    // Exact match: config requires only (AspectFoo, "value"), but filter has two path-bearing
+    // criteria. The extra criterion means a different query shape — force index must not activate.
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.LESS_THAN, IndexValue.create(50)));
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(25, listUrns.getTotalCount());
+
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
+  }
+
+  @Test
+  public void testForceIndexIgnoresAspectOnlyCriteria() {
+    // Criteria without pathParams (aspect-existence checks) should be excluded from the
+    // exact match comparison. Config requires (AspectFoo, "value"); filter has that plus
+    // an aspect-only criterion for AspectBar — should still activate.
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
+    indexCriterionArray.add(new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName()));
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
+  }
+
+  @Test
   public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
     // Keyset-pagination path must NOT include FORCE INDEX even when configured.
     Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1073,6 +1073,30 @@ public class EbeanLocalAccessTest {
   }
 
   @Test
+  public void testForceIndexPathNormalization() {
+    // Config uses "/value" (with leading slash), filter criterion uses "value" (without).
+    // Normalization should make them match.
+    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "/value");
+    _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    indexCriterionArray.add(SQLIndexFilterUtils.createIndexCriterion(
+        AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO, IndexValue.create(25)));
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+
+    _ebeanLocalAccessFoo.configureOptionalForceIndex(null, null);
+  }
+
+  @Test
   public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
     // Keyset-pagination path must NOT include FORCE INDEX even when configured.
     Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1002,4 +1002,66 @@ public class EbeanLocalAccessTest {
     assertEquals(1, results.size());
     assertFalse(EBeanDAOUtils.isSoftDeletedMetadata(results.get(0).getMetadata()));
   }
+
+  @Test
+  public void testListUrnsWithOffsetAndForceIndex() {
+    // Given: metadata_entity_foo with fooUrns 0-99 and forceFilterIndexName configured
+    // MariaDB accepts FORCE INDEX syntax; this verifies the generated SQL executes without error.
+    _ebeanLocalAccessFoo.setForceFilterIndexName("PRIMARY");
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    IndexCriterion indexCriterion =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
+            IndexValue.create(25));
+    indexCriterionArray.add(indexCriterion);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+
+    // Clean up: reset to null so other tests are unaffected
+    _ebeanLocalAccessFoo.setForceFilterIndexName(null);
+  }
+
+  @Test
+  public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
+    // Keyset-pagination path must NOT include FORCE INDEX even when the field is configured.
+    _ebeanLocalAccessFoo.setForceFilterIndexName("PRIMARY");
+
+    List<FooUrn> result = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
+
+    // If FORCE INDEX leaked into the keyset path we'd get a different SQL shape,
+    // but the result count should be the same as without the hint.
+    assertEquals(10, result.size());
+
+    _ebeanLocalAccessFoo.setForceFilterIndexName(null);
+  }
+
+  @Test
+  public void testListUrnsWithOffsetAndNullForceIndex() {
+    // Verify that null forceFilterIndexName produces identical results to default behavior.
+    _ebeanLocalAccessFoo.setForceFilterIndexName(null);
+
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    IndexCriterion indexCriterion =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
+            IndexValue.create(25));
+    indexCriterionArray.add(indexCriterion);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    IndexSortCriterion indexSortCriterion =
+        SQLIndexFilterUtils.createIndexSortCriterion(AspectFoo.class, "value", SortOrder.ASCENDING);
+
+    ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(indexFilter, indexSortCriterion, 0, 10);
+
+    assertEquals(10, listUrns.getValues().size());
+    assertEquals(75, listUrns.getTotalCount());
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
@@ -218,8 +218,10 @@ public class InstrumentedEbeanLocalAccessTest {
 
   @Test
   public void testConfigureOptionalForceIndexDelegates() {
-    _instrumented.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
-    verify(_mockDelegate).configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+    Map<Class<? extends RecordTemplate>, String> criteria =
+        Collections.singletonMap(AspectFoo.class, "/value");
+    _instrumented.configureOptionalForceIndex("PRIMARY", criteria);
+    verify(_mockDelegate).configureOptionalForceIndex("PRIMARY", criteria);
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
@@ -217,6 +217,12 @@ public class InstrumentedEbeanLocalAccessTest {
   }
 
   @Test
+  public void testConfigureOptionalForceIndexDelegates() {
+    _instrumented.configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+    verify(_mockDelegate).configureOptionalForceIndex("PRIMARY", AspectFoo.class);
+  }
+
+  @Test
   public void testReadDeletionInfoBatchDelegatesAndRecordsLatency() {
     Map<TestUrn, EntityDeletionInfo> expected = new HashMap<>();
     when(_mockDelegate.readDeletionInfoBatch(any(), anyBoolean())).thenReturn(expected);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -186,6 +186,52 @@ public class SQLStatementUtilsTest {
   }
 
   @Test
+  public void testCreateFilterSqlWithForceIndex() {
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+
+    IndexCriterion indexCriterion =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.GREATER_THAN_OR_EQUAL_TO,
+            IndexValue.create(25));
+    indexCriterionArray.add(indexCriterion);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    // null forceIndexName — identical to the 4-arg overload
+    String sqlNoHint = SQLStatementUtils.createFilterSql("foo", indexFilter, false, mockValidator, null);
+    String expectedNoHint = "SELECT urn FROM metadata_entity_foo\n"
+        + "WHERE i_aspectfoo$value >= 25\n" + "AND deleted_ts IS NULL";
+    assertEquals(sqlNoHint, expectedNoHint);
+
+    // non-null forceIndexName — FORCE INDEX clause between table name and WHERE
+    String sqlWithHint = SQLStatementUtils.createFilterSql("foo", indexFilter, false, mockValidator,
+        "idx_urn$model_urn$status");
+    String expectedWithHint = "SELECT urn FROM metadata_entity_foo FORCE INDEX (`idx_urn$model_urn$status`)\n"
+        + "WHERE i_aspectfoo$value >= 25\n" + "AND deleted_ts IS NULL";
+    assertEquals(sqlWithHint, expectedWithHint);
+  }
+
+  @Test
+  public void testForceIndexCountQueryRewriteCompatibility() {
+    IndexFilter indexFilter = new IndexFilter();
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray();
+    IndexCriterion indexCriterion =
+        SQLIndexFilterUtils.createIndexCriterion(AspectFoo.class, "value", Condition.EQUAL,
+            IndexValue.create(42));
+    indexCriterionArray.add(indexCriterion);
+    indexFilter.setCriteria(indexCriterionArray);
+
+    String baseSql = SQLStatementUtils.createFilterSql("foo", indexFilter, false, mockValidator,
+        "idx_urn$model_urn$status");
+    String countSql = baseSql.replaceFirst("SELECT urn", "SELECT COUNT(urn) AS _total_count");
+
+    // COUNT rewrite must preserve the FORCE INDEX clause
+    String expectedCountSql = "SELECT COUNT(urn) AS _total_count FROM metadata_entity_foo"
+        + " FORCE INDEX (`idx_urn$model_urn$status`)\n"
+        + "WHERE i_aspectfoo$value = 42\n" + "AND deleted_ts IS NULL";
+    assertEquals(countSql, expectedCountSql);
+  }
+
+  @Test
   public void testCreateFilterSqlWithArrayContainsCondition() {
     IndexFilter indexFilter = new IndexFilter();
     IndexCriterionArray indexCriterionArray = new IndexCriterionArray();

--- a/spec/force-index-mlmodelinstance-spec.md
+++ b/spec/force-index-mlmodelinstance-spec.md
@@ -1,0 +1,365 @@
+# Spec: FORCE INDEX hint for `MlModelInstanceAssetService.filter`
+
+**Status:** datahub-gma PR implemented ([#616](https://github.com/linkedin/datahub-gma/pull/616)), MGA wiring pending.
+**Owner:** MG team (oncall: `naulashchick`). **Last decision:** All other options (histograms, drop-foot-gun, invisible
+index, Hikari `prefer_ordering_index=off`, alternative composite indexes) are off the table. FORCE INDEX in code is the
+only remaining structural fix.
+
+---
+
+## 1. Background
+
+`MlModelInstanceAssetService.filter` (gRPC, served by `metadata-graph-assets`) intermittently fails for the AIM team
+with `Code: Unknown` empty-message errors, concentrated at `paging.count = 100` (97.8% of observed failures over a 48h
+window). The query gets killed by MySQL's 5s threshold.
+
+### Failing query shape
+
+App-generated; cannot be modified at the call site:
+
+```sql
+SELECT urn FROM metadata_entity_mlmodelinstance
+WHERE i_urn$model_urn IN (<~15 model URNs>)
+  AND a_model_instance_status IS NOT NULL
+  AND JSON_EXTRACT(a_model_instance_status, '$.gma_deleted') IS NULL
+  AND i_model_instance_status$status = 'ACTIVE'
+  AND deleted_ts IS NULL
+ORDER BY urn LIMIT 100 OFFSET 0;
+```
+
+### Root cause
+
+MySQL's `prefer_ordering_index=on` heuristic. At small `LIMIT`, the optimizer prefers a no-filesort plan that walks an
+index already ordered by `urn` (PRIMARY, or formerly `idx2_model_instance_status$status`), expecting to find `LIMIT`
+matching rows quickly. In practice the IN-list matches are sparsely distributed across urn-space, so the walk traverses
+millions of rows and times out.
+
+### Existing schema state on `metadata_entity_mlmodelinstance` (~1.47M rows, ~117 GB)
+
+- `PRIMARY KEY (urn)` -- clustered.
+- `idx_urn$model_urn (urn, i_urn$model_urn)` -- dead (urn never constrained).
+- `idx2_urn$model_urn (i_urn$model_urn)` -- useful for the IN-list seek.
+- `idx_urn$model_urn$status (i_urn$model_urn, i_model_instance_status$status)` -- composite added in
+  [PR #882](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/882) (Flyway V24). Useful for the
+  IN-list seek with status as second column.
+- `idx_model_instance_status$status (urn, i_model_instance_status$status)` -- dead.
+- `idx2_model_instance_status$status (i_model_instance_status$status)` -- formerly mis-picked at small `LIMIT`; dropped
+  via [PR #898](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/898) (Flyway V26). After drop, the
+  optimizer just shifted to PRIMARY scan with the same pathology.
+- `idx_model_instance_info$trained_model_urn (i_model_instance_info$trained_model_urn)` -- for `findByTrainedModelUrn`,
+  unrelated.
+
+### Why FORCE INDEX
+
+Only structural fix that:
+
+- Doesn't require running heavy DDL on a 117 GB prod table.
+- Doesn't require server-side stats/optimizer changes (which the MySQL SRE team declined).
+- Is bounded to one entity (not a global flag flip).
+- Is reversible without touching prod schema.
+
+`FORCE INDEX` (not `USE INDEX`): hard directive -- optimizer must use the named index. `USE INDEX` is only a suggestion.
+
+---
+
+## 2. Solution overview
+
+Add `configureOptionalForceIndex(indexName, requiredCriteria)` to `datahub-gma`. The FORCE INDEX hint is only emitted
+when the `IndexFilter` contains criteria matching ALL configured (aspect, path) pairs -- ensuring the hint only fires
+for the exact composite query shape it was designed for. MGA registers the configuration on the mlmodelinstance DAO
+only. No other entity, no other code path affected.
+
+### End state -- generated SQL
+
+For mlmodelinstance filter (when filter contains both `model_urn` and `status` criteria):
+
+```sql
+SELECT urn FROM metadata_entity_mlmodelinstance FORCE INDEX (`idx_urn$model_urn$status`)
+WHERE i_urn$model_urn IN (...) AND ... ORDER BY urn LIMIT 100 OFFSET 0;
+```
+
+Count query (auto-derived via `replaceFirst` from the same base SQL):
+
+```sql
+SELECT COUNT(urn) AS _total_count FROM metadata_entity_mlmodelinstance FORCE INDEX (`idx_urn$model_urn$status`)
+WHERE i_urn$model_urn IN (...) AND ...;
+```
+
+For every other entity, every other query shape, or when the filter lacks the required criteria: SQL output unchanged.
+
+---
+
+## 3. Code changes
+
+Two repos. `datahub-gma`: 5 production files + tests. `metadata-graph-assets`: 1 file.
+
+### 3.1. `datahub-gma` -- `SQLStatementUtils.createFilterSql`
+
+**Path:** `dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java`
+
+**Change:** New 5-arg overload with `@Nullable String forceIndexName`. Existing 4-arg delegates with `null`.
+
+```java
+public static String createFilterSql(String entityType, @Nullable IndexFilter indexFilter,
+    boolean nonDollarVirtualColumnsEnabled, @Nonnull SchemaValidatorUtil schemaValidator) {
+  return createFilterSql(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator, null);
+}
+
+public static String createFilterSql(String entityType, @Nullable IndexFilter indexFilter,
+    boolean nonDollarVirtualColumnsEnabled, @Nonnull SchemaValidatorUtil schemaValidator,
+    @Nullable String forceIndexName) {
+  final String tableName = getTableName(entityType);
+  final String whereClause = parseIndexFilter(entityType, indexFilter, nonDollarVirtualColumnsEnabled, schemaValidator);
+  final String forceIndex = (forceIndexName == null) ? "" : " FORCE INDEX (`" + forceIndexName + "`)";
+  return "SELECT urn FROM " + tableName + forceIndex + "\n" + whereClause;
+}
+```
+
+The FORCE INDEX clause sits between the table name and `\n<WHERE>`, so the existing
+`replaceFirst("SELECT urn", "SELECT COUNT(urn) AS _total_count")` count-query rewrite is unaffected.
+
+### 3.2. `datahub-gma` -- `IEbeanLocalAccess` interface
+
+**Path:** `dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java`
+
+**Change:** Add `configureOptionalForceIndex` to the interface.
+
+```java
+void configureOptionalForceIndex(@Nullable String indexName,
+    @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria);
+```
+
+### 3.3. `datahub-gma` -- `EbeanLocalAccess`
+
+**Path:** `dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java`
+
+**Fields:**
+
+```java
+private String _forceIndexName;
+private Map<String, String> _forceIndexRequiredCriteria;  // aspect FQCN -> path
+```
+
+**`configureOptionalForceIndex`** -- converts `Class<?>` keys to FQCN strings at config time for compile-time safety:
+
+```java
+@Override
+public void configureOptionalForceIndex(@Nullable String indexName,
+    @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {
+  _forceIndexName = indexName;
+  if (requiredCriteria != null) {
+    _forceIndexRequiredCriteria = requiredCriteria.entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey().getCanonicalName(), Map.Entry::getValue));
+  } else {
+    _forceIndexRequiredCriteria = null;
+  }
+}
+```
+
+**`resolveForceIndex`** -- returns the index name only when ALL (aspect, path) pairs match the filter criteria:
+
+```java
+@Nullable
+private String resolveForceIndex(@Nullable IndexFilter indexFilter) {
+  if (_forceIndexName == null || _forceIndexRequiredCriteria == null || _forceIndexRequiredCriteria.isEmpty()) {
+    return null;
+  }
+  if (indexFilter == null || !indexFilter.hasCriteria()) {
+    return null;
+  }
+  boolean allMatch = _forceIndexRequiredCriteria.entrySet().stream().allMatch(required ->
+      indexFilter.getCriteria().stream().anyMatch(c ->
+          required.getKey().equals(c.getAspect())
+              && c.hasPathParams()
+              && required.getValue().equals(c.getPathParams().getPath())));
+  return allMatch ? _forceIndexName : null;
+}
+```
+
+**`validateForceIndex`** -- called during `ensureSchemaUpToDate()`. Uses `SchemaValidatorUtil.indexExists()` (cached).
+If the index is missing, logs ERROR and auto-disables the hint instead of crashing:
+
+```java
+void validateForceIndex() {
+  if (_forceIndexName == null) {
+    return;
+  }
+  String tableName = getTableName(_entityType);
+  if (!validator.indexExists(tableName, _forceIndexName)) {
+    log.error("Configured forceIndexName '{}' does not exist on table '{}'. "
+        + "Disabling FORCE INDEX hint to prevent query failures.", _forceIndexName, tableName);
+    _forceIndexName = null;
+    _forceIndexRequiredCriteria = null;
+  }
+}
+```
+
+**Offset-pagination `listUrns`** -- the only query path that receives the hint:
+
+```java
+@Override
+public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter,
+    @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
+  // When configured, emit FORCE INDEX to override MySQL's prefer_ordering_index heuristic
+  // which can pick a full-table PRIMARY scan instead of the composite index at small LIMITs.
+  final String effectiveForceIndex = resolveForceIndex(indexFilter);
+  final String baseSql = SQLStatementUtils.createFilterSql(_entityType, indexFilter,
+      _nonDollarVirtualColumnsEnabled, validator, effectiveForceIndex);
+  // Run COUNT in a separate query so neither query exceeds the 5s kill threshold.
+  final String countSql = baseSql.replaceFirst("SELECT urn", "SELECT COUNT(urn) AS _total_count");
+  // ... rest unchanged ...
+}
+```
+
+The keyset-pagination `listUrns(IndexFilter, IndexSortCriterion, URN lastUrn, int pageSize)` is NOT modified.
+
+### 3.4. `datahub-gma` -- `InstrumentedEbeanLocalAccess`
+
+**Path:** `dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java`
+
+Delegates `configureOptionalForceIndex` to the wrapped `_delegate`.
+
+### 3.5. `datahub-gma` -- `EbeanLocalDAO`
+
+**Path:** `dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java`
+
+Public `configureOptionalForceIndex` that delegates to `_localAccess` when non-null (NEW_SCHEMA mode). No constructor
+changes.
+
+### 3.6. `metadata-graph-assets` -- wire the hint for mlmodelinstance only
+
+**Path:**
+`metadata-graph-assets-dao-factories/src/main/java/com/linkedin/metadata/factory/aim/MlModelInstanceLocalDaoFactory.java`
+
+```diff
+   @Override
+   protected EbeanLocalDAO<InternalMlModelInstanceAspect, MlModelInstanceUrn> createInstance(@Nonnull ConfigView view) {
+     EbeanLocalDAO<InternalMlModelInstanceAspect, MlModelInstanceUrn> dao = super.createInstance(view);
+     dao.setUrnPathExtractor(new MlModelInstanceUrnPathExtractor());
+     dao.setUseAspectColumnForRelationshipRemoval(true);
++    Map<Class<? extends RecordTemplate>, String> forceIndexCriteria = new LinkedHashMap<>();
++    forceIndexCriteria.put(MlModelInstanceUrn.class, "/model_urn");
++    forceIndexCriteria.put(MlModelInstanceStatus.class, "/status");
++    dao.configureOptionalForceIndex("idx_urn$model_urn$status", forceIndexCriteria);
+     return dao;
+   }
+```
+
+**Note:** The path values (`"/model_urn"`, `"/status"`) must match the `IndexCriterion.pathParams.path` format sent by
+the gRPC client. The PDL spec for `IndexPathParams.path` documents the leading-`/` convention (e.g., `"/removed"`).
+Verify the actual runtime values before the MGA PR.
+
+---
+
+## 4. Tests
+
+### 4.1. `datahub-gma` unit tests
+
+**File:** `dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java`
+
+- `testCreateFilterSqlWithForceIndex` -- null produces no hint (regression); non-null emits `FORCE INDEX`.
+- `testForceIndexCountQueryRewriteCompatibility` -- `replaceFirst` count rewrite preserves the FORCE INDEX clause.
+
+### 4.2. `datahub-gma` integration tests
+
+**File:** `dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java`
+
+Tests run against embedded MariaDB:
+
+- `testListUrnsWithOffsetAndForceIndex` -- FORCE INDEX activates when filter matches required (aspect, path) criteria.
+- `testForceIndexNotAppliedWhenFilterLacksRequiredAspect` -- wrong aspect in config, hint does not activate.
+- `testForceIndexNotAppliedWhenFilterLacksRequiredPath` -- right aspect but wrong path, hint does not activate.
+- `testListUrnsWithLastUrnIgnoresForceIndex` -- keyset-pagination path is unaffected.
+- `testListUrnsWithOffsetAndNullForceIndex` -- null config produces default behavior.
+- `testForceIndexNotAppliedWhenFilterIsNull` -- null IndexFilter, hint does not activate.
+- `testValidateForceIndexDisablesHintWhenIndexMissing` -- non-existent index auto-disabled at validation.
+- `testValidateForceIndexKeepsHintWhenIndexExists` -- PRIMARY index passes validation.
+- `testValidateForceIndexNoOpWhenNotConfigured` -- null config, validation is a no-op.
+
+**File:** `dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java`
+
+- `testConfigureOptionalForceIndexDelegates` -- verifies delegation to wrapped implementation.
+
+---
+
+## 5. Release sequence
+
+1. **datahub-gma PR** ([#616](https://github.com/linkedin/datahub-gma/pull/616)): all code + tests. Reviewed and merged.
+2. **datahub-gma release:** wait for the next version cut.
+3. **metadata-graph-assets PR:** bump datahub-gma dependency, add `configureOptionalForceIndex(...)` in
+   `MlModelInstanceLocalDaoFactory`. Reviewed and merged.
+4. **Deploy MGA to canary fabric** -- recommend `prod-lor1` since AIM-team failures concentrate there.
+5. **Verify on canary** (see SS7).
+6. **Roll to remaining prod fabrics** (ltx1, lva1).
+7. **Coordinate with AIM team** to remove the `count == 100 -> 1000` clamp in mlops-midtier.
+
+---
+
+## 6. Pre-conditions
+
+- V24 composite index `idx_urn$model_urn$status` already exists in all prod fabrics (deployed via
+  [PR #882](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/882)). If missing, the startup
+  validation auto-disables the hint and logs an ERROR (queries degrade to default plan, not crash).
+- The `idx2_model_instance_status$status` drop
+  ([PR #898](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/898)) is independent -- FORCE INDEX
+  makes the optimizer's mis-pick irrelevant regardless.
+
+---
+
+## 7. Verification on canary fabric
+
+After deploying the patched MGA to one prod fabric:
+
+1. **Confirm the SQL the app emits.** Enable MGA's slow-query log or add a debug log in `EbeanLocalAccess.listUrns`.
+   Confirm it contains `` FORCE INDEX (`idx_urn$model_urn$status`) `` for an mlmodelinstance filter call that includes
+   both `model_urn` and `status` criteria.
+2. **Run the failing query directly against MySQL** at `LIMIT 100` and verify:
+   - `EXPLAIN` shows `key = idx_urn$model_urn$status`, `rows` in the low thousands.
+   - Wall-clock completes in < 500 ms (preferably < 100 ms).
+3. **Watch the gRPC error rate dashboard for the patched fabric.** Expect: error rate on the patched fabric drops to
+   baseline within minutes.
+4. **Confirm no regression on other entities** by sampling non-mlmodelinstance filter calls -- their SQL must not
+   contain FORCE INDEX.
+
+---
+
+## 8. Risks & mitigations
+
+| Risk                                                                             | Mitigation                                                                                                                    |
+| -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Index renamed or dropped without updating MGA config                             | Startup validation auto-disables the hint and logs ERROR. Queries degrade to default plan instead of failing.                 |
+| MariaDB-embedded tests parse FORCE INDEX differently than prod MySQL 8.0         | Verified in CI -- embedded MariaDB accepts the syntax.                                                                        |
+| Future TiDB migration: TiDB accepts FORCE INDEX syntax but plan semantics differ | Per-entity opt-in means TiDB-backed entities can be left unconfigured.                                                        |
+| Other gma-using MPs accidentally adopt the hint                                  | Javadoc on `configureOptionalForceIndex` notes it's per-asset opt-in for known pathological queries. Default null.            |
+| Filter criteria path format mismatch (with/without leading `/`)                  | Verify actual runtime `IndexCriterion.pathParams.path` values before the MGA PR. Consider path normalization if formats vary. |
+
+---
+
+## 9. Rollback
+
+Two levels:
+
+1. **Per-fabric (fast):** revert the MGA wiring commit (`configureOptionalForceIndex` call in
+   `MlModelInstanceLocalDaoFactory.java`) and redeploy. The datahub-gma library change stays in place, dormant. Single
+   MGA deploy cycle (~1h).
+2. **Full revert:** revert both the MGA PR and the datahub-gma PR. No DDL state to reconcile.
+
+---
+
+## 10. Acceptance criteria
+
+- `EXPLAIN` of the failing query at `LIMIT 100` in prod shows `key = idx_urn$model_urn$status`, `rows` in the low
+  thousands, completes in < 500 ms.
+- `MlModelInstanceAssetService.filter` `Code: Unknown` error rate drops to baseline on each rolled-out fabric.
+- AIM team's mlops-midtier `count == 100 -> 1000` clamp can be removed without re-introducing failures.
+- No regression in any non-mlmodelinstance filter query (no FORCE INDEX in sampled SQL; error rates unchanged).
+- Filter queries that lack the required (aspect, path) criteria do NOT receive the FORCE INDEX hint.
+
+---
+
+## 11. Reference materials
+
+- Composite-index PR (V24): [PR #882](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/882)
+- Foot-gun-drop PR (V26): [PR #898](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/898)
+- datahub-gma implementation PR: [PR #616](https://github.com/linkedin/datahub-gma/pull/616)
+- LinkedIn MySQL fork version: `8.0.28-li.1`

--- a/spec/force-index-mlmodelinstance-spec.md
+++ b/spec/force-index-mlmodelinstance-spec.md
@@ -282,48 +282,7 @@ Tests run against embedded MariaDB:
 
 ---
 
-## 5. Release sequence
-
-1. **datahub-gma PR** ([#616](https://github.com/linkedin/datahub-gma/pull/616)): all code + tests. Reviewed and merged.
-2. **datahub-gma release:** wait for the next version cut.
-3. **metadata-graph-assets PR:** bump datahub-gma dependency, add `configureOptionalForceIndex(...)` in
-   `MlModelInstanceLocalDaoFactory`. Reviewed and merged.
-4. **Deploy MGA to canary fabric** -- recommend `prod-lor1` since AIM-team failures concentrate there.
-5. **Verify on canary** (see SS7).
-6. **Roll to remaining prod fabrics** (ltx1, lva1).
-7. **Coordinate with AIM team** to remove the `count == 100 -> 1000` clamp in mlops-midtier.
-
----
-
-## 6. Pre-conditions
-
-- V24 composite index `idx_urn$model_urn$status` already exists in all prod fabrics (deployed via
-  [PR #882](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/882)). If missing, the startup
-  validation auto-disables the hint and logs an ERROR (queries degrade to default plan, not crash).
-- The `idx2_model_instance_status$status` drop
-  ([PR #898](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/898)) is independent -- FORCE INDEX
-  makes the optimizer's mis-pick irrelevant regardless.
-
----
-
-## 7. Verification on canary fabric
-
-After deploying the patched MGA to one prod fabric:
-
-1. **Confirm the SQL the app emits.** Enable MGA's slow-query log or add a debug log in `EbeanLocalAccess.listUrns`.
-   Confirm it contains `` FORCE INDEX (`idx_urn$model_urn$status`) `` for an mlmodelinstance filter call that includes
-   both `model_urn` and `status` criteria.
-2. **Run the failing query directly against MySQL** at `LIMIT 100` and verify:
-   - `EXPLAIN` shows `key = idx_urn$model_urn$status`, `rows` in the low thousands.
-   - Wall-clock completes in < 500 ms (preferably < 100 ms).
-3. **Watch the gRPC error rate dashboard for the patched fabric.** Expect: error rate on the patched fabric drops to
-   baseline within minutes.
-4. **Confirm no regression on other entities** by sampling non-mlmodelinstance filter calls -- their SQL must not
-   contain FORCE INDEX.
-
----
-
-## 8. Risks & mitigations
+## 5. Risks & mitigations
 
 | Risk                                                                             | Mitigation                                                                                                                    |
 | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
@@ -332,34 +291,3 @@ After deploying the patched MGA to one prod fabric:
 | Future TiDB migration: TiDB accepts FORCE INDEX syntax but plan semantics differ | Per-entity opt-in means TiDB-backed entities can be left unconfigured.                                                        |
 | Other gma-using MPs accidentally adopt the hint                                  | Javadoc on `configureOptionalForceIndex` notes it's per-asset opt-in for known pathological queries. Default null.            |
 | Filter criteria path format mismatch (with/without leading `/`)                  | Verify actual runtime `IndexCriterion.pathParams.path` values before the MGA PR. Consider path normalization if formats vary. |
-
----
-
-## 9. Rollback
-
-Two levels:
-
-1. **Per-fabric (fast):** revert the MGA wiring commit (`configureOptionalForceIndex` call in
-   `MlModelInstanceLocalDaoFactory.java`) and redeploy. The datahub-gma library change stays in place, dormant. Single
-   MGA deploy cycle (~1h).
-2. **Full revert:** revert both the MGA PR and the datahub-gma PR. No DDL state to reconcile.
-
----
-
-## 10. Acceptance criteria
-
-- `EXPLAIN` of the failing query at `LIMIT 100` in prod shows `key = idx_urn$model_urn$status`, `rows` in the low
-  thousands, completes in < 500 ms.
-- `MlModelInstanceAssetService.filter` `Code: Unknown` error rate drops to baseline on each rolled-out fabric.
-- AIM team's mlops-midtier `count == 100 -> 1000` clamp can be removed without re-introducing failures.
-- No regression in any non-mlmodelinstance filter query (no FORCE INDEX in sampled SQL; error rates unchanged).
-- Filter queries that lack the required (aspect, path) criteria do NOT receive the FORCE INDEX hint.
-
----
-
-## 11. Reference materials
-
-- Composite-index PR (V24): [PR #882](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/882)
-- Foot-gun-drop PR (V26): [PR #898](https://github.com/linkedin-multiproduct/metadata-graph-assets/pull/898)
-- datahub-gma implementation PR: [PR #616](https://github.com/linkedin/datahub-gma/pull/616)
-- LinkedIn MySQL fork version: `8.0.28-li.1`

--- a/spec/force-index-mlmodelinstance-spec.md
+++ b/spec/force-index-mlmodelinstance-spec.md
@@ -65,9 +65,11 @@ Only structural fix that:
 ## 2. Solution overview
 
 Add `configureOptionalForceIndex(indexName, requiredCriteria)` to `datahub-gma`. The FORCE INDEX hint is only emitted
-when the `IndexFilter` contains criteria matching ALL configured (aspect, path) pairs -- ensuring the hint only fires
-for the exact composite query shape it was designed for. MGA registers the configuration on the mlmodelinstance DAO
-only. No other entity, no other code path affected.
+when the `IndexFilter`'s path-bearing criteria (those with `pathParams`) exactly match the configured (aspect, path)
+pairs -- same count, all match. Criteria without `pathParams` (aspect-existence checks that produce `IS NOT NULL` /
+soft-delete guards) are excluded from the comparison since they don't affect index choice. This is intentionally strict:
+if the filter shape changes, the hint deactivates and MySQL picks its own plan. MGA registers the configuration on the
+mlmodelinstance DAO only. No other entity, no other code path affected.
 
 ### End state -- generated SQL
 
@@ -156,7 +158,8 @@ public void configureOptionalForceIndex(@Nullable String indexName,
 }
 ```
 
-**`resolveForceIndex`** -- returns the index name only when ALL (aspect, path) pairs match the filter criteria:
+**`resolveForceIndex`** -- exact-matches the filter's path-bearing criteria against the configured pairs. Criteria
+without `pathParams` are excluded. Path comparison normalizes leading `/` to tolerate convention differences:
 
 ```java
 @Nullable
@@ -167,12 +170,21 @@ private String resolveForceIndex(@Nullable IndexFilter indexFilter) {
   if (indexFilter == null || !indexFilter.hasCriteria()) {
     return null;
   }
+  List<IndexCriterion> pathBearingCriteria = indexFilter.getCriteria().stream()
+      .filter(IndexCriterion::hasPathParams)
+      .collect(Collectors.toList());
+  if (pathBearingCriteria.size() != _forceIndexRequiredCriteria.size()) {
+    return null;
+  }
   boolean allMatch = _forceIndexRequiredCriteria.entrySet().stream().allMatch(required ->
-      indexFilter.getCriteria().stream().anyMatch(c ->
+      pathBearingCriteria.stream().anyMatch(c ->
           required.getKey().equals(c.getAspect())
-              && c.hasPathParams()
-              && required.getValue().equals(c.getPathParams().getPath())));
+              && normalizePath(required.getValue()).equals(normalizePath(c.getPathParams().getPath()))));
   return allMatch ? _forceIndexName : null;
+}
+
+private static String normalizePath(@Nonnull String path) {
+  return path.startsWith("/") ? path.substring(1) : path;
 }
 ```
 
@@ -266,9 +278,12 @@ Verify the actual runtime values before the MGA PR.
 
 Tests run against embedded MariaDB:
 
-- `testListUrnsWithOffsetAndForceIndex` -- FORCE INDEX activates when filter matches required (aspect, path) criteria.
-- `testForceIndexNotAppliedWhenFilterLacksRequiredAspect` -- wrong aspect in config, hint does not activate.
+- `testListUrnsWithOffsetAndForceIndex` -- FORCE INDEX activates when filter exactly matches required criteria.
+- `testForceIndexNotAppliedWhenFilterLacksRequiredAspect` -- wrong aspect, hint does not activate.
 - `testForceIndexNotAppliedWhenFilterLacksRequiredPath` -- right aspect but wrong path, hint does not activate.
+- `testForceIndexNotAppliedWhenFilterHasExtraPathCriteria` -- extra path-bearing criterion, hint does not activate.
+- `testForceIndexIgnoresAspectOnlyCriteria` -- aspect-only criteria (no pathParams) excluded from match.
+- `testForceIndexPathNormalization` -- config with leading `/`, filter without -- normalization makes them match.
 - `testListUrnsWithLastUrnIgnoresForceIndex` -- keyset-pagination path is unaffected.
 - `testListUrnsWithOffsetAndNullForceIndex` -- null config produces default behavior.
 - `testForceIndexNotAppliedWhenFilterIsNull` -- null IndexFilter, hint does not activate.
@@ -284,10 +299,10 @@ Tests run against embedded MariaDB:
 
 ## 5. Risks & mitigations
 
-| Risk                                                                             | Mitigation                                                                                                                    |
-| -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Index renamed or dropped without updating MGA config                             | Startup validation auto-disables the hint and logs ERROR. Queries degrade to default plan instead of failing.                 |
-| MariaDB-embedded tests parse FORCE INDEX differently than prod MySQL 8.0         | Verified in CI -- embedded MariaDB accepts the syntax.                                                                        |
-| Future TiDB migration: TiDB accepts FORCE INDEX syntax but plan semantics differ | Per-entity opt-in means TiDB-backed entities can be left unconfigured.                                                        |
-| Other gma-using MPs accidentally adopt the hint                                  | Javadoc on `configureOptionalForceIndex` notes it's per-asset opt-in for known pathological queries. Default null.            |
-| Filter criteria path format mismatch (with/without leading `/`)                  | Verify actual runtime `IndexCriterion.pathParams.path` values before the MGA PR. Consider path normalization if formats vary. |
+| Risk                                                                             | Mitigation                                                                                                         |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Index renamed or dropped without updating MGA config                             | Startup validation auto-disables the hint and logs ERROR. Queries degrade to default plan instead of failing.      |
+| MariaDB-embedded tests parse FORCE INDEX differently than prod MySQL 8.0         | Verified in CI -- embedded MariaDB accepts the syntax.                                                             |
+| Future TiDB migration: TiDB accepts FORCE INDEX syntax but plan semantics differ | Per-entity opt-in means TiDB-backed entities can be left unconfigured.                                             |
+| Other gma-using MPs accidentally adopt the hint                                  | Javadoc on `configureOptionalForceIndex` notes it's per-asset opt-in for known pathological queries. Default null. |
+| Filter criteria path format mismatch (with/without leading `/`)                  | Path comparison normalizes leading `/` -- `"/status"` and `"status"` are treated as equal.                         |


### PR DESCRIPTION
## Summary

- Adds per-DAO `configureOptionalForceIndex(String indexName, Class<? extends RecordTemplate> requiredAspect)` that conditionally emits a MySQL `FORCE INDEX` hint on the offset-pagination `listUrns` filter query
- The hint only activates when the `IndexFilter` contains a criterion matching the required aspect class — other queries against the same entity table are unaffected
- At startup, validates the configured index exists via `SchemaValidatorUtil.indexExists()`; if missing, auto-disables the hint and logs an ERROR instead of letting queries fail

## Motivation

`MlModelInstanceAssetService.filter` intermittently times out because MySQL's `prefer_ordering_index=on` heuristic picks a PRIMARY key scan instead of the composite index `idx_urn$model_urn$status`. FORCE INDEX is the only structural fix that doesn't require DDL on the 117GB prod table or server-side optimizer changes. See `spec/force-index-mlmodelinstance-spec.md` for full investigation.

## Changes

| File | Change |
|---|---|
| `SQLStatementUtils.java` | New 5-arg `createFilterSql` overload with `forceIndexName`; existing 4-arg delegates with `null` |
| `IEbeanLocalAccess.java` | Added `configureOptionalForceIndex(String, Class<? extends RecordTemplate>)` |
| `EbeanLocalAccess.java` | Stores index name + required aspect FQCN; `resolveForceIndex()` gates on `IndexFilter` criteria; `validateForceIndex()` checks index existence at boot |
| `InstrumentedEbeanLocalAccess.java` | Delegates `configureOptionalForceIndex` to wrapped `_delegate` |
| `EbeanLocalDAO.java` | Public `configureOptionalForceIndex` that delegates to `_localAccess` |

## Test plan

- [x] Unit test: `createFilterSql` with null `forceIndexName` — identical to 4-arg (regression)
- [x] Unit test: `createFilterSql` with non-null `forceIndexName` — `FORCE INDEX` between table name and WHERE
- [x] Unit test: count-query `replaceFirst` rewrite preserves FORCE INDEX clause
- [x] Integration test: offset-pagination `listUrns` with FORCE INDEX executes against embedded MariaDB
- [x] Integration test: FORCE INDEX not applied when filter lacks the required aspect
- [x] Integration test: keyset-pagination path does NOT include FORCE INDEX
- [x] Integration test: null config produces identical results to default
- [x] Integration test: `validateForceIndex` auto-disables when index is missing
- [x] Integration test: `validateForceIndex` keeps hint when index exists (PRIMARY)

## Follow-up (metadata-graph-assets)

After this is released, MGA adds one line in `MlModelInstanceLocalDaoFactory.createInstance()`:
```java
dao.configureOptionalForceIndex("idx_urn$model_urn$status", MlModelInstanceStatus.class);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)