### PR TITLE
refactor(tracking): replace flat operationType with dimensional attributes

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoBenchmarkMetrics.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoBenchmarkMetrics.java
@@ -1,44 +1,43 @@
 package com.linkedin.metadata.dao.tracking;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 /**
- * Interface for recording per-DAO-operation latency and error metrics.
+ * Interface for recording per-DAO-operation latency and count metrics with dimensional attributes.
  *
- * <p>Implementations collect histograms (latency) and counters (operation count, error count)
- * to benchmark DAO performance during the MySQL to TiDB migration evaluation.</p>
+ * <p>Each call records both a count (one increment) and a latency observation. Implementations
+ * are expected to emit one metric per dimension instead of baking dimensions into metric names,
+ * so consumers can aggregate or filter on individual attributes without enumerating every
+ * concrete metric series.
  *
- * <p>Follows the same pattern as {@link BaseTrackingManager} / {@link DummyTrackingManager}:
- * a no-op implementation ({@code NoOpDaoBenchmarkMetrics}) lives in the kernel (datahub-gma)
- * and the real Dropwizard-backed implementation lives in the service layer.</p>
+ * <p>A no-op implementation ({@link NoOpDaoBenchmarkMetrics}) lives in the kernel; concrete
+ * backends (OTEL, Dropwizard, etc.) live in the service layer.
  */
 public interface BaseDaoBenchmarkMetrics {
 
   /**
-   * Record the latency of a successful or failed DAO operation.
+   * Record a completed DAO operation with its dimensional attributes.
    *
-   * @param operationType the DAO operation name (e.g. "add", "batchGetUnion", "list")
-   * @param entityType    the entity type derived from the URN class (e.g. "dataset", "corpuser")
-   * @param latencyMs     wall-clock latency in milliseconds
+   * @param operation   pure operation name with no concatenation (e.g. {@code "add"},
+   *                    {@code "batchGetUnion"})
+   * @param entityType  entity type derived from the URN class (e.g. {@code "dataset"})
+   * @param aspect      aspect class simple name for per-aspect operations, or {@code null} when
+   *                    the operation is not per-aspect
+   * @param countBucket pre-bucketed count label ({@code "1"} through {@code "9"}, {@code "10+"})
+   *                    for batch operations, or {@code null} when there is no count dimension
+   * @param status      outcome string, e.g. {@code "success"} or {@code "failure"}
+   * @param errorClass  simple name of the thrown exception on failure, or {@code null} on success
+   * @param latencyMs   wall-clock latency of the operation in milliseconds
    */
-  void recordOperationLatency(@Nonnull String operationType, @Nonnull String entityType, long latencyMs);
+  void recordOperation(@Nonnull String operation, @Nonnull String entityType,
+      @Nullable String aspect, @Nullable String countBucket, @Nonnull String status,
+      @Nullable String errorClass, long latencyMs);
 
   /**
-   * Record an error that occurred during a DAO operation.
-   *
-   * @param operationType  the DAO operation name (e.g. "add", "create")
-   * @param entityType     the entity type derived from the URN class
-   * @param exceptionClass the simple class name of the thrown exception (e.g. "SQLException")
-   */
-  void recordOperationError(@Nonnull String operationType, @Nonnull String entityType,
-      @Nonnull String exceptionClass);
-
-  /**
-   * Whether metrics collection is enabled. Callers may short-circuit expensive
-   * instrumentation when this returns {@code false}.
-   *
-   * @return true if metrics are being collected
+   * Whether metrics collection is enabled. Callers may short-circuit instrumentation when
+   * this returns {@code false}.
    */
   boolean isEnabled();
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/NoOpDaoBenchmarkMetrics.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/NoOpDaoBenchmarkMetrics.java
@@ -1,24 +1,20 @@
 package com.linkedin.metadata.dao.tracking;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 /**
- * A no-op implementation of {@link BaseDaoBenchmarkMetrics} that discards all metrics.
+ * A no-op implementation of {@link BaseDaoBenchmarkMetrics} that discards all observations.
  *
  * <p>Used as the default when no real metrics backend is configured.
- * Follows the same pattern as {@link DummyTrackingManager}.</p>
  */
 public class NoOpDaoBenchmarkMetrics implements BaseDaoBenchmarkMetrics {
 
   @Override
-  public void recordOperationLatency(@Nonnull String operationType, @Nonnull String entityType, long latencyMs) {
-    // Do nothing
-  }
-
-  @Override
-  public void recordOperationError(@Nonnull String operationType, @Nonnull String entityType,
-      @Nonnull String exceptionClass) {
+  public void recordOperation(@Nonnull String operation, @Nonnull String entityType,
+      @Nullable String aspect, @Nullable String countBucket, @Nonnull String status,
+      @Nullable String errorClass, long latencyMs) {
     // Do nothing
   }
 

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/NoOpDaoBenchmarkMetricsTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/NoOpDaoBenchmarkMetricsTest.java
@@ -11,9 +11,9 @@ public class NoOpDaoBenchmarkMetricsTest {
   public void testNoOpBehavior() {
     NoOpDaoBenchmarkMetrics metrics = new NoOpDaoBenchmarkMetrics();
 
-    // Should not throw
-    metrics.recordOperationLatency("add", "dataset", 42L);
-    metrics.recordOperationError("add", "dataset", "SQLException");
+    // Should not throw on any dimension combination
+    metrics.recordOperation("add", "dataset", "AspectFoo", null, "success", null, 42L);
+    metrics.recordOperation("batchUpsert", "corpuser", null, "3", "failure", "SQLException", 15L);
 
     assertFalse(metrics.isEnabled());
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccess.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.dao;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
@@ -19,19 +20,32 @@ import javax.annotation.Nullable;
 
 
 /**
- * A decorator around {@link IEbeanLocalAccess} that records per-operation latency and error metrics
- * via {@link BaseDaoBenchmarkMetrics}.
+ * A decorator around {@link IEbeanLocalAccess} that records per-operation latency and count
+ * metrics via {@link BaseDaoBenchmarkMetrics}, passing dimensions (operation, aspect, count
+ * bucket, status, error class) as separate attributes rather than baking them into a single
+ * metric name.
  *
  * <p>Delegates every call to the wrapped implementation, measuring wall-clock time with
- * {@link System#nanoTime()}. On success, records latency; on error, records both latency and
- * the exception class, then re-throws.</p>
+ * {@link System#nanoTime()}. On both success and failure, calls
+ * {@link BaseDaoBenchmarkMetrics#recordOperation} once with the observed latency, status, and
+ * (on failure) the thrown exception's simple class name; the exception is re-thrown unchanged.
  *
  * <p>When {@link BaseDaoBenchmarkMetrics#isEnabled()} returns {@code false}, delegation is
- * direct with zero overhead (no timing).</p>
+ * direct with zero overhead (no timing).
  *
  * @param <URN> the URN type for this entity
  */
 public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN> {
+
+  static final String STATUS_SUCCESS = "success";
+  static final String STATUS_FAILURE = "failure";
+
+  // 1..9 mapped to interned strings; 0 and 10+ handled separately. Avoids
+  // Integer.toString() allocation on the hot path.
+  private static final String[] COUNT_BUCKET_INTERNED =
+      {"1", "2", "3", "4", "5", "6", "7", "8", "9"};
+  private static final String BUCKET_ZERO = "0";
+  private static final String BUCKET_OVERFLOW = "10+";
 
   private final IEbeanLocalAccess<URN> _delegate;
   private final BaseDaoBenchmarkMetrics _metrics;
@@ -40,15 +54,32 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   /**
    * Creates an instrumented wrapper around the given local access implementation.
    *
-   * @param delegate   the real local access implementation to wrap
-   * @param metrics    the metrics recorder (may be a no-op)
-   * @param urnClass   the URN class, used to derive the entity type name once at construction
+   * @param delegate the real local access implementation to wrap
+   * @param metrics  the metrics recorder (may be a no-op)
+   * @param urnClass the URN class, used to derive the entity type name once at construction
    */
   public InstrumentedEbeanLocalAccess(@Nonnull IEbeanLocalAccess<URN> delegate,
       @Nonnull BaseDaoBenchmarkMetrics metrics, @Nonnull Class<URN> urnClass) {
     _delegate = delegate;
     _metrics = metrics;
     _entityType = urnClass.getSimpleName().replace("Urn", "").toLowerCase();
+  }
+
+  /**
+   * Bucket a count value into a small fixed set of labels to keep metric cardinality bounded.
+   *
+   * <p>Returns {@code "0"} for non-positive values (defensive; batch ops shouldn't hit this),
+   * the interned digit string {@code "1".."9"} for 1-9, or {@code "10+"} for anything >= 10.
+   */
+  @VisibleForTesting
+  static String bucketCount(int n) {
+    if (n <= 0) {
+      return BUCKET_ZERO;
+    }
+    if (n >= 10) {
+      return BUCKET_OVERFLOW;
+    }
+    return COUNT_BUCKET_INTERNED[n - 1];
   }
 
   @Override
@@ -66,8 +97,9 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   public <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue,
       @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp,
       @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode) {
-    return instrument("add." + aspectClass.getSimpleName(), () -> _delegate.add(urn, newValue,
-        aspectClass, auditStamp, ingestionTrackingContext, isTestMode));
+    return instrument("add", aspectClass.getSimpleName(), null,
+        () -> _delegate.add(urn, newValue, aspectClass, auditStamp,
+            ingestionTrackingContext, isTestMode));
   }
 
   @Override
@@ -75,7 +107,7 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
       @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp,
       @Nullable Timestamp oldTimestamp, @Nullable IngestionTrackingContext ingestionTrackingContext,
       boolean isTestMode, boolean softDeleteOverwrite) {
-    return instrument("addWithOptimisticLocking." + aspectClass.getSimpleName(),
+    return instrument("addWithOptimisticLocking", aspectClass.getSimpleName(), null,
         () -> _delegate.addWithOptimisticLocking(urn, newValue, aspectClass, auditStamp,
             oldTimestamp, ingestionTrackingContext, isTestMode, softDeleteOverwrite));
   }
@@ -86,7 +118,7 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
       @Nonnull List<BaseLocalDAO.AspectCreateLambda<? extends RecordTemplate>> aspectCreateLambdas,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext ingestionTrackingContext,
       boolean isTestMode) {
-    return instrument("create.aspects_" + aspectValues.size(),
+    return instrument("create", null, bucketCount(aspectValues.size()),
         () -> _delegate.create(urn, aspectValues, aspectCreateLambdas,
             auditStamp, ingestionTrackingContext, isTestMode));
   }
@@ -96,8 +128,9 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
       @Nonnull List<BaseLocalDAO.AspectUpdateContext<RecordTemplate>> updateContexts,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext ingestionTrackingContext,
       boolean isTestMode) {
-    return instrument("batchUpsert.aspects_" + updateContexts.size(),
-        () -> _delegate.batchUpsert(urn, updateContexts, auditStamp, ingestionTrackingContext, isTestMode));
+    return instrument("batchUpsert", null, bucketCount(updateContexts.size()),
+        () -> _delegate.batchUpsert(urn, updateContexts, auditStamp,
+            ingestionTrackingContext, isTestMode));
   }
 
   @Nonnull
@@ -105,51 +138,54 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   public <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> batchGetUnion(
       @Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys, int keysCount, int position,
       boolean includeSoftDeleted, boolean isTestMode) {
-    return instrument("batchGetUnion.keys_" + keys.size(),
+    return instrument("batchGetUnion", null, bucketCount(keys.size()),
         () -> _delegate.batchGetUnion(keys, keysCount, position, includeSoftDeleted, isTestMode));
   }
 
   @Override
   public int softDeleteAsset(@Nonnull URN urn, boolean isTestMode) {
-    return instrument("softDeleteAsset", () -> _delegate.softDeleteAsset(urn, isTestMode));
+    return instrument("softDeleteAsset", null, null,
+        () -> _delegate.softDeleteAsset(urn, isTestMode));
   }
 
   @Override
-  public Map<URN, EntityDeletionInfo> readDeletionInfoBatch(@Nonnull List<URN> urns, boolean isTestMode) {
-    return instrument("readDeletionInfoBatch.urns_" + urns.size(),
+  public Map<URN, EntityDeletionInfo> readDeletionInfoBatch(@Nonnull List<URN> urns,
+      boolean isTestMode) {
+    return instrument("readDeletionInfoBatch", null, bucketCount(urns.size()),
         () -> _delegate.readDeletionInfoBatch(urns, isTestMode));
   }
 
   @Override
-  public int batchSoftDeleteAssets(@Nonnull List<URN> urns, @Nonnull String cutoffTimestamp, boolean isTestMode) {
-    return instrument("batchSoftDeleteAssets.urns_" + urns.size(),
+  public int batchSoftDeleteAssets(@Nonnull List<URN> urns, @Nonnull String cutoffTimestamp,
+      boolean isTestMode) {
+    return instrument("batchSoftDeleteAssets", null, bucketCount(urns.size()),
         () -> _delegate.batchSoftDeleteAssets(urns, cutoffTimestamp, isTestMode));
   }
 
   @Override
   public List<URN> listUrns(@Nullable IndexFilter indexFilter,
       @Nullable IndexSortCriterion indexSortCriterion, @Nullable URN lastUrn, int pageSize) {
-    return instrument("listUrns.cursor",
+    return instrument("listUrns.cursor", null, null,
         () -> _delegate.listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize));
   }
 
   @Override
   public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter,
       @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
-    return instrument("listUrns.offset",
+    return instrument("listUrns.offset", null, null,
         () -> _delegate.listUrns(indexFilter, indexSortCriterion, start, pageSize));
   }
 
   @Override
   public boolean exists(@Nonnull URN urn) {
-    return instrument("exists", () -> _delegate.exists(urn));
+    return instrument("exists", null, null, () -> _delegate.exists(urn));
   }
 
   @Nonnull
   @Override
   public Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
       @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
-    return instrument("countAggregate",
+    return instrument("countAggregate", null, null,
         () -> _delegate.countAggregate(indexFilter, indexGroupByCriterion));
   }
 
@@ -157,21 +193,22 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   @Override
   public <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull Class<ASPECT> aspectClass,
       int start, int pageSize) {
-    return instrument("listUrns", () -> _delegate.listUrns(aspectClass, start, pageSize));
+    return instrument("listUrns", null, null,
+        () -> _delegate.listUrns(aspectClass, start, pageSize));
   }
 
   @Nonnull
   @Override
   public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull URN urn, int start, int pageSize) {
-    return instrument("list", () -> _delegate.list(aspectClass, urn, start, pageSize));
+    return instrument("list", null, null, () -> _delegate.list(aspectClass, urn, start, pageSize));
   }
 
   @Nonnull
   @Override
   public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
       int start, int pageSize) {
-    return instrument("list", () -> _delegate.list(aspectClass, start, pageSize));
+    return instrument("list", null, null, () -> _delegate.list(aspectClass, start, pageSize));
   }
 
   @Override
@@ -181,21 +218,26 @@ public class InstrumentedEbeanLocalAccess<URN extends Urn> implements IEbeanLoca
   }
 
   /**
-   * Core instrumentation wrapper. When metrics are disabled, delegates directly.
-   * When enabled, times the operation and records latency on success, latency + error on failure.
+   * Core instrumentation wrapper. When metrics are disabled, delegates directly. When enabled,
+   * times the operation and emits one {@code recordOperation} call in the {@code finally} block
+   * with status and (on failure) error class populated.
    */
-  private <T> T instrument(@Nonnull String operationType, @Nonnull Supplier<T> supplier) {
+  private <T> T instrument(@Nonnull String operation, @Nullable String aspect,
+      @Nullable String countBucket, @Nonnull Supplier<T> supplier) {
     if (!_metrics.isEnabled()) {
       return supplier.get();
     }
     final long startNanos = System.nanoTime();
+    String status = STATUS_SUCCESS;
+    String errorClass = null;
     try {
       return supplier.get();
     } catch (RuntimeException ex) {
-      _metrics.recordOperationError(operationType, _entityType, ex.getClass().getSimpleName());
+      status = STATUS_FAILURE;
+      errorClass = ex.getClass().getSimpleName();
       throw ex;
     } finally {
-      _metrics.recordOperationLatency(operationType, _entityType,
+      _metrics.recordOperation(operation, _entityType, aspect, countBucket, status, errorClass,
           TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos));
     }
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/InstrumentedEbeanLocalAccessTest.java
@@ -24,9 +24,10 @@ import static org.testng.Assert.*;
  * Tests for {@link InstrumentedEbeanLocalAccess}. Verifies:
  * <ul>
  *   <li>Delegation to the wrapped implementation</li>
- *   <li>Latency recording on success</li>
- *   <li>Latency + error recording on failure</li>
+ *   <li>Per-method dimension wiring (operation, aspect, count bucket) into recordOperation</li>
+ *   <li>Status and error class capture on success and failure</li>
  *   <li>Direct delegation (no timing) when metrics are disabled</li>
+ *   <li>bucketCount boundary behavior</li>
  * </ul>
  */
 public class InstrumentedEbeanLocalAccessTest {
@@ -54,90 +55,106 @@ public class InstrumentedEbeanLocalAccessTest {
   }
 
   @Test
-  public void testEntityTypeExtraction() {
-    // "TestUrn" -> "test"
-    InstrumentedEbeanLocalAccess<TestUrn> access =
-        new InstrumentedEbeanLocalAccess<>(_mockDelegate, _mockMetrics, TestUrn.class);
+  public void testBucketCountBoundaries() {
+    assertEquals(InstrumentedEbeanLocalAccess.bucketCount(0), "0");
+    assertEquals(InstrumentedEbeanLocalAccess.bucketCount(-1), "0");
+    assertEquals(InstrumentedEbeanLocalAccess.bucketCount(1), "1");
+    assertEquals(InstrumentedEbeanLocalAccess.bucketCount(5), "5");
+    assertEquals(InstrumentedEbeanLocalAccess.bucketCount(9), "9");
+    assertEquals(InstrumentedEbeanLocalAccess.bucketCount(10), "10+");
+    assertEquals(InstrumentedEbeanLocalAccess.bucketCount(100), "10+");
+  }
 
-    // Trigger any instrumented call to verify the entity type passed to metrics
+  @Test
+  public void testEntityTypeExtraction() {
+    // "TestUrn" -> "test"; trigger any instrumented call to verify entity type
     when(_mockDelegate.exists(any())).thenReturn(true);
-    access.exists(null);
+    _instrumented.exists(null);
 
     ArgumentCaptor<String> entityCaptor = ArgumentCaptor.forClass(String.class);
-    verify(_mockMetrics).recordOperationLatency(eq("exists"), entityCaptor.capture(), anyLong());
+    verify(_mockMetrics).recordOperation(eq("exists"), entityCaptor.capture(),
+        isNull(), isNull(), eq("success"), isNull(), anyLong());
     assertEquals(entityCaptor.getValue(), "test");
   }
 
   @Test
-  public void testAddDelegatesAndRecordsLatency() {
+  public void testAddDelegatesAndRecordsOperation() {
     when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
 
     int result = _instrumented.add(null, null, AspectFoo.class, mock(AuditStamp.class), null, false);
 
     assertEquals(result, 1);
     verify(_mockDelegate).add(any(), any(), any(), any(), any(), anyBoolean());
-    verify(_mockMetrics).recordOperationLatency(eq("add.AspectFoo"), eq("test"), anyLong());
-    verify(_mockMetrics, never()).recordOperationError(anyString(), anyString(), anyString());
+    verify(_mockMetrics).recordOperation(eq("add"), eq("test"), eq("AspectFoo"),
+        isNull(), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testAddWithOptimisticLockingDelegatesAndRecordsLatency() {
-    when(_mockDelegate.addWithOptimisticLocking(any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
-        .thenReturn(1);
+  public void testAddWithOptimisticLockingDelegatesAndRecordsOperation() {
+    when(_mockDelegate.addWithOptimisticLocking(any(), any(), any(), any(), any(), any(),
+        anyBoolean(), anyBoolean())).thenReturn(1);
 
     int result = _instrumented.addWithOptimisticLocking(null, null, AspectFoo.class,
         mock(AuditStamp.class), null, null, false, false);
 
     assertEquals(result, 1);
-    verify(_mockDelegate).addWithOptimisticLocking(any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean());
-    verify(_mockMetrics).recordOperationLatency(eq("addWithOptimisticLocking.AspectFoo"), eq("test"), anyLong());
+    verify(_mockDelegate).addWithOptimisticLocking(any(), any(), any(), any(), any(), any(),
+        anyBoolean(), anyBoolean());
+    verify(_mockMetrics).recordOperation(eq("addWithOptimisticLocking"), eq("test"),
+        eq("AspectFoo"), isNull(), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testCreateDelegatesAndRecordsLatency() {
+  public void testCreateRecordsCountBucket() {
     when(_mockDelegate.create(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
 
     int result = _instrumented.create(null, Collections.emptyList(), Collections.emptyList(),
         mock(AuditStamp.class), null, false);
 
     assertEquals(result, 1);
-    verify(_mockMetrics).recordOperationLatency(eq("create.aspects_0"), eq("test"), anyLong());
+    // Empty list -> bucket "0" (defensive: shouldn't happen in real usage, but still bucketed)
+    verify(_mockMetrics).recordOperation(eq("create"), eq("test"), isNull(),
+        eq("0"), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testBatchGetUnionDelegatesAndRecordsLatency() {
+  public void testBatchGetUnionRecordsCountBucket() {
     List<EbeanMetadataAspect> expected = Collections.emptyList();
     when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
         .thenReturn(expected);
 
-    List<EbeanMetadataAspect> result = _instrumented.batchGetUnion(Collections.emptyList(), 10, 0, false, false);
+    List<EbeanMetadataAspect> result =
+        _instrumented.batchGetUnion(Collections.emptyList(), 10, 0, false, false);
 
     assertSame(result, expected);
-    verify(_mockMetrics).recordOperationLatency(eq("batchGetUnion.keys_0"), eq("test"), anyLong());
+    verify(_mockMetrics).recordOperation(eq("batchGetUnion"), eq("test"), isNull(),
+        eq("0"), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testSoftDeleteAssetDelegatesAndRecordsLatency() {
+  public void testSoftDeleteAssetRecordsOperation() {
     when(_mockDelegate.softDeleteAsset(any(), anyBoolean())).thenReturn(3);
 
     int result = _instrumented.softDeleteAsset(null, false);
 
     assertEquals(result, 3);
-    verify(_mockMetrics).recordOperationLatency(eq("softDeleteAsset"), eq("test"), anyLong());
+    verify(_mockMetrics).recordOperation(eq("softDeleteAsset"), eq("test"), isNull(),
+        isNull(), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testExistsDelegatesAndRecordsLatency() {
+  public void testExistsRecordsOperation() {
     when(_mockDelegate.exists(any())).thenReturn(true);
 
     boolean result = _instrumented.exists(null);
 
     assertTrue(result);
-    verify(_mockMetrics).recordOperationLatency(eq("exists"), eq("test"), anyLong());
+    verify(_mockMetrics).recordOperation(eq("exists"), eq("test"), isNull(),
+        isNull(), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testCountAggregateDelegatesAndRecordsLatency() {
+  public void testCountAggregateRecordsOperation() {
     Map<String, Long> expected = new HashMap<>();
     expected.put("key", 5L);
     when(_mockDelegate.countAggregate(any(), any())).thenReturn(expected);
@@ -145,35 +162,38 @@ public class InstrumentedEbeanLocalAccessTest {
     Map<String, Long> result = _instrumented.countAggregate(null, mock(IndexGroupByCriterion.class));
 
     assertSame(result, expected);
-    verify(_mockMetrics).recordOperationLatency(eq("countAggregate"), eq("test"), anyLong());
+    verify(_mockMetrics).recordOperation(eq("countAggregate"), eq("test"), isNull(),
+        isNull(), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testListDelegatesAndRecordsLatency() {
+  public void testListRecordsOperation() {
     ListResult<RecordTemplate> expected = mock(ListResult.class);
     when(_mockDelegate.list(any(Class.class), anyInt(), anyInt())).thenReturn(expected);
 
     ListResult<RecordTemplate> result = _instrumented.list(RecordTemplate.class, 0, 10);
 
     assertSame(result, expected);
-    verify(_mockMetrics).recordOperationLatency(eq("list"), eq("test"), anyLong());
+    verify(_mockMetrics).recordOperation(eq("list"), eq("test"), isNull(),
+        isNull(), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testListUrnsWithPaginationDelegatesAndRecordsLatency() {
+  public void testListUrnsOffsetRecordsOperation() {
     ListResult<TestUrn> expected = mock(ListResult.class);
-    when(_mockDelegate.listUrns(any(IndexFilter.class), any(IndexSortCriterion.class), anyInt(), anyInt()))
-        .thenReturn(expected);
+    when(_mockDelegate.listUrns(any(IndexFilter.class), any(IndexSortCriterion.class),
+        anyInt(), anyInt())).thenReturn(expected);
 
     ListResult<TestUrn> result = _instrumented.listUrns(
         mock(IndexFilter.class), mock(IndexSortCriterion.class), 0, 10);
 
     assertSame(result, expected);
-    verify(_mockMetrics).recordOperationLatency(eq("listUrns.offset"), eq("test"), anyLong());
+    verify(_mockMetrics).recordOperation(eq("listUrns.offset"), eq("test"), isNull(),
+        isNull(), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testErrorRecordingAndRethrow() {
+  public void testFailureRecordsStatusAndErrorClassAndRethrows() {
     RuntimeException error = new IllegalStateException("DB error");
     when(_mockDelegate.exists(any())).thenThrow(error);
 
@@ -184,8 +204,8 @@ public class InstrumentedEbeanLocalAccessTest {
       assertSame(ex, error);
     }
 
-    verify(_mockMetrics).recordOperationLatency(eq("exists"), eq("test"), anyLong());
-    verify(_mockMetrics).recordOperationError("exists", "test", "IllegalStateException");
+    verify(_mockMetrics).recordOperation(eq("exists"), eq("test"), isNull(), isNull(),
+        eq("failure"), eq("IllegalStateException"), anyLong());
   }
 
   @Test
@@ -197,9 +217,9 @@ public class InstrumentedEbeanLocalAccessTest {
 
     assertTrue(result);
     verify(_mockDelegate).exists(any());
-    // No metrics calls should be made
-    verify(_mockMetrics, never()).recordOperationLatency(anyString(), anyString(), anyLong());
-    verify(_mockMetrics, never()).recordOperationError(anyString(), anyString(), anyString());
+    // No record* calls should be made
+    verify(_mockMetrics, never()).recordOperation(anyString(), anyString(), any(), any(),
+        anyString(), any(), anyLong());
   }
 
   @Test
@@ -207,7 +227,8 @@ public class InstrumentedEbeanLocalAccessTest {
     _instrumented.ensureSchemaUpToDate();
 
     verify(_mockDelegate).ensureSchemaUpToDate();
-    verify(_mockMetrics, never()).recordOperationLatency(anyString(), anyString(), anyLong());
+    verify(_mockMetrics, never()).recordOperation(anyString(), anyString(), any(), any(),
+        anyString(), any(), anyLong());
   }
 
   @Test
@@ -225,7 +246,7 @@ public class InstrumentedEbeanLocalAccessTest {
   }
 
   @Test
-  public void testReadDeletionInfoBatchDelegatesAndRecordsLatency() {
+  public void testReadDeletionInfoBatchRecordsCountBucket() {
     Map<TestUrn, EntityDeletionInfo> expected = new HashMap<>();
     when(_mockDelegate.readDeletionInfoBatch(any(), anyBoolean())).thenReturn(expected);
 
@@ -234,12 +255,12 @@ public class InstrumentedEbeanLocalAccessTest {
 
     assertSame(result, expected);
     verify(_mockDelegate).readDeletionInfoBatch(urns, false);
-    verify(_mockMetrics).recordOperationLatency(eq("readDeletionInfoBatch.urns_1"), eq("test"), anyLong());
-    verify(_mockMetrics, never()).recordOperationError(anyString(), anyString(), anyString());
+    verify(_mockMetrics).recordOperation(eq("readDeletionInfoBatch"), eq("test"), isNull(),
+        eq("1"), eq("success"), isNull(), anyLong());
   }
 
   @Test
-  public void testBatchSoftDeleteAssetsDelegatesAndRecordsLatency() {
+  public void testBatchSoftDeleteAssetsRecordsCountBucket() {
     when(_mockDelegate.batchSoftDeleteAssets(any(), any(), anyBoolean())).thenReturn(5);
 
     List<TestUrn> urns = Collections.singletonList(null);
@@ -247,7 +268,7 @@ public class InstrumentedEbeanLocalAccessTest {
 
     assertEquals(result, 5);
     verify(_mockDelegate).batchSoftDeleteAssets(urns, "2026-01-01", false);
-    verify(_mockMetrics).recordOperationLatency(eq("batchSoftDeleteAssets.urns_1"), eq("test"), anyLong());
-    verify(_mockMetrics, never()).recordOperationError(anyString(), anyString(), anyString());
+    verify(_mockMetrics).recordOperation(eq("batchSoftDeleteAssets"), eq("test"), isNull(),
+        eq("1"), eq("success"), isNull(), anyLong());
   }
 }


### PR DESCRIPTION
## Summary
- Rewrite `BaseDaoBenchmarkMetrics` so impls receive each dimension (operation, aspect, count bucket, status, error class) as a separate parameter instead of one concatenated `operationType` string.
- Update `InstrumentedEbeanLocalAccess` to pass dimensions through cleanly: aspect class name for per-aspect ops, a bucketed count label (`1`..`9`, `10+`) for batch ops.
- Bucketing keeps cardinality bounded for downstream backends (OTEL especially).

## Why
Today the impl gets strings like `add.AliasesInfo`, `create.aspects_3`, `batchGetUnion.keys_42` — each becomes its own metric path in RRD/Dropwizard, so aggregating "all adds across all aspects" requires summing hundreds of named series. Splitting into native dimensions lets backends emit one metric with attributes and aggregate/filter natively. This is a pre-req for a downstream OTEL-backed impl.

## Follow-up (required in metadata-graph-assets)
This PR changes the interface contract; it does **not** itself emit any metrics. The existing `DropwizardDaoBenchmarkMetrics` in metadata-graph-assets (the only known concrete impl) implements the old `recordOperationLatency` / `recordOperationError` methods and **will not compile** against the new contract.

When MGA picks up this version (via a metadata-models bump), it must in the same PR:

1. Replace `DropwizardDaoBenchmarkMetrics` with a new `DaoBenchmarkOtelMetrics` that implements the single `recordOperation(...)` method.
   - Mirror the existing `MgaClientMetrics` facade pattern (typed `AttributeKey`s, pre-built `LongCounter` + `LongHistogram`, `Meter` obtained from `com.linkedin.opentelemetry.OpenTelemetry.meterBuilder(...)`).
   - Suggested metric names: `Dao.Benchmark.Operation.Count` (counter), `Dao.Benchmark.Operation.Latency` (histogram, ms).
   - Attribute keys (PascalCase, per LinkedIn MDM convention): `Operation`, `EntityType`, `Aspect`, `CountBucket`, `Status`, `ErrorClass`.
2. Update `DaoBenchmarkMetricsFactory.createInstance(...)` to return the OTEL impl instead of the Dropwizard one.
3. Delete `DropwizardDaoBenchmarkMetrics` and its `DropwizardDaoBenchmarkMetricsTest`.
4. Add unit tests using `InMemoryMetricReader` (mirror `MgaClientMetricsTest`).

The MGA-side OTEL impl is where the real metric emission lives — this PR is purely kernel plumbing.

## Test plan
- [x] `:dao-api` + `:dao-impl:ebean-dao` compile clean (Java 11)
- [x] `InstrumentedEbeanLocalAccessTest` passes — rewrote assertions to verify the 7-param contract, added `bucketCount` boundary tests (0, 1, 5, 9, 10, 100), covered success + failure paths
- [ ] Full `:dao-impl:ebean-dao:test` suite (CI will run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)