### PR TITLE
fix(ebean-dao): widen configureOptionalForceIndex to accept Class<?>

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -126,7 +126,7 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
    */
   @Override
   public void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {
+      @Nullable Map<Class<?>, String> requiredCriteria) {
     _forceIndexName = indexName;
     if (requiredCriteria != null) {
       _forceIndexRequiredCriteria = requiredCriteria.entrySet().stream()

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -154,13 +154,15 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * deactivates and MySQL picks its own plan. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredCriteria map of aspect class to path (e.g. {@code "/status"}, {@code "/model_urn"})
+   * @param requiredCriteria map of aspect or URN class to path (e.g. {@code "/status"}, {@code "/model_urn"})
    *                         that must exactly match the filter's path-bearing criteria for the
-   *                         force index to activate, or null to disable. Leading '/' in paths is
-   *                         optional -- comparison is normalized.
+   *                         force index to activate, or null to disable. Accepts both
+   *                         {@code RecordTemplate} subclasses (aspects) and {@code Urn} subclasses
+   *                         (URN-derived index columns). Leading '/' in paths is optional --
+   *                         comparison is normalized.
    */
   public void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {
+      @Nullable Map<Class<?>, String> requiredCriteria) {
     if (_localAccess != null) {
       _localAccess.configureOptionalForceIndex(indexName, requiredCriteria);
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -30,13 +30,15 @@ public interface IEbeanLocalAccess<URN extends Urn> {
    * deactivates and MySQL picks its own plan. Pass {@code null} for both to disable.
    *
    * @param indexName MySQL index name, or null to disable
-   * @param requiredCriteria map of aspect class to path (e.g. {@code "/status"}, {@code "/model_urn"})
+   * @param requiredCriteria map of aspect or URN class to path (e.g. {@code "/status"}, {@code "/model_urn"})
    *                         that must exactly match the filter's path-bearing criteria for the
-   *                         force index to activate, or null to disable. Leading '/' in paths is
-   *                         optional -- comparison is normalized.
+   *                         force index to activate, or null to disable. Accepts both
+   *                         {@code RecordTemplate} subclasses (aspects) and {@code Urn} subclasses
+   *                         (URN-derived index columns). Leading '/' in paths is optional --
+   *                         comparison is normalized.
    */
   void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria);
+      @Nullable Map<Class<?>, String> requiredCriteria);
 
   /**
    * Upsert aspect into entity table.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
@@ -58,7 +58,7 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
 
   @Override
   public void configureOptionalForceIndex(@Nullable String indexName,
-      @Nullable Map<Class<? extends RecordTemplate>, String> requiredCriteria) {
+      @Nullable Map<Class<?>, String> requiredCriteria) {
     _delegate.configureOptionalForceIndex(indexName, requiredCriteria);
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -1006,7 +1006,7 @@ public class EbeanLocalAccessTest {
   @Test
   public void testListUrnsWithOffsetAndForceIndex() {
     // Filter contains (AspectFoo, "value") matching the required criteria — force index activates.
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
@@ -1029,7 +1029,7 @@ public class EbeanLocalAccessTest {
   @Test
   public void testForceIndexNotAppliedWhenFilterLacksRequiredAspect() {
     // Required criteria is (AspectBar, "value") but filter only has AspectFoo — must not activate.
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectBar.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectBar.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
@@ -1052,7 +1052,7 @@ public class EbeanLocalAccessTest {
   @Test
   public void testForceIndexNotAppliedWhenFilterLacksRequiredPath() {
     // Required criteria is (AspectFoo, "other") but filter has (AspectFoo, "value") — path mismatch.
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "other");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "other");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
@@ -1076,7 +1076,7 @@ public class EbeanLocalAccessTest {
   public void testForceIndexPathNormalization() {
     // Config uses "/value" (with leading slash), filter criterion uses "value" (without).
     // Normalization should make them match.
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "/value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "/value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
@@ -1100,7 +1100,7 @@ public class EbeanLocalAccessTest {
   public void testForceIndexNotAppliedWhenFilterHasExtraPathCriteria() {
     // Exact match: config requires only (AspectFoo, "value"), but filter has two path-bearing
     // criteria. The extra criterion means a different query shape — force index must not activate.
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
@@ -1127,7 +1127,7 @@ public class EbeanLocalAccessTest {
     // Criteria without pathParams (aspect-existence checks) should be excluded from the
     // exact match comparison. Config requires (AspectFoo, "value"); filter has that plus
     // an aspect-only criterion for AspectBar — should still activate.
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     IndexFilter indexFilter = new IndexFilter();
@@ -1151,7 +1151,7 @@ public class EbeanLocalAccessTest {
   @Test
   public void testListUrnsWithLastUrnIgnoresForceIndex() throws URISyntaxException {
     // Keyset-pagination path must NOT include FORCE INDEX even when configured.
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     List<FooUrn> result = _ebeanLocalAccessFoo.listUrns(null, null, null, 10);
@@ -1182,7 +1182,7 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testValidateForceIndexDisablesHintWhenIndexMissing() {
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("idx_does_not_exist", criteria);
     _ebeanLocalAccessFoo.validateForceIndex();
 
@@ -1202,7 +1202,7 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testValidateForceIndexKeepsHintWhenIndexExists() {
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
     _ebeanLocalAccessFoo.validateForceIndex();
 
@@ -1224,7 +1224,7 @@ public class EbeanLocalAccessTest {
 
   @Test
   public void testForceIndexNotAppliedWhenFilterIsNull() {
-    Map<Class<? extends RecordTemplate>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
+    Map<Class<?>, String> criteria = Collections.singletonMap(AspectFoo.class, "value");
     _ebeanLocalAccessFoo.configureOptionalForceIndex("PRIMARY", criteria);
 
     ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(null, null, 0, 10);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
@@ -218,7 +218,7 @@ public class InstrumentedEbeanLocalAccessTest {
 
   @Test
   public void testConfigureOptionalForceIndexDelegates() {
-    Map<Class<? extends RecordTemplate>, String> criteria =
+    Map<Class<?>, String> criteria =
         Collections.singletonMap(AspectFoo.class, "/value");
     _instrumented.configureOptionalForceIndex("PRIMARY", criteria);
     verify(_mockDelegate).configureOptionalForceIndex("PRIMARY", criteria);


### PR DESCRIPTION
## Summary

Widen `configureOptionalForceIndex` parameter from `Map<Class<? extends RecordTemplate>, String>` to `Map<Class<?>, String>`.

`IndexCriterion.aspect` can reference both `RecordTemplate` subclasses (aspect classes like `MlModelInstanceStatus`) and `Urn` subclasses (URN classes like `MlModelUrn` for URN-derived index columns). The previous type bound rejected URN classes at compile time, preventing MGA from wiring the force index for the mlmodelinstance filter query which requires both `MlModelUrn` (URN) and `MlModelInstanceStatus` (aspect) criteria.

Follow-up to #616.

## Testing Done

- [x] All existing `configureOptionalForceIndex` unit and integration tests updated and pass
- [x] End-to-end verified via local MGA deploy to qei-ltx1 against staging MySQL — FORCE INDEX emitted correctly for mlmodelinstance filter with both URN and aspect criteria

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Links to related issues: #616
- [ ] Docs related to the changes have been added/updated (if applicable)