### PR TITLE
fix(ebean-dao): move SharedSchemaCache pre-warm to EbeanLocalAccess c…

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -97,6 +97,10 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
     _schemaEvolutionManager = createSchemaEvolutionManager(serverConfig);
     _nonDollarVirtualColumnsEnabled = nonDollarVirtualColumnsEnabled;
     validator = buildValidator(server, serverConfig);
+    // Pre-warm at construction time so the cache is hot before the first request,
+    // regardless of whether ensureSchemaUpToDate() is called by the service.
+    validator.registerAndPreWarm(getTableName(_entityType));
+    validator.registerAndPreWarm(getTestTableName(_entityType));
   }
 
   private static SchemaValidatorUtil buildValidator(EbeanServer server, ServerConfig serverConfig) {
@@ -135,9 +139,6 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   public void ensureSchemaUpToDate() {
     _schemaEvolutionManager.ensureSchemaUpToDate();
-    // Pre-warm the shared cache for both the prod and test tables so the first request is never slow.
-    validator.registerAndPreWarm(getTableName(_entityType));
-    validator.registerAndPreWarm(getTestTableName(_entityType));
     validateForceIndex();
   }
 


### PR DESCRIPTION
…onstructor

ensureSchemaUpToDate() is LiX'd off in some services (e.g. MGA), so pre-warming was never firing in production. Moving registerAndPreWarm() into the constructor guarantees it runs at bean creation time regardless of whether ensureSchemaUpToDate() is called.

 ## Summary                                                                                                                                         
  
  - Moves `SharedSchemaCache` pre-warming from `ensureSchemaUpToDate()` into the `EbeanLocalAccess`                                                  
    constructor so it fires at bean creation time regardless of whether `ensureSchemaUpToDate()` is called
  - Root cause: `ensureSchemaUpToDate()` is LiX'd off in MGA so pre-warming was never executing in production
  - No behavior change for callers that do invoke `ensureSchemaUpToDate()` — schema evolution DDL still
    runs there; only the cache warm-up moved to constructor

  ## Testing Done

  - `SharedSchemaCacheTest` (14 tests) — pass
  - `EbeanLocalAccessTest` — pass
  - `EbeanLocalAccessTestWithoutServiceIdentifier` — pass

  ## Checklist

  - [x] Conforms to Commit Message Format

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
