### PR TITLE
fix(dao): run shouldUpdateAspect after the callback in addManyBatchInternal

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -812,19 +812,6 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       // AspectUpdateLambda is defined and constructed
       RecordTemplate newValue = (RecordTemplate) updateLambda.getUpdateLambda().apply(oldValue);
 
-      // Equality testing & backfill logic using unified shouldUpdateAspect
-      EqualityTester<RecordTemplate> equalityTester = getEqualityTester(aspectClass);
-      AuditStamp eTagAuditStamp = extractOptimisticLockForAspectFromIngestionParamsIfPossible(
-          ingestionParams, aspectClass, urn);
-      
-      if (!shouldUpdateAspect(ingestionParams.getIngestionMode(), urn, oldAspect, newValue,
-                              aspectClass, auditStamp, equalityTester, oldAuditStamp, eTagAuditStamp,
-                              trackingContext, oldEmitTime, false /* isSoftDeleted not tracked in batch path */)) {
-        // Skip this aspect - add as unchanged for MAE skip logic
-        processedResults.add(new AddResult<RecordTemplate>(oldAspect, oldAspect, aspectClass));
-        continue;
-      }
-
       // Apply Lambda Function Registry transformations (with old value)
       if (_lambdaFunctionRegistry != null && _lambdaFunctionRegistry.isRegistered(aspectClass)) {
         newValue = updatePreIngestionLambdas(urn, oldValue, newValue);
@@ -833,8 +820,26 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       // Aspect callbacks (with old value)
       AspectUpdateResult callbackResult = aspectCallbackHelper(urn, newValue, oldValue, ingestionParams, auditStamp);
       newValue = (RecordTemplate) callbackResult.getUpdatedAspect();
-      
+
       if (newValue == null || callbackResult.isSkipProcessing()) {
+        continue;
+      }
+
+      // Equality testing & backfill logic using unified shouldUpdateAspect.
+      // Run this AFTER the callback so we compare the post-callback (merged) value against the
+      // stored (also post-callback) value, matching the per-aspect aspectUpdateHelper path.
+      // Comparing the raw pre-callback newValue here caused callback-transformed aspects (e.g.
+      // SchemaDefinition, which the callback enriches with normalizedSchema/baseSemanticVersion)
+      // to never compare equal to the stored merged value, so every no-op re-ingest wrote a row.
+      EqualityTester<RecordTemplate> equalityTester = getEqualityTester(aspectClass);
+      AuditStamp eTagAuditStamp = extractOptimisticLockForAspectFromIngestionParamsIfPossible(
+          ingestionParams, aspectClass, urn);
+
+      if (!shouldUpdateAspect(ingestionParams.getIngestionMode(), urn, oldAspect, newValue,
+                              aspectClass, auditStamp, equalityTester, oldAuditStamp, eTagAuditStamp,
+                              trackingContext, oldEmitTime, false /* isSoftDeleted not tracked in batch path */)) {
+        // Skip this aspect - add as unchanged for MAE skip logic
+        processedResults.add(new AddResult<RecordTemplate>(oldAspect, oldAspect, aspectClass));
         continue;
       }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -4551,6 +4551,67 @@ public class EbeanLocalDAOTest {
   }
 
   /**
+   * Regression test for the callback/equality ordering fix in addManyBatch().
+   *
+   * <p>Before the fix, addManyBatch() evaluated shouldUpdateAspect() on the RAW pre-callback value
+   * but persisted the POST-callback value. For an aspect whose callback deterministically rewrites
+   * the incoming value (modeling SchemaDefinition, whose callback enriches the raw aspect with
+   * normalizedSchema/baseSemanticVersion), re-ingesting the same raw value produced raw != stored on
+   * every crawl, so the equality check never skipped and every no-op re-ingest wrote a new version.
+   *
+   * <p>After the fix the equality check runs on the post-callback value, which equals the stored
+   * value, so the redundant write is suppressed. We assert the audit timestamp is unchanged on the
+   * second ingest -- exactly like {@link #testAddManyBatchWithEqualitySkip()} but with a transforming
+   * callback in the path.
+   */
+  @Test
+  public void testAddManyBatchCallbackNoOpReingestSkips() throws URISyntaxException {
+    if (_schemaConfig != SchemaConfig.NEW_SCHEMA_ONLY) {
+      return;
+    }
+
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+    FooUrn fooUrn = makeFooUrn(6005);
+
+    // Enriching callback: any incoming AspectFoo is rewritten to the fixed value "merged", just as a
+    // real callback enriches the raw aspect into a stable merged value before it is persisted.
+    AspectCallbackRoutingClient<AspectFoo> enrichCallback = new AspectCallbackRoutingClient<AspectFoo>() {
+      @Override
+      public AspectCallbackResponse<AspectFoo> routeAspectCallback(Urn urn, AspectFoo newAspectValue,
+          java.util.Optional<AspectFoo> existingAspectValue) {
+        return new AspectCallbackResponse<>(new AspectFoo().setValue("merged"));
+      }
+    };
+    java.util.Map<AspectCallbackMapKey, AspectCallbackRoutingClient> callbackMap = new java.util.HashMap<>();
+    callbackMap.put(new AspectCallbackMapKey(AspectFoo.class, fooUrn.getEntityType()), enrichCallback);
+    dao.setAspectCallbackRegistry(new AspectCallbackRegistry(callbackMap));
+
+    // First ingest at T1 - persists the post-callback "merged" value.
+    AuditStamp auditStamp1 = makeAuditStamp("actor1", _now);
+    dao.addManyBatch(fooUrn, Collections.singletonList(new AspectFoo().setValue("raw")), auditStamp1, null);
+
+    BaseLocalDAO.AspectEntry<AspectFoo> entry1 = dao.getLatest(fooUrn, AspectFoo.class, false);
+    assertNotNull(entry1.getAspect());
+    assertEquals(entry1.getAspect().getValue(), "merged");
+    Long timestamp1 = entry1.getExtraInfo() != null ? entry1.getExtraInfo().getAudit().getTime() : null;
+
+    // Second ingest of the SAME raw value at a LATER T2. The callback again yields "merged", which
+    // equals the stored value, so shouldUpdateAspect() must skip and NO new version is written.
+    AuditStamp auditStamp2 = makeAuditStamp("actor2", _now + 1000);
+    List<EntityAspectUnion> results =
+        dao.addManyBatch(fooUrn, Collections.singletonList(new AspectFoo().setValue("raw")), auditStamp2, null);
+
+    assertEquals(results.size(), 1);
+
+    BaseLocalDAO.AspectEntry<AspectFoo> entry2 = dao.getLatest(fooUrn, AspectFoo.class, false);
+    Long timestamp2 = entry2.getExtraInfo() != null ? entry2.getExtraInfo().getAudit().getTime() : null;
+    assertEquals(timestamp1, timestamp2,
+        "Re-ingesting the same raw value through a transforming callback must skip the write: the "
+            + "post-callback value equals the stored value, so no new version should be written");
+    assertEquals(entry2.getAspect().getValue(), "merged");
+  }
+
+  /**
    * Tests addManyBatch() backfill skip behavior.
    * Verifies that backfill events with older timestamps do not overwrite newer data.
    */


### PR DESCRIPTION
## Problem

In `addManyBatchInternal` (added in #608), `shouldUpdateAspect` runs on the **raw, pre-callback** `newValue`, but the value persisted to the DB is the **post-callback (merged)** value. 

What the callback actually does

For SchemaDefinition, the remote schemaDefinitionCallback enriches the incoming aspect — it adds normalizedSchema and baseSemanticVersion. So:
- V_new (raw, from sceptre) = { rawSchema, schemaErrorType }
- V_merged (after callback) = { rawSchema, schemaErrorType, normalizedSchema, baseSemanticVersion: 12.1.350 }

What's stored in the DB is V_merged (the enriched version), because the last write happened after the callback.

Per-aspect path (aspectUpdateHelper) — writes correctly suppressed

1. Run callback: raw V_new → V_merged.
2. Then compare: V_merged (new) vs V_merged (stored). Same schema → same enrichment → equal → shouldUpdateAspect returns false → skip the write. ✅

So the write is "cancelled" by the equality check — but only because the callback ran first, making both sides the enriched form.

**Batch path (addManyBatchInternal) — the bug**

1. Compare first: raw V_new (no normalizedSchema/baseSemanticVersion) vs V_merged (stored, has them).
2. They're not equal — V_merged has extra fields V_new lacks → shouldUpdateAspect returns true → write.
3. Then it runs the callback and stores V_merged anyway.

This was observed in production: a registeredschema `_test` shadow table (batch path) was rewritten on every sceptre crawl while the prod table (per-aspect) stayed put for weeks, with byte-identical aspect content — a 15–25 day gap on unchanged schemas.

## Fix

Move the `shouldUpdateAspect` (equality/backfill) check to run **after** `aspectCallbackHelper`, on the merged `newValue` — matching `aspectUpdateHelper`'s ordering. Batch and per-aspect now suppress no-ops identically.

## Why it's safe
- **Callback aspects:** the callback already ran every time (the pre-check never skipped them, since raw != merged), so callback frequency is unchanged — only the **redundant write/MAE is now suppressed**.
- **Non-callback aspects:** `aspectCallbackHelper` is a no-op (no client registered) and the lambda registry is gated by `isRegistered(...)`, so running them before the equality check on an unchanged aspect costs ~nothing.
- Net: aligns the batch path with the canonical per-aspect ordering.

## Testing
- `:dao-api:compileJava` passes.
- Tests not yet updated — existing `addManyBatchInternal` tests that assert the old pre-callback ordering (e.g. callback skipped for unchanged aspects) will need updating.