### PR TITLE
perf(ebean-dao): collapse N per-aspect SQL queries into 1 in batchGetUnion

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -37,8 +37,8 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +65,11 @@ import static com.linkedin.metadata.dao.utils.SQLStatementUtils.*;
 @Slf4j
 public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN> {
   public static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+
+  // Maximum number of URNs per SQL IN clause. Keeps queries safe for MySQL query planner and packet limits.
+  // Aspect columns are always all selected in each chunk — only URN count is chunked.
+  static final int MAX_URNS_PER_QUERY = 100;
+
   private final EbeanServer _server;
   private final Class<URN> _urnClass;
   private final String _entityType;
@@ -300,13 +305,18 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
   }
 
   /**
-   * Construct and execute a SQL statement as follows.
-   * SELECT urn, aspect1, lastmodifiedon, lastmodifiedby FROM metadata_entity_foo WHERE JSON_EXTRACT(aspect1, '$.gma_deleted') IS NULL
-   * AND urn IN ('urn:1', 'urn:2', 'urn:3')
+   * Fetch aspects for the given keys in a single SQL query. Generates:
+   * SELECT urn, a_col1, a_col2, ..., lastmodifiedon, lastmodifiedby, createdfor
+   * FROM metadata_entity_foo WHERE urn IN (...) [AND deleted_ts IS NULL]
+   *
+   * <p>Aspect-level soft-deletes (gma_deleted) are NOT filtered in SQL — they are returned as marker rows
+   * and must be filtered by callers (e.g., EbeanLocalDAO.toRecordTemplate checks isSoftDeletedAspect).
+   * The includeSoftDeleted flag controls only asset-level deletion (deleted_ts column).
+   *
    * @param aspectKeys a List of keys (urn, aspect pairings) to query for
    * @param keysCount number of keys to query
    * @param position position of the key to start from
-   * @param includeSoftDeleted whether to include soft deleted aspect in the query
+   * @param includeSoftDeleted whether to include asset-level soft deleted entities (deleted_ts)
    * @param isTestMode whether the operation is in test mode or not
    */
   @Override
@@ -315,31 +325,38 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
       boolean includeSoftDeleted, boolean isTestMode) {
 
     final int end = Math.min(aspectKeys.size(), position + keysCount);
-    final Map<Class<ASPECT>, Set<Urn>> keysToQueryMap = new HashMap<>();
+
+    // Collect all valid aspect columns and all URNs, validating column existence per aspect class.
+    // Use LinkedHashSet for allUrns so IN-clause order is deterministic across runs/JVMs.
+    final Set<Urn> allUrns = new LinkedHashSet<>();
+    final Map<String, Class<ASPECT>> columnToAspectClassMap = new LinkedHashMap<>();
     for (int index = position; index < end; index++) {
       final Urn entityUrn = aspectKeys.get(index).getUrn();
       final Class<ASPECT> aspectClass = (Class<ASPECT>) aspectKeys.get(index).getAspectClass();
-      if (validator.columnExists(isTestMode ? getTestTableName(entityUrn) : getTableName(entityUrn),
-          getAspectColumnName(entityUrn.getEntityType(), aspectClass))) {
-        keysToQueryMap.computeIfAbsent(aspectClass, unused -> new HashSet<>()).add(entityUrn);
+      final String tableName = isTestMode ? getTestTableName(entityUrn) : getTableName(entityUrn);
+      final String columnName = getAspectColumnName(entityUrn.getEntityType(), aspectClass);
+      if (validator.columnExists(tableName, columnName)) {
+        columnToAspectClassMap.putIfAbsent(columnName, aspectClass);
+        allUrns.add(entityUrn);
       }
     }
 
-    // each statement is for a single aspect class
-    Map<String, Class<ASPECT>> selectStatements = keysToQueryMap.entrySet()
-        .stream()
-        .collect(Collectors.toMap(
-            entry -> SQLStatementUtils.createAspectReadSql(entry.getKey(), entry.getValue(), includeSoftDeleted,
-                isTestMode), entry -> entry.getKey()));
-
-    // consolidate/join the results
-    final Map<SqlRow, Class<ASPECT>> sqlRows = new LinkedHashMap<>();
-    for (Map.Entry<String, Class<ASPECT>> entry : selectStatements.entrySet()) {
-      for (SqlRow sqlRow : _server.createSqlQuery(entry.getKey()).findList()) {
-        sqlRows.put(sqlRow, entry.getValue());
-      }
+    if (columnToAspectClassMap.isEmpty()) {
+      return Collections.emptyList();
     }
-    return EBeanDAOUtils.readSqlRows(sqlRows);
+
+    // gma_deleted is NOT filtered in SQL — handled per-column in Java by readMultiAspectSqlRows.
+    // Chunk by URN count to keep IN clause size safe for MySQL. Single-URN-batch case is handled
+    // by the same loop with a single iteration.
+    final List<EbeanMetadataAspect> results = new ArrayList<>();
+    final List<Urn> urnList = new ArrayList<>(allUrns);
+    for (int i = 0; i < urnList.size(); i += MAX_URNS_PER_QUERY) {
+      final Set<Urn> chunk = new LinkedHashSet<>(urnList.subList(i, Math.min(i + MAX_URNS_PER_QUERY, urnList.size())));
+      final String sql = SQLStatementUtils.createMultiAspectReadSql(
+          columnToAspectClassMap.keySet(), chunk, includeSoftDeleted, isTestMode);
+      results.addAll(EBeanDAOUtils.readMultiAspectSqlRows(_server.createSqlQuery(sql).findList(), columnToAspectClassMap));
+    }
+    return results;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -1319,6 +1319,16 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       final List<EbeanMetadataAspect> oneStatementResult = batchGetHelper(new ArrayList<>(keys), keysCount, position);
       finalResult.addAll(oneStatementResult);
     }
+
+    // For DUAL_SCHEMA: compare the accumulated old-schema results (paged) against a single
+    // unpaged new-schema fetch. Doing the comparison here (rather than per-page in batchGetHelper)
+    // ensures both sides cover the same key set when keys.size() > keysCount.
+    boolean nonLatestVersionFlag = keys.stream().anyMatch(key -> key.getVersion() != LATEST_VERSION);
+    if (!nonLatestVersionFlag && _schemaConfig == SchemaConfig.DUAL_SCHEMA && _localAccess != null) {
+      final List<EbeanMetadataAspect> resultsNewSchema =
+          _localAccess.batchGetUnion(new ArrayList<>(keys), keys.size(), 0, false, false);
+      EBeanDAOUtils.compareResults(finalResult, resultsNewSchema, "batchGet");
+    }
     return finalResult;
   }
 
@@ -1383,16 +1393,19 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
 
     if (_schemaConfig == SchemaConfig.NEW_SCHEMA_ONLY) {
-      return _localAccess.batchGetUnion(keys, keysCount, position, false, false);
+      // For new schema, all aspects are columns in a single SELECT — no need for keysCount pagination.
+      // The first call (position=0) fetches everything; subsequent pages return empty to avoid duplicates.
+      if (position > 0) {
+        return Collections.emptyList();
+      }
+      return _localAccess.batchGetUnion(keys, keys.size(), 0, false, false);
     }
 
     if (_schemaConfig == SchemaConfig.DUAL_SCHEMA) {
-      // Compare results from both new and old schemas
-      final List<EbeanMetadataAspect> resultsOldSchema = batchGetUnion(keys, keysCount, position);
-      final List<EbeanMetadataAspect> resultsNewSchema =
-          _localAccess.batchGetUnion(keys, keysCount, position, false, false);
-      EBeanDAOUtils.compareResults(resultsOldSchema, resultsNewSchema, "batchGet");
-      return resultsOldSchema;
+      // Return paginated old-schema results per page; the cross-schema comparison is hoisted to
+      // batchGet() so both sides cover the same key set (avoiding spurious mismatches when
+      // keys.size() > keysCount).
+      return batchGetUnion(keys, keysCount, position);
     }
 
     log.error("Please check that the SchemaConfig supplied to EbeanLocalDAO constructor is valid.");

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/IEbeanLocalAccess.java
@@ -110,11 +110,27 @@ public interface IEbeanLocalAccess<URN extends Urn> {
       @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode);
 
   /**
-   * Get read aspects from entity table. This a new schema implementation for batchGetUnion() in {@link EbeanLocalDAO}
+   * Fetch aspects from the entity table using a single multi-column SELECT per URN chunk.
+   * This is the new-schema implementation for batchGetUnion() in {@link EbeanLocalDAO}.
+   *
+   * <p>Aspect-level soft-deletes (gma_deleted) are always returned as marker rows — callers must
+   * filter them (e.g., via {@code EbeanLocalDAO.toRecordTemplate} which checks {@code isSoftDeletedAspect}).
+   * The {@code includeSoftDeleted} flag controls only asset-level deletion (deleted_ts column).
+   *
+   * <p>URNs are chunked internally (max {@link EbeanLocalAccess#MAX_URNS_PER_QUERY} per SQL IN clause).
+   *
+   * <p><b>Cross-product semantics:</b> the input {@code keys} are reduced to a unique set of URNs and a
+   * unique set of aspect columns. The query selects ALL collected aspect columns for ALL collected URNs.
+   * If a caller passes heterogeneous pairs like {@code [(urn1, AspectFoo), (urn2, AspectBar)]} and both
+   * URNs have both columns populated, this returns 4 {@link EbeanMetadataAspect} entries — not the 2
+   * requested. The internal callers in {@link EbeanLocalDAO} re-filter via {@code matchKeys}, but external
+   * callers requesting heterogeneous (urn, aspect) pairs must filter to the exact requested pairs themselves.
+   *
    * @param keys {@link AspectKey} to retrieve aspect metadata
-   * @param keysCount pagination key count limit
-   * @param position starting position of pagination
-   * @param includeSoftDeleted include soft deleted aspects, default false
+   * @param keysCount slice window: the method processes {@code aspectKeys[position .. min(size, position+keysCount))}
+   *                  when collecting URNs and aspect columns. Callers that want to process all keys pass {@code keys.size()}.
+   * @param position starting index for the slice window (callers that want to process all keys pass {@code 0})
+   * @param includeSoftDeleted whether to include asset-level soft deleted entities (deleted_ts)
    * @param isTestMode whether the operation is in test mode or not
    * @param <ASPECT> metadata aspect value
    * @return a list of {@link EbeanMetadataAspect} as get response

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/EBeanDAOUtils.java
@@ -297,6 +297,30 @@ public class EBeanDAOUtils {
   }
 
   /**
+   * Read {@link SqlRow} list from a multi-aspect query into a {@link EbeanMetadataAspect} list.
+   * Unlike {@link #readSqlRows(Map)}, this handles rows that contain MULTIPLE aspect columns.
+   * Each non-null aspect column in a row produces a separate EbeanMetadataAspect in the result.
+   *
+   * <p>Soft-deleted aspects (gma_deleted JSON marker) are NOT filtered here — they are returned
+   * with their marker metadata and soft-delete PrimaryKey populated by {@link #readSqlRow}.
+   * Callers must filter via {@link #isSoftDeletedMetadata} if soft-deleted aspects should be excluded.
+   *
+   * @param sqlRows list of {@link SqlRow} from the multi-aspect query
+   * @param columnToAspectClassMap mapping of column name to aspect class for each requested aspect
+   * @param <ASPECT> aspect class type
+   * @return list of {@link EbeanMetadataAspect}
+   */
+  public static <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> readMultiAspectSqlRows(
+      @Nonnull List<SqlRow> sqlRows,
+      @Nonnull Map<String, Class<ASPECT>> columnToAspectClassMap) {
+    return sqlRows.stream().flatMap(sqlRow ->
+        columnToAspectClassMap.entrySet().stream()
+            .filter(entry -> sqlRow.get(entry.getKey()) != null)
+            .map(entry -> readSqlRow(sqlRow, entry.getValue()))
+    ).collect(Collectors.toList());
+  }
+
+  /**
    * Parse a list of {@link SqlRow} results from an entity table into a map of
    * URN to {@link EntityDeletionInfo}. Each row must contain urn, deleted_ts, and the Status aspect column.
    * Rows that cannot be parsed as a valid URN are skipped with a warning.

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -239,6 +239,57 @@ public class SQLStatementUtils {
   }
 
   /**
+   * Create a single SQL statement to read multiple aspect columns for a set of URNs.
+   * Unlike {@link #createAspectReadSql} which generates one SQL per aspect class, this generates a single query
+   * selecting all requested aspect columns at once. The gma_deleted check is NOT included in SQL — it must be
+   * handled in Java by the caller (checking each aspect column individually after retrieval).
+   *
+   * @param aspectColumnNames the set of aspect column names to select (e.g., "a_status", "a_ownership")
+   * @param urns the set of URNs to query
+   * @param includeSoftDeleted if true, omits deleted_ts IS NULL filter and includes deleted_ts in SELECT
+   * @param isTestMode whether to use the test table
+   * @return SQL string for the multi-aspect read
+   */
+  public static String createMultiAspectReadSql(@Nonnull Set<String> aspectColumnNames,
+      @Nonnull Set<Urn> urns, boolean includeSoftDeleted, boolean isTestMode) {
+    if (urns.isEmpty()) {
+      throw new IllegalArgumentException("Need at least 1 urn to query.");
+    }
+    if (aspectColumnNames.isEmpty()) {
+      throw new IllegalArgumentException("Need at least 1 aspect column to query.");
+    }
+
+    final Urn firstUrn = urns.iterator().next();
+    final String firstEntityType = firstUrn.getEntityType();
+    if (urns.stream().anyMatch(u -> !u.getEntityType().equals(firstEntityType))) {
+      throw new IllegalArgumentException("All URNs must belong to the same entity type");
+    }
+    final String tableName = isTestMode ? getTestTableName(firstUrn) : getTableName(firstUrn);
+
+    // Build column list: urn, <aspect columns>, lastmodifiedon, lastmodifiedby, createdfor [, deleted_ts]
+    StringBuilder sb = new StringBuilder("SELECT urn, ");
+    sb.append(String.join(", ", aspectColumnNames));
+    sb.append(", lastmodifiedon, lastmodifiedby, createdfor");
+    if (includeSoftDeleted) {
+      sb.append(", deleted_ts");
+    }
+    sb.append(" FROM ").append(tableName);
+
+    // WHERE urn IN (...)
+    String urnList = urns.stream()
+        .map(urn -> "'" + escapeReservedCharInUrn(urn.toString()) + "'")
+        .collect(Collectors.joining(", "));
+    sb.append(" WHERE urn IN (").append(urnList).append(")");
+
+    // Add deleted_ts filter when not including soft-deleted entities
+    if (!includeSoftDeleted) {
+      sb.append(" AND ").append(DELETED_TS_IS_NULL_CHECK);
+    }
+
+    return sb.toString();
+  }
+
+  /**
    * List all the aspect record (0 or 1) for a given entity urn and aspect type.
    * @param aspectClass aspect type
    * @param urn entity urn

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -455,14 +456,21 @@ public class EbeanLocalAccessTest {
     FooUrn fooUrn = makeFooUrn(0);
     _ebeanLocalAccessFoo.add(fooUrn, null, AspectFoo.class, makeAuditStamp("foo", System.currentTimeMillis()), null, false);
     AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey(AspectFoo.class, fooUrn, 0L);
+
+    // With includeSoftDeleted=false: the row is still returned (gma_deleted check moved to Java),
+    // but the aspect is marked as soft-deleted. The upstream EbeanLocalDAO.toRecordTemplate() filters it
+    // to Optional.empty(). At batchGetUnion level, we get 1 result with soft-delete metadata.
     List<EbeanMetadataAspect> ebeanMetadataAspectList =
         _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(aspectKey), 1000, 0, false, false);
-    assertEquals(0, ebeanMetadataAspectList.size());
+    assertEquals(1, ebeanMetadataAspectList.size());
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(ebeanMetadataAspectList.get(0).getMetadata()));
 
+    // With includeSoftDeleted=true: same result — soft-deleted marker is returned
     ebeanMetadataAspectList =
         _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(aspectKey), 1000, 0, true, false);
-    assertFalse(ebeanMetadataAspectList.isEmpty());
+    assertEquals(1, ebeanMetadataAspectList.size());
     assertEquals(fooUrn.toString(), ebeanMetadataAspectList.get(0).getKey().getUrn());
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(ebeanMetadataAspectList.get(0).getMetadata()));
   }
 
   @Test
@@ -615,6 +623,363 @@ public class EbeanLocalAccessTest {
     assertEquals("{\"value\":\"single\"}", results.get(0).getMetadata());
     assertEquals(fooUrn.toString(), results.get(0).getKey().getUrn());
     assertEquals(AspectFoo.class.getCanonicalName(), results.get(0).getKey().getAspect());
+  }
+
+  @Test
+  public void testBatchGetUnionMultiAspectReturnsCorrectResults() {
+    // Write two different aspects for the same URN, verify both returned correctly
+    FooUrn fooUrn = makeFooUrn(400);
+    AspectFoo foo = new AspectFoo().setValue("multi_foo");
+    AspectBar bar = new AspectBar().setValue("multi_bar");
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(fooUrn, foo, AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(fooUrn, bar, AspectBar.class, auditStamp, null, false);
+
+    // Fetch both aspects in a single batchGetUnion call
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, fooUrn, 0L),
+        new AspectKey<>(AspectBar.class, fooUrn, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    assertEquals(2, results.size());
+    // Verify both aspects are returned with correct metadata
+    Map<String, String> aspectToValue = results.stream()
+        .collect(Collectors.toMap(r -> r.getKey().getAspect(), EbeanMetadataAspect::getMetadata));
+    assertEquals("{\"value\":\"multi_foo\"}", aspectToValue.get(AspectFoo.class.getCanonicalName()));
+    assertEquals("{\"value\":\"multi_bar\"}", aspectToValue.get(AspectBar.class.getCanonicalName()));
+  }
+
+  @Test
+  public void testBatchGetUnionMultiAspectWithNullAspect() {
+    // Write only one aspect, request two — one should be null
+    FooUrn fooUrn = makeFooUrn(401);
+    AspectFoo foo = new AspectFoo().setValue("only_foo");
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(fooUrn, foo, AspectFoo.class, auditStamp, null, false);
+
+    // Request both AspectFoo (present) and AspectBar (never written, null column)
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, fooUrn, 0L),
+        new AspectKey<>(AspectBar.class, fooUrn, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    // Only AspectFoo should be returned — AspectBar is null
+    assertEquals(1, results.size());
+    assertEquals(AspectFoo.class.getCanonicalName(), results.get(0).getKey().getAspect());
+    assertEquals("{\"value\":\"only_foo\"}", results.get(0).getMetadata());
+  }
+
+  @Test
+  public void testBatchGetUnionMultiAspectWithSoftDeletedAspect() {
+    // Write two aspects, then soft-delete one
+    FooUrn fooUrn = makeFooUrn(402);
+    AspectFoo foo = new AspectFoo().setValue("present_foo");
+    AspectBar bar = new AspectBar().setValue("will_delete_bar");
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(fooUrn, foo, AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(fooUrn, bar, AspectBar.class, auditStamp, null, false);
+
+    // Soft-delete AspectBar
+    _ebeanLocalAccessFoo.add(fooUrn, null, AspectBar.class, auditStamp, null, false);
+
+    // Request both — AspectFoo should be present, AspectBar should be soft-deleted marker
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, fooUrn, 0L),
+        new AspectKey<>(AspectBar.class, fooUrn, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    assertEquals(2, results.size());
+    Map<String, EbeanMetadataAspect> aspectMap = results.stream()
+        .collect(Collectors.toMap(r -> r.getKey().getAspect(), r -> r));
+
+    // AspectFoo: present with correct value
+    assertFalse(EBeanDAOUtils.isSoftDeletedMetadata(aspectMap.get(AspectFoo.class.getCanonicalName()).getMetadata()));
+    assertEquals("{\"value\":\"present_foo\"}", aspectMap.get(AspectFoo.class.getCanonicalName()).getMetadata());
+
+    // AspectBar: soft-deleted
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(aspectMap.get(AspectBar.class.getCanonicalName()).getMetadata()));
+  }
+
+  @Test
+  public void testBatchGetUnionMultipleUrnsMultipleAspects() {
+    // Write 2 aspects for 2 different URNs
+    FooUrn urn1 = makeFooUrn(500);
+    FooUrn urn2 = makeFooUrn(501);
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(urn1, new AspectFoo().setValue("urn1_foo"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn1, new AspectBar().setValue("urn1_bar"), AspectBar.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn2, new AspectFoo().setValue("urn2_foo"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn2, new AspectBar().setValue("urn2_bar"), AspectBar.class, auditStamp, null, false);
+
+    // Request 2 aspects for 2 URNs = 4 keys — should be 1 SQL query
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, urn1, 0L),
+        new AspectKey<>(AspectBar.class, urn1, 0L),
+        new AspectKey<>(AspectFoo.class, urn2, 0L),
+        new AspectKey<>(AspectBar.class, urn2, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    assertEquals(4, results.size());
+    Map<String, String> resultMap = results.stream()
+        .collect(Collectors.toMap(
+            r -> r.getKey().getUrn() + ":" + r.getKey().getAspect(),
+            EbeanMetadataAspect::getMetadata));
+    assertEquals("{\"value\":\"urn1_foo\"}", resultMap.get(urn1.toString() + ":" + AspectFoo.class.getCanonicalName()));
+    assertEquals("{\"value\":\"urn1_bar\"}", resultMap.get(urn1.toString() + ":" + AspectBar.class.getCanonicalName()));
+    assertEquals("{\"value\":\"urn2_foo\"}", resultMap.get(urn2.toString() + ":" + AspectFoo.class.getCanonicalName()));
+    assertEquals("{\"value\":\"urn2_bar\"}", resultMap.get(urn2.toString() + ":" + AspectBar.class.getCanonicalName()));
+  }
+
+  @Test
+  public void testBatchGetUnionAsymmetricKeysReturnsCrossProduct() {
+    // Cross-product semantics: caller passes [(urn1, AspectFoo), (urn2, AspectBar)] but both URNs
+    // have both aspects populated. The method collects {AspectFoo, AspectBar} columns and {urn1, urn2}
+    // URNs, then issues SELECT urn, a_aspectfoo, a_aspectbar WHERE urn IN (urn1, urn2). This returns
+    // 4 EbeanMetadataAspect entries, not the 2 the caller "asked for". Callers that pass heterogeneous
+    // (urn, aspect) pairs are responsible for filtering — EbeanLocalDAO.get does this via matchKeys.
+    FooUrn urn1 = makeFooUrn(560);
+    FooUrn urn2 = makeFooUrn(561);
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(urn1, new AspectFoo().setValue("urn1_foo"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn1, new AspectBar().setValue("urn1_bar"), AspectBar.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn2, new AspectFoo().setValue("urn2_foo"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn2, new AspectBar().setValue("urn2_bar"), AspectBar.class, auditStamp, null, false);
+
+    // Heterogeneous keys: only urn1.AspectFoo and urn2.AspectBar requested
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, urn1, 0L),
+        new AspectKey<>(AspectBar.class, urn2, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    // Returns 4 (urn1.foo, urn1.bar, urn2.foo, urn2.bar) due to cross-product semantics — documented in
+    // IEbeanLocalAccess.batchGetUnion Javadoc. Callers must filter to requested (urn, aspect) pairs.
+    assertEquals(4, results.size());
+  }
+
+  @Test
+  public void testBatchGetUnionMultipleUrnsSameAspect() {
+    // Write same aspect for 3 different URNs
+    FooUrn urn1 = makeFooUrn(510);
+    FooUrn urn2 = makeFooUrn(511);
+    FooUrn urn3 = makeFooUrn(512);
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(urn1, new AspectFoo().setValue("val1"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn2, new AspectFoo().setValue("val2"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn3, new AspectFoo().setValue("val3"), AspectFoo.class, auditStamp, null, false);
+
+    // Request same aspect for 3 URNs — 1 SQL, 3 rows returned
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, urn1, 0L),
+        new AspectKey<>(AspectFoo.class, urn2, 0L),
+        new AspectKey<>(AspectFoo.class, urn3, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    assertEquals(3, results.size());
+    Map<String, String> urnToValue = results.stream()
+        .collect(Collectors.toMap(r -> r.getKey().getUrn(), EbeanMetadataAspect::getMetadata));
+    assertEquals("{\"value\":\"val1\"}", urnToValue.get(urn1.toString()));
+    assertEquals("{\"value\":\"val2\"}", urnToValue.get(urn2.toString()));
+    assertEquals("{\"value\":\"val3\"}", urnToValue.get(urn3.toString()));
+  }
+
+  @Test
+  public void testBatchGetUnionSingleUrnSingleAspect() {
+    // Simplest case: 1 URN, 1 aspect
+    FooUrn fooUrn = makeFooUrn(520);
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(fooUrn, new AspectFoo().setValue("single"), AspectFoo.class, auditStamp, null, false);
+
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Collections.singletonList(
+        new AspectKey<>(AspectFoo.class, fooUrn, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    assertEquals(1, results.size());
+    assertEquals("{\"value\":\"single\"}", results.get(0).getMetadata());
+    assertEquals(fooUrn.toString(), results.get(0).getKey().getUrn());
+  }
+
+  @Test
+  public void testBatchGetUnionSoftDeletedAspectsExcludedByCallers() {
+    // Write 3 aspects, soft-delete 1, verify the DAO-level toRecordTemplate filters it
+    FooUrn fooUrn = makeFooUrn(530);
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(fooUrn, new AspectFoo().setValue("keep_foo"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(fooUrn, new AspectBar().setValue("delete_bar"), AspectBar.class, auditStamp, null, false);
+
+    // Soft-delete AspectBar
+    _ebeanLocalAccessFoo.add(fooUrn, null, AspectBar.class, auditStamp, null, false);
+
+    // batchGetUnion with includeSoftDeleted=false returns soft-deleted marker
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, fooUrn, 0L),
+        new AspectKey<>(AspectBar.class, fooUrn, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    // Both returned: 1 normal + 1 soft-deleted marker
+    assertEquals(2, results.size());
+
+    // Simulate what EbeanLocalDAO.toRecordTemplate does: filter out soft-deleted
+    long nonDeletedCount = results.stream()
+        .filter(r -> !EBeanDAOUtils.isSoftDeletedMetadata(r.getMetadata()))
+        .count();
+    assertEquals(1, nonDeletedCount);
+
+    // The non-deleted one should be AspectFoo
+    EbeanMetadataAspect kept = results.stream()
+        .filter(r -> !EBeanDAOUtils.isSoftDeletedMetadata(r.getMetadata()))
+        .findFirst().get();
+    assertEquals(AspectFoo.class.getCanonicalName(), kept.getKey().getAspect());
+    assertEquals("{\"value\":\"keep_foo\"}", kept.getMetadata());
+  }
+
+  @Test
+  public void testBatchGetUnionAllKeysPassedWhenKeysCountExceedsTotal() {
+    // Verify behavior when keysCount > total keys (all processed in 1 call)
+    FooUrn urn1 = makeFooUrn(540);
+    FooUrn urn2 = makeFooUrn(541);
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(urn1, new AspectFoo().setValue("a"), AspectFoo.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn1, new AspectBar().setValue("b"), AspectBar.class, auditStamp, null, false);
+    _ebeanLocalAccessFoo.add(urn2, new AspectFoo().setValue("c"), AspectFoo.class, auditStamp, null, false);
+
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, urn1, 0L),
+        new AspectKey<>(AspectBar.class, urn1, 0L),
+        new AspectKey<>(AspectFoo.class, urn2, 0L)
+    );
+    // keysCount=1000 >> 3 keys, position=0 — all processed in one shot
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+    assertEquals(3, results.size());
+  }
+
+  @Test
+  public void testBatchGetUnionNonExistentUrnReturnsEmpty() {
+    FooUrn nonExistent = makeFooUrn(999);
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Collections.singletonList(
+        new AspectKey<>(AspectFoo.class, nonExistent, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+    assertEquals(0, results.size());
+  }
+
+  @Test
+  public void testBatchGetUnionMixOfExistingAndNonExistingUrns() {
+    FooUrn existing = makeFooUrn(550);
+    FooUrn nonExisting = makeFooUrn(551);
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    _ebeanLocalAccessFoo.add(existing, new AspectFoo().setValue("exists"), AspectFoo.class, auditStamp, null, false);
+
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = Arrays.asList(
+        new AspectKey<>(AspectFoo.class, existing, 0L),
+        new AspectKey<>(AspectFoo.class, nonExisting, 0L)
+    );
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, 1000, 0, false, false);
+
+    // Only the existing URN should return data
+    assertEquals(1, results.size());
+    assertEquals(existing.toString(), results.get(0).getKey().getUrn());
+    assertEquals("{\"value\":\"exists\"}", results.get(0).getMetadata());
+  }
+
+  @Test
+  public void testBatchGetUnionUrnChunkingOver100Urns() {
+    // Write AspectFoo for 120 URNs — exceeds MAX_URNS_PER_QUERY (100).
+    // batchGetUnion should internally chunk into 2 queries (100 + 20) and combine results.
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    int urnStart = 600;
+    int urnCount = 120;
+    for (int i = 0; i < urnCount; i++) {
+      FooUrn urn = makeFooUrn(urnStart + i);
+      _ebeanLocalAccessFoo.add(urn, new AspectFoo().setValue("val_" + i), AspectFoo.class, auditStamp, null, false);
+    }
+
+    // Build keys for all 120 URNs × 1 aspect
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = new ArrayList<>();
+    for (int i = 0; i < urnCount; i++) {
+      keys.add(new AspectKey<>(AspectFoo.class, makeFooUrn(urnStart + i), 0L));
+    }
+
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, keys.size(), 0, false, false);
+
+    // All 120 URNs should return results
+    assertEquals(urnCount, results.size());
+
+    // Verify each URN has correct data
+    Map<String, String> urnToMetadata = results.stream()
+        .collect(Collectors.toMap(r -> r.getKey().getUrn(), EbeanMetadataAspect::getMetadata));
+    for (int i = 0; i < urnCount; i++) {
+      String urn = makeFooUrn(urnStart + i).toString();
+      assertEquals("{\"value\":\"val_" + i + "\"}", urnToMetadata.get(urn),
+          "Mismatch for URN " + urn);
+    }
+  }
+
+  @Test
+  public void testBatchGetUnionUrnChunkingMultipleAspects() {
+    // 120 URNs × 2 aspects — verifies chunking works with multiple aspect columns
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+    int urnStart = 800;
+    int urnCount = 120;
+    for (int i = 0; i < urnCount; i++) {
+      FooUrn urn = makeFooUrn(urnStart + i);
+      _ebeanLocalAccessFoo.add(urn, new AspectFoo().setValue("foo_" + i), AspectFoo.class, auditStamp, null, false);
+      _ebeanLocalAccessFoo.add(urn, new AspectBar().setValue("bar_" + i), AspectBar.class, auditStamp, null, false);
+    }
+
+    // Build keys for all 120 URNs × 2 aspects = 240 keys
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = new ArrayList<>();
+    for (int i = 0; i < urnCount; i++) {
+      FooUrn urn = makeFooUrn(urnStart + i);
+      keys.add(new AspectKey<>(AspectFoo.class, urn, 0L));
+      keys.add(new AspectKey<>(AspectBar.class, urn, 0L));
+    }
+
+    List<EbeanMetadataAspect> results = _ebeanLocalAccessFoo.batchGetUnion(keys, keys.size(), 0, false, false);
+
+    // 120 URNs × 2 aspects = 240 results
+    assertEquals(urnCount * 2, results.size());
+  }
+
+  @Test
+  public void testBatchGetUnionUrnChunkingBoundary() {
+    // Test boundary at MAX_URNS_PER_QUERY (100): 99 (single query), 100 (single query), 101 (2 queries)
+    AuditStamp auditStamp = makeAuditStamp("actor", _now);
+
+    // Write AspectFoo for 101 URNs (covers all boundary cases)
+    int urnStart = 1000;
+    for (int i = 0; i < 101; i++) {
+      _ebeanLocalAccessFoo.add(makeFooUrn(urnStart + i),
+          new AspectFoo().setValue("b_" + i), AspectFoo.class, auditStamp, null, false);
+    }
+
+    // 99 URNs — should use single query path (<=100)
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys99 = new ArrayList<>();
+    for (int i = 0; i < 99; i++) {
+      keys99.add(new AspectKey<>(AspectFoo.class, makeFooUrn(urnStart + i), 0L));
+    }
+    assertEquals(99, _ebeanLocalAccessFoo.batchGetUnion(keys99, keys99.size(), 0, false, false).size());
+
+    // 100 URNs — should use single query path (<=100)
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys100 = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      keys100.add(new AspectKey<>(AspectFoo.class, makeFooUrn(urnStart + i), 0L));
+    }
+    assertEquals(100, _ebeanLocalAccessFoo.batchGetUnion(keys100, keys100.size(), 0, false, false).size());
+
+    // 101 URNs — should use chunked path (>100): 100 + 1
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys101 = new ArrayList<>();
+    for (int i = 0; i < 101; i++) {
+      keys101.add(new AspectKey<>(AspectFoo.class, makeFooUrn(urnStart + i), 0L));
+    }
+    assertEquals(101, _ebeanLocalAccessFoo.batchGetUnion(keys101, keys101.size(), 0, false, false).size());
   }
 
   @Test(expectedExceptions = NullPointerException.class)

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTestWithoutServiceIdentifier.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTestWithoutServiceIdentifier.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao;
 import com.google.common.io.Resources;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
+import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
 import com.linkedin.metadata.dao.utils.EmbeddedMariaInstance;
 import com.linkedin.metadata.dao.utils.SchemaValidatorUtil;
 import java.lang.reflect.Field;
@@ -408,11 +409,15 @@ public class EbeanLocalAccessTestWithoutServiceIdentifier {
     AspectKey<FooUrn, AspectFoo> aspectKey = new AspectKey(AspectFoo.class, fooUrn, 0L);
     List<EbeanMetadataAspect> ebeanMetadataAspectList =
         _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(aspectKey), 1000, 0, false, false);
-    assertEquals(0, ebeanMetadataAspectList.size());
+    // batchGetUnion now returns soft-deleted aspects with gma_deleted marker (filtering moved from SQL to Java)
+    assertEquals(1, ebeanMetadataAspectList.size());
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(ebeanMetadataAspectList.get(0).getMetadata()));
 
+    // With includeSoftDeleted=true: same result — soft-deleted marker is returned
     ebeanMetadataAspectList =
         _ebeanLocalAccessFoo.batchGetUnion(Collections.singletonList(aspectKey), 1000, 0, true, false);
-    assertFalse(ebeanMetadataAspectList.isEmpty());
+    assertEquals(1, ebeanMetadataAspectList.size());
     assertEquals(fooUrn.toString(), ebeanMetadataAspectList.get(0).getKey().getUrn());
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(ebeanMetadataAspectList.get(0).getMetadata()));
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -113,6 +113,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.RollbackException;
+import java.lang.reflect.Field;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.MockedStatic;
@@ -1393,7 +1394,7 @@ public class EbeanLocalDAOTest {
     ListResult<Long> results = dao.listVersions(AspectFoo.class, urn, 0, 5);
     if (!dao.isChangeLogEnabled()) {
       // when: change log is disabled,
-      // expect: listVersion should only return 1 result which is the LATEST_VERSION
+      // expect: listVersion should only return 1 result which is the 0L
       assertFalse(results.isHavingMore());
       assertEquals(results.getTotalCount(), 1);
       assertEquals(results.getValues(), versions.subList(0, 1));
@@ -3346,6 +3347,59 @@ public class EbeanLocalDAOTest {
   @Test
   public void testPageSizeGreaterThanResultsSize() {
     testGetWithQuerySize(1000);
+  }
+
+  @Test
+  public void testGetWithSmallPageSizeNoDuplicatesNewSchema() throws Exception {
+    // Tests the position>0 short-circuit: with queryKeysCount=2 and 5 keys at 0L,
+    // the outer loop runs 3 times. For NEW_SCHEMA_ONLY, only the first call should hit
+    // _localAccess.batchGetUnion; subsequent calls return empty to avoid duplicate DB work.
+    if (_schemaConfig != SchemaConfig.NEW_SCHEMA_ONLY) {
+      return; // This test is specifically for NEW_SCHEMA_ONLY (DUAL_SCHEMA has its own paged comparison logic)
+    }
+
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+    FooUrn urn1 = makeFooUrn(901);
+    FooUrn urn2 = makeFooUrn(902);
+    AuditStamp auditStamp = makeAuditStamp("tester", System.currentTimeMillis());
+
+    // Write 3 aspects across 2 URNs at LATEST_VERSION (0L)
+    dao.add(urn1, new AspectFoo().setValue("foo1"), auditStamp);
+    dao.add(urn1, new AspectBar().setValue("bar1"), auditStamp);
+    dao.add(urn2, new AspectFoo().setValue("foo2"), auditStamp);
+
+    // Inject a Mockito spy on _localAccess so we can verify the call count
+    Field localAccessField = EbeanLocalDAO.class.getDeclaredField("_localAccess");
+    localAccessField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    IEbeanLocalAccess<FooUrn> originalLocalAccess = (IEbeanLocalAccess<FooUrn>) localAccessField.get(dao);
+    IEbeanLocalAccess<FooUrn> spy = Mockito.spy(originalLocalAccess);
+    localAccessField.set(dao, spy);
+
+    Set<AspectKey<FooUrn, ? extends RecordTemplate>> keys = new HashSet<>(Arrays.asList(
+        new AspectKey<>(AspectFoo.class, urn1, 0L),
+        new AspectKey<>(AspectBar.class, urn1, 0L),
+        new AspectKey<>(AspectFoo.class, urn2, 0L),
+        new AspectKey<>(AspectBar.class, urn2, 0L),  // not present — should be Optional.empty()
+        new AspectKey<>(AspectBaz.class, urn1, 0L)   // not present — should be Optional.empty()
+    ));
+
+    dao.setQueryKeysCount(2);  // Force outer loop to iterate 3 times: 5 keys / 2 per page
+
+    Map<AspectKey<FooUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> results = dao.get(keys);
+
+    // Verify the position>0 short-circuit: batchGetUnion should be called EXACTLY ONCE,
+    // not 3 times (which is what would happen if every page hit the DB).
+    Mockito.verify(spy, Mockito.times(1))
+        .batchGetUnion(Mockito.anyList(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyBoolean(), Mockito.anyBoolean());
+
+    // Exactly 1 entry per key — no duplicates from outer loop
+    assertEquals(5, results.size());
+    assertTrue(results.get(new AspectKey<>(AspectFoo.class, urn1, 0L)).isPresent());
+    assertTrue(results.get(new AspectKey<>(AspectBar.class, urn1, 0L)).isPresent());
+    assertTrue(results.get(new AspectKey<>(AspectFoo.class, urn2, 0L)).isPresent());
+    assertFalse(results.get(new AspectKey<>(AspectBar.class, urn2, 0L)).isPresent());
+    assertFalse(results.get(new AspectKey<>(AspectBaz.class, urn1, 0L)).isPresent());
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/EBeanDAOUtilsTest.java
@@ -23,6 +23,7 @@ import com.linkedin.testing.AnnotatedRelationshipBar;
 import com.linkedin.testing.AnnotatedRelationshipBarArray;
 import com.linkedin.testing.AnnotatedRelationshipFoo;
 import com.linkedin.testing.AnnotatedRelationshipFooArray;
+import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.AspectWithDefaultValue;
 import com.linkedin.testing.CommonAspect;
@@ -42,6 +43,8 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -721,5 +724,111 @@ public class EBeanDAOUtilsTest {
     assertTrue(results.get(AnnotatedRelationshipFoo.class).contains(test2));
     assertTrue(results.get(AnnotatedRelationshipFoo.class).contains(test3));
     assertTrue(results.get(AnnotatedRelationshipBar.class).contains(new AnnotatedRelationshipBar()));
+  }
+
+  private SqlRow mockSqlRowForMultiAspect(String urn, Map<String, String> aspectValues) {
+    SqlRow sqlRow = mock(SqlRow.class);
+    when(sqlRow.getString("urn")).thenReturn(urn);
+    when(sqlRow.getString("lastmodifiedon")).thenReturn("2026-01-01 00:00:00");
+    when(sqlRow.getString("lastmodifiedby")).thenReturn("urn:li:corpuser:testuser");
+    when(sqlRow.getString("createdfor")).thenReturn(null);
+    when(sqlRow.keySet()).thenReturn(new LinkedHashSet<>(aspectValues.keySet()));
+    for (Map.Entry<String, String> entry : aspectValues.entrySet()) {
+      when(sqlRow.get(entry.getKey())).thenReturn(entry.getValue());
+      when(sqlRow.getString(entry.getKey())).thenReturn(entry.getValue());
+    }
+    return sqlRow;
+  }
+
+  private String buildAuditedAspectJson(String canonicalName, String aspectJson) {
+    return "{\"canonicalName\":\"" + canonicalName + "\",\"aspect\":" + aspectJson
+        + ",\"lastmodifiedby\":\"urn:li:corpuser:testuser\",\"lastmodifiedon\":\"2026-01-01 00:00:00\"}";
+  }
+
+  @Test
+  public void testReadMultiAspectSqlRowsMultipleColumns() {
+    String urn = "urn:li:foo:1";
+    String fooJson = buildAuditedAspectJson(AspectFoo.class.getCanonicalName(), "{\"value\":\"foo_val\"}");
+    String barJson = buildAuditedAspectJson(AspectBar.class.getCanonicalName(), "{\"value\":\"bar_val\"}");
+    Map<String, String> values = new LinkedHashMap<>();
+    values.put("a_aspectfoo", fooJson);
+    values.put("a_aspectbar", barJson);
+    SqlRow row = mockSqlRowForMultiAspect(urn, values);
+
+    Map<String, Class<RecordTemplate>> columnMap = new LinkedHashMap<>();
+    columnMap.put("a_aspectfoo", (Class) AspectFoo.class);
+    columnMap.put("a_aspectbar", (Class) AspectBar.class);
+
+    List<EbeanMetadataAspect> results = EBeanDAOUtils.readMultiAspectSqlRows(
+        Collections.singletonList(row), columnMap);
+
+    assertEquals(2, results.size());
+    assertEquals(urn, results.get(0).getKey().getUrn());
+    assertEquals(AspectFoo.class.getCanonicalName(), results.get(0).getKey().getAspect());
+    assertEquals(AspectBar.class.getCanonicalName(), results.get(1).getKey().getAspect());
+  }
+
+  @Test
+  public void testReadMultiAspectSqlRowsSkipsNullColumn() {
+    String urn = "urn:li:foo:2";
+    String fooJson = buildAuditedAspectJson(AspectFoo.class.getCanonicalName(), "{\"value\":\"present\"}");
+    Map<String, String> values = new LinkedHashMap<>();
+    values.put("a_aspectfoo", fooJson);
+    SqlRow row = mockSqlRowForMultiAspect(urn, values);
+    // a_aspectbar is not in the map → sqlRow.get("a_aspectbar") returns null (default mock behavior)
+
+    Map<String, Class<RecordTemplate>> columnMap = new LinkedHashMap<>();
+    columnMap.put("a_aspectfoo", (Class) AspectFoo.class);
+    columnMap.put("a_aspectbar", (Class) AspectBar.class);
+
+    List<EbeanMetadataAspect> results = EBeanDAOUtils.readMultiAspectSqlRows(
+        Collections.singletonList(row), columnMap);
+
+    assertEquals(1, results.size());
+    assertEquals(AspectFoo.class.getCanonicalName(), results.get(0).getKey().getAspect());
+  }
+
+  @Test
+  public void testReadMultiAspectSqlRowsEmptyInput() {
+    Map<String, Class<RecordTemplate>> columnMap = new LinkedHashMap<>();
+    columnMap.put("a_aspectfoo", (Class) AspectFoo.class);
+
+    List<EbeanMetadataAspect> results = EBeanDAOUtils.readMultiAspectSqlRows(
+        Collections.emptyList(), columnMap);
+
+    assertEquals(0, results.size());
+  }
+
+  @Test
+  public void testReadMultiAspectSqlRowsEmptyColumnMap() {
+    String urn = "urn:li:foo:3";
+    Map<String, String> values = new LinkedHashMap<>();
+    values.put("a_aspectfoo", "{\"value\":\"present\"}");
+    SqlRow row = mockSqlRowForMultiAspect(urn, values);
+
+    Map<String, Class<RecordTemplate>> emptyColumnMap = new LinkedHashMap<>();
+
+    List<EbeanMetadataAspect> results = EBeanDAOUtils.readMultiAspectSqlRows(
+        Collections.singletonList(row), emptyColumnMap);
+
+    assertEquals(0, results.size());
+  }
+
+  @Test
+  public void testReadMultiAspectSqlRowsSoftDeletedAspectStillEmitted() {
+    String urn = "urn:li:foo:4";
+    Map<String, String> values = new LinkedHashMap<>();
+    values.put("a_aspectfoo", "{\"gma_deleted\":true}");
+    SqlRow row = mockSqlRowForMultiAspect(urn, values);
+
+    Map<String, Class<RecordTemplate>> columnMap = new LinkedHashMap<>();
+    columnMap.put("a_aspectfoo", (Class) AspectFoo.class);
+
+    List<EbeanMetadataAspect> results = EBeanDAOUtils.readMultiAspectSqlRows(
+        Collections.singletonList(row), columnMap);
+
+    // Soft-deleted marker IS returned — callers must filter
+    assertEquals(1, results.size());
+    assertTrue(EBeanDAOUtils.isSoftDeletedMetadata(results.get(0).getMetadata()));
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/utils/SQLStatementUtilsTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1480,6 +1481,95 @@ public class SQLStatementUtilsTest {
 
     assertEquals(SQLStatementUtils.parseLocalRelationshipField(aspectCriterion4, null, PLACEHOLDER_TABLE_NAME,
         mockValidator, false), "i_urn$value");
+  }
+
+  @Test
+  public void testCreateMultiAspectReadSqlBasic() {
+    FooUrn fooUrn = makeFooUrn(1);
+    Set<String> columns = new LinkedHashSet<>(Arrays.asList("a_aspectfoo", "a_aspectbar"));
+    Set<Urn> urns = new HashSet<>(Collections.singletonList(fooUrn));
+
+    String sql = SQLStatementUtils.createMultiAspectReadSql(columns, urns, false, false);
+
+    assertTrue(sql.startsWith("SELECT urn, a_aspectfoo, a_aspectbar, lastmodifiedon, lastmodifiedby, createdfor FROM metadata_entity_foo"));
+    assertTrue(sql.contains("WHERE urn IN ("));
+    assertTrue(sql.contains(fooUrn.toString()));
+    assertTrue(sql.contains("AND deleted_ts IS NULL"));
+    assertFalse(sql.contains("deleted_ts,"));  // deleted_ts NOT in SELECT columns
+    assertFalse(sql.contains("JSON_EXTRACT"));  // no gma_deleted check in SQL
+  }
+
+  @Test
+  public void testCreateMultiAspectReadSqlIncludeSoftDeleted() {
+    FooUrn fooUrn = makeFooUrn(2);
+    Set<String> columns = new LinkedHashSet<>(Collections.singletonList("a_aspectfoo"));
+    Set<Urn> urns = new HashSet<>(Collections.singletonList(fooUrn));
+
+    String sql = SQLStatementUtils.createMultiAspectReadSql(columns, urns, true, false);
+
+    assertTrue(sql.contains("deleted_ts FROM"));  // deleted_ts in SELECT
+    assertFalse(sql.contains("AND deleted_ts IS NULL"));  // no deleted_ts filter
+  }
+
+  @Test
+  public void testCreateMultiAspectReadSqlTestMode() {
+    FooUrn fooUrn = makeFooUrn(3);
+    Set<String> columns = new LinkedHashSet<>(Collections.singletonList("a_aspectfoo"));
+    Set<Urn> urns = new HashSet<>(Collections.singletonList(fooUrn));
+
+    String sql = SQLStatementUtils.createMultiAspectReadSql(columns, urns, false, true);
+
+    assertTrue(sql.contains("FROM metadata_entity_foo_test"));
+  }
+
+  @Test
+  public void testCreateMultiAspectReadSqlMultipleUrns() {
+    FooUrn urn1 = makeFooUrn(10);
+    FooUrn urn2 = makeFooUrn(11);
+    Set<String> columns = new LinkedHashSet<>(Collections.singletonList("a_aspectfoo"));
+    Set<Urn> urns = new HashSet<>(Arrays.asList(urn1, urn2));
+
+    String sql = SQLStatementUtils.createMultiAspectReadSql(columns, urns, false, false);
+
+    assertTrue(sql.contains(urn1.toString()));
+    assertTrue(sql.contains(urn2.toString()));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateMultiAspectReadSqlEmptyUrns() {
+    SQLStatementUtils.createMultiAspectReadSql(
+        new LinkedHashSet<>(Collections.singletonList("a_aspectfoo")),
+        Collections.emptySet(), false, false);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateMultiAspectReadSqlEmptyColumns() {
+    FooUrn fooUrn = makeFooUrn(1);
+    SQLStatementUtils.createMultiAspectReadSql(
+        Collections.emptySet(),
+        new HashSet<>(Collections.singletonList(fooUrn)), false, false);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateMultiAspectReadSqlMixedEntityTypes() throws URISyntaxException {
+    FooUrn fooUrn = makeFooUrn(1);
+    BarUrn barUrn = BarUrn.createFromString("urn:li:bar:1");
+    Set<String> columns = new LinkedHashSet<>(Collections.singletonList("a_aspectfoo"));
+    Set<Urn> urns = new HashSet<>(Arrays.asList(fooUrn, barUrn));
+
+    SQLStatementUtils.createMultiAspectReadSql(columns, urns, false, false);
+  }
+
+  @Test
+  public void testCreateMultiAspectReadSqlEscapesSpecialChars() {
+    FooUrn fooUrn = makeFooUrn(1);
+    Set<String> columns = new LinkedHashSet<>(Collections.singletonList("a_aspectfoo"));
+    Set<Urn> urns = new HashSet<>(Collections.singletonList(fooUrn));
+
+    String sql = SQLStatementUtils.createMultiAspectReadSql(columns, urns, false, false);
+
+    // URN should be quoted in the IN clause
+    assertTrue(sql.contains("'" + fooUrn.toString() + "'"));
   }
 
 }


### PR DESCRIPTION
 ## Summary
- **Collapse N per-aspect SQL queries into 1 in `batchGetUnion()`** — previously generated 1 SQL per aspect class (e.g., 73 queries for a Dataset get with all aspects). Now issues a single SELECT with all requested `a_*` columns.
- **URN chunking at MAX_URNS_PER_QUERY=100** to keep IN clause safe for MySQL. Old implicit limit was 50 URNs/IN clause (keysCount=50, 1 aspect per key).
- **gma_deleted filtering moves from SQL to Java** — no `JSON_EXTRACT` in the query. Soft-deleted aspects are returned with their marker; callers (`EbeanLocalDAO.toRecordTemplate`) filter them out via `isSoftDeletedAspect()`.

### Changes

  | File | Change |
  |------|--------|
  | `SQLStatementUtils.java` | New `createMultiAspectReadSql()` — single SELECT with explicit aspect columns, entity-type validation guard |
  | `EBeanDAOUtils.java` | New `readMultiAspectSqlRows()` — parses multi-column rows, delegates to existing `readSqlRow()` |
  | `EbeanLocalAccess.java` | Rewrote `batchGetUnion()` to collect all columns + URNs, issue chunked queries (URN-count based) |
  | `EbeanLocalDAO.java` | Added `position>0` short-circuit for NEW_SCHEMA_ONLY/DUAL_SCHEMA to avoid duplicate results from outer pagination
  loop |
  | `IEbeanLocalAccess.java` | Updated Javadoc to describe new behavior |

  ### Edge Cases Handled

  - `a_urn` column excluded (not an aspect)
  - Column-doesn't-exist check per aspect (`validator.columnExists`)
  - NULL aspect columns (never written) — skipped in parser
  - Soft-deleted aspects (`gma_deleted`) — returned as markers, filtered by callers
  - Asset-level deletion (`deleted_ts`) — correctly applied per row
  - Empty URN set after column filtering — returns empty list
  - Mixed entity types in URN set — throws IllegalArgumentException
  - Pagination duplicates — `position>0` returns empty for NEW_SCHEMA_ONLY
  - Large URN batches — chunked into 100-URN queries

 ### Motivation

Code Yellow investigation: MGA SLO violations caused by N+1 query pattern in `batchGetUnion`. Legacy design from the old row-per-aspect schema. The new entity table schema has all aspects as columns on the same row, making single-query reads trivial.

  **Performance examples (with MAX_URNS_PER_QUERY=100):**

  | Scenario | Old code | New code |
  |----------|----------|----------|
  | 1 URN × 73 aspects | 73 SQL queries | 1 SQL |
  | 10 URNs × 73 aspects | ~146 SQL | 1 SQL |
  | 200 URNs × 3 aspects | 36 SQL | 2 SQL |
  | 1000 URNs × 3 aspects | 180 SQL | 10 SQL |

## Testing Done

### Unit tests (all passing)

  - [x] `SQLStatementUtilsTest` — 7 tests for `createMultiAspectReadSql`: basic, includeSoftDeleted, testMode, multiple URNs, empty URNs/columns, mixed entity types, URN escaping
  - [x] `EBeanDAOUtilsTest` — 5 tests for `readMultiAspectSqlRows`: multi-column, null skip, empty input, empty map, soft-deleted marker
  - [x] `EbeanLocalAccessTest` — 14 tests: multi-aspect, null aspect, soft-deleted, multi-URN multi-aspect, multi-URN same aspect, single URN, soft-delete filtering by callers, non-existent URN, mixed existing/non-existing, **120 URN chunking**, **120 URNs × 2 aspects**, **boundary at 99/100/101**
  - [x] `EbeanLocalDAOTest.testGetWithSmallPageSizeNoDuplicatesNewSchema` — verifies `position>0` short-circuit with `setQueryKeysCount(2)` and 5 keys
  - [x] `EbeanLocalAccessTestWithoutServiceIdentifier.testGetAspectNoSoftDeleteCheck` — sibling test updated for new behavior
Full `dao-impl/ebean-dao:test`: 2055 tests, 0 failures.

### E2E verification on QEI

Deployed to `qei-ltx1` with the new datahub-gma JAR via test-gma-changes workflow.
#### Test 1: Dataset get (all aspects) — verifies single-query path

  ```bash
  grpcurli --dv-auth SELF -f ei-ltx1 localhost:25403 \
    proto.com.linkedin.mg.assets.service.DatasetAssetService.get \
    -d '{"key":{"urn":{"platform":{"platformName":"gridTable"},"datasetName":"test_create_009","origin":"FabricType_EI"}}}'
  ```
Response: 4 populated aspects (complianceinfo, retentionpolicy, status, draftretentionpolicy)
  ```
  Logs:
  [batchGetHelper] NEW_SCHEMA_ONLY: totalKeys=73 keysCount=50 — passing all keys to batchGetUnion
  [batchGetUnion] keys=73 uniqueUrns=1 aspectColumns=72 includeSoftDeleted=false isTestMode=false
  [batchGetUnion] Executing single query: urns=1 sql=SELECT urn, a_usereditableschemainfo, a_dataprivacyreviewv2, a_retentionpolicy, ... [72
  columns] ... lastmodifiedon, lastmodifiedby, createdfor FROM metadata_entity_dataset WHERE urn IN
  ('urn:li:dataset:(urn:li:dataPlatform:gridTable,test_create_009,EI)') AND deleted_ts IS NULL
  [readMultiAspectSqlRows] Parsed 1 rows × 72 columns: normal=4 softDeleted=0 null(skipped)=68
  [batchGetUnion] Single query returned 1 DB rows, parsed into 4 aspects
  [batchGetHelper] NEW_SCHEMA_ONLY: skipping position=50 (already fetched all on position=0)
  ```
  ✅ 1 SQL for 73 aspects (vs 73 in old code), no JSON_EXTRACT, null aspects skipped in Java, position guard prevents duplicate fetching.

#### Test 2: Dataset get with specific aspects
  ```bash
grpcurli --dv-auth SELF -f ei-ltx1 localhost:25403 \
    proto.com.linkedin.mg.assets.service.DatasetAssetService.get \
    -d '{"key":{"urn":{...},"aspectTypes":["proto.com.linkedin.common.Status","proto.com.linkedin.dataset.RetentionPolicy"]}}'
  ```

  Response: exactly 2 requested aspects returned.

  Test 3: getWithContext
  ```bash
  grpcurli --dv-auth SELF -f ei-ltx1 localhost:25403 \
    proto.com.linkedin.mg.assets.service.DatasetAssetService.getWithContext \
    -d '{"key":{"urn":{...},"aspectTypes":["Status","RetentionPolicy","DraftRetentionPolicy"]}}'
  ```
  Response: 3 aspects + per-aspect etag metadata.

  #### Test 4: filter (with aspect hydration)
```bash
  grpcurli --dv-auth SELF -f ei-ltx1 d2://datasetAssetService \
    proto.com.linkedin.mg.assets.service.DatasetAssetService.filter \
    -d '{"aspectTypes":["RetentionPolicy","Status"],"indexFilter":{"criteria":{"items":[{"aspect":"com.linkedin.common.urn.DatasetUrn","pathPar
  ams":{"condition":"Condition_EQUAL","path":"/platform/platformName","value":{"stringValue":"gridTable"}}}]}},"paging":{"start":0,"count":3}}'
  ```
  Response: 3 URNs hydrated with requested aspects via single batchGetUnion call.

  #### Test 5: Soft-delete verification (update + delete + get)
```bash
  # Create URN with status + draftretentionpolicy
  grpcurli --dv-auth SELF -f ei-ltx1 -d '{"value":{"urn":{...},"status":{"removed":false},"draftretentionpolicy":{...}}}' \
    d2://datasetAssetService proto.com.linkedin.mg.assets.service.DatasetAssetService/update

  # Soft-delete DraftRetentionPolicy
  grpcurli --dv-auth SELF -f ei-ltx1 -d '{"key":{"urn":{...},"aspectTypes":["com.linkedin.dataset.DraftRetentionPolicy"]}}' \
    d2://datasetAssetService proto.com.linkedin.mg.assets.service.DatasetAssetService/delete

  # Get both aspects
  grpcurli --dv-auth SELF -f ei-ltx1 localhost:25403 \
    proto.com.linkedin.mg.assets.service.DatasetAssetService.get \
    -d '{"key":{"urn":{...},"aspectTypes":["proto.com.linkedin.common.Status","proto.com.linkedin.dataset.DraftRetentionPolicy"]}}'
  ```

  Response: only status returned — draftretentionpolicy correctly excluded.
  ```

  Logs:
  [batchGetUnion] Executing single query: urns=1 sql=SELECT urn, a_status, a_draftretentionpolicy, lastmodifiedon, lastmodifiedby, createdfor FROM metadata_entity_dataset WHERE urn IN ('urn:li:dataset:...') AND deleted_ts IS NULL

  [readMultiAspectSqlRows] Soft-deleted aspect: urn=urn:li:dataset:(urn:li:dataPlatform:gridTable,testDb.rakagraw_log_test,DEV)
  column=a_draftretentionpolicy

  ✅ SQL has no JSON_EXTRACT (both columns selected unconditionally). Soft-delete marker detected in Java and filtered by caller.

#### Test 6: batchGet (multiple URNs)
```bash
  grpcurli --dv-auth SELF -f ei-ltx1 d2://datasetAssetService \
    proto.com.linkedin.mg.assets.service.DatasetAssetService.batchGet \
    -d '{"aspectTypes":["Status","RetentionPolicy"],"urns":[{...urn1},{...urn2}]}'
```
  Response: both URNs returned with correct aspects in 1 call.

```
  Verification matrix
┌───────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────┐
  │                 Behavior                  │                                   Log evidence                                    │
  ├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Single SQL with all columns               │ Executing single query: urns=1 sql=SELECT urn, a_aspect1, a_aspect2, ...          │
  ├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ All 72 aspect columns hydrated in 1 query │ keys=73 uniqueUrns=1 aspectColumns=72                                             │
  ├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Null aspects skipped in Java              │ Parsed 1 rows × 72 columns: normal=4 softDeleted=0 null(skipped)=68               │
  ├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Soft-delete filtered in Java (not SQL)    │ Soft-deleted aspect: urn=... column=a_draftretentionpolicy + response excludes it │
  ├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Position guard prevents duplicates        │ skipping position=50 (already fetched all on position=0)                          │
  ├───────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ No JSON_EXTRACT in SQL                    │ SQL string in log, no JSON_EXTRACT clause                                         │
  └───────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────┘
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
