### PR TITLE
fix(ebean-dao): re-warm schema cache at end of ensureSchemaUpToDate (#618 regression)

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalAccess.java
@@ -138,7 +138,10 @@ public class EbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN>
 
   public void ensureSchemaUpToDate() {
     _schemaEvolutionManager.ensureSchemaUpToDate();
-    // Cache pre-warm moved to constructor — see comment there for rationale.
+    // Re-warm after applying the evolution DDL: the constructor pre-warm ran before these tables
+    // existed, so refresh the cache here so reads reflect the migrated schema.
+    validator.registerAndPreWarm(getTableName(_entityType));
+    validator.registerAndPreWarm(getTestTableName(_entityType));
     validateForceIndex();
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalAccessTest.java
@@ -25,10 +25,12 @@ import com.linkedin.testing.AspectBaz;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.FooAsset;
 import com.linkedin.testing.urn.BurgerUrn;
+import com.linkedin.metadata.dao.utils.SharedSchemaCache;
 import com.linkedin.testing.urn.FooUrn;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import io.ebean.SqlRow;
+import io.ebean.config.ServerConfig;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URISyntaxException;
@@ -1270,5 +1272,58 @@ public class EbeanLocalAccessTest {
 
     ListResult<FooUrn> listUrns = _ebeanLocalAccessFoo.listUrns(null, null, 0, 10);
     assertEquals(10, listUrns.getValues().size());
+  }
+
+  /**
+   * Regression test for #618 (datahub-gma 0.6.185). #615 pre-warmed the shared schema cache at the
+   * end of {@link EbeanLocalAccess#ensureSchemaUpToDate()}; #618 moved that pre-warm to the
+   * constructor. For consumers that build their schema in-JVM at boot (i.e. that call
+   * ensureSchemaUpToDate(), e.g. integration tests / dev deploys with skipSchemaUpdate=false), the
+   * constructor pre-warm runs BEFORE the schema-evolution DDL, so it caches an empty/incomplete
+   * view that is then pinned for the cache TTL — making columnExists()/indexExists() report missing
+   * columns and reads silently drop aspects. ensureSchemaUpToDate() must re-warm the cache after
+   * applying the DDL so it reflects the complete, post-migration schema.
+   *
+   * <p>Uses a freshly-constructed access (the production shared-cache validator, not the per-method
+   * local one injected by {@link #resetValidatorInstance()}) and stubs out the Flyway evolution so
+   * the test isolates the re-warm behavior. Reflection mirrors the existing validator-injection
+   * pattern in {@code resetValidatorInstance()}.</p>
+   */
+  @Test
+  public void testEnsureSchemaUpToDateReWarmsSharedSchemaCache() throws Exception {
+    final ServerConfig serverConfig = EmbeddedMariaInstance.SERVER_CONFIG_MAP.get(_server.getName());
+    final String dbUrl = serverConfig.getDataSourceConfig().getUrl();
+
+    // Start from a clean registry so the freshly-constructed access owns the shared cache.
+    SharedSchemaCache.clearRegistry();
+
+    // Construct an access on the shared-cache path; its constructor pre-warms metadata_entity_foo
+    // with the columns that exist now (no a_rewarmprobe column yet).
+    EbeanLocalAccess<FooUrn> access = new EbeanLocalAccess<>(_server, serverConfig, FooUrn.class,
+        new FooUrnPathExtractor(), _ebeanConfig.isNonDollarVirtualColumnsEnabled());
+
+    final SharedSchemaCache sharedCache = SharedSchemaCache.getInstance(_server, dbUrl);
+    assertFalse(sharedCache.columnExists("metadata_entity_foo", "a_rewarmprobe"));
+
+    // Simulate schema evolution adding a column AFTER construction (what the boot-time DDL does).
+    _server.execute(Ebean.createSqlUpdate("ALTER TABLE metadata_entity_foo ADD a_rewarmprobe JSON"));
+
+    // The cache is now stale: the constructor pre-warm predates the ALTER, so without a re-warm the
+    // new column stays invisible for the whole TTL.
+    assertFalse(sharedCache.columnExists("metadata_entity_foo", "a_rewarmprobe"));
+
+    // Stub the Flyway evolution to a no-op so the test isolates only the re-warm.
+    Field semField = EbeanLocalAccess.class.getDeclaredField("_schemaEvolutionManager");
+    semField.setAccessible(true);
+    semField.set(access, mock(SchemaEvolutionManager.class));
+
+    access.ensureSchemaUpToDate();
+
+    // With the post-evolution re-warm, the shared cache now reflects the complete schema.
+    assertTrue("ensureSchemaUpToDate must re-warm the shared schema cache after evolution (regression #618)",
+        sharedCache.columnExists("metadata_entity_foo", "a_rewarmprobe"));
+
+    // Clean up the probe column (the @BeforeMethod recreate would also drop it, but be explicit).
+    _server.execute(Ebean.createSqlUpdate("ALTER TABLE metadata_entity_foo DROP COLUMN a_rewarmprobe"));
   }
 }


### PR DESCRIPTION
## Summary

#615 pre-warmed `SharedSchemaCache` at the end of `EbeanLocalAccess.ensureSchemaUpToDate()`. #618 moved that pre-warm into the **constructor** (so it also runs for deploys that gate `ensureSchemaUpToDate()` off and migrate schema as a separate job) — but it **removed** the post-evolution re-warm.

For consumers that build their schema **in-JVM at boot** (i.e. that call `ensureSchemaUpToDate()` — e.g. integration tests / dev deploys with `skipSchemaUpdate=false`), the constructor pre-warm now runs **before** the schema-evolution DDL. It caches an empty/incomplete view that is pinned for the cache TTL, so `columnExists()`/`indexExists()` report missing columns/indexes, `EbeanLocalAccess.batchGetUnion` drops the aspect from its query, and reads silently return nothing.


**Fix:** restore the pre-warm at the end of `ensureSchemaUpToDate()` (after the evolution DDL is applied), while keeping #618's constructor pre-warm. The re-warm overwrites the stale entry with the complete, post-migration schema. It runs **only** where `ensureSchemaUpToDate()` is called (in-JVM schema build, `skipSchemaUpdate=false`); deploys that gate it off (prod) are unaffected — there the constructor pre-warm already sees the complete schema. Effectively recovers #615/0.6.183 behavior for that path without giving up #618's prod cold-start win.

## Testing Done

- Added `EbeanLocalAccessTest.testEnsureSchemaUpToDateReWarmsSharedSchemaCache`: constructs an access (constructor pre-warm), adds a column **after** construction, then asserts `ensureSchemaUpToDate()` re-warms the shared cache. **Fails on the pre-fix behavior** (verified — 2 failures across both `nonDollarVirtualColumnsEnabled` factory variants); **passes with the fix**.
- All `ensureSchemaUpToDate`-exercising test classes pass: `EbeanLocalAccessTest`, `InstrumentedEbeanLocalAccessTest`, `FlywaySchemaEvolutionManagerTest`, `FlywaySchemaEvolutionManagerTestWithoutServiceIdentifier`.
- AIM to verify end-to-end on ai-metadata-gms against a build with this change.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (Commit Message Format)
- [x] Links to related issues — regression from #618; restores #615 behavior; alternative to #625
- [ ] Docs related to the changes have been added/updated (if applicable) — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
