### PR TITLE
fix(dao): use canonical DB-stored URN when emitting MAE events

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -126,11 +126,15 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     }
   }
 
-  @Value
+  @Getter
+  @AllArgsConstructor
   static class AddResult<ASPECT extends RecordTemplate> {
     ASPECT oldValue;
     ASPECT newValue;
     Class<ASPECT> klass;
+    // The canonical URN as stored in the DB (may differ in case from the incoming MCE URN).
+    // For new entities with no existing DB row, this is set to the incoming MCE URN.
+    @Nonnull Urn canonicalUrn;
   }
 
   @Value
@@ -184,7 +188,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   @Value
   @EqualsAndHashCode(callSuper = true)
   public static class AspectCreateLambda<ASPECT extends RecordTemplate> extends AspectUpdateLambda<ASPECT> {
-    
+
     public AspectCreateLambda(@Nonnull ASPECT value) {
       super(value); // Uses AspectUpdateLambda constructor that creates lambda: (ignored) -> value
     }
@@ -200,7 +204,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * Immutable class to package aspect update context for batch operations.
    * Eliminates the need for multiple parallel lists by bundling related data together.
-   * 
+   *
    * <p>The 'newValue' field contains the final computed value after all transformations (lambda application,
    * callback processing, lambda function registry). This is the value that will be persisted to the database.
    *
@@ -213,7 +217,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     @Nonnull
     ASPECT newValue;
-    
+
     @Nonnull
     AspectUpdateLambda<ASPECT> lambda;
   }
@@ -547,10 +551,16 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     final AuditStamp optimisticLockAuditStamp = extractOptimisticLockForAspectFromIngestionParamsIfPossible(ingestionParams, aspectClass, urn);
 
+    // Use the canonical URN from the DB row to ensure MAE doc IDs are consistent even when MCEs
+    // arrive with different-case URNs (e.g. lixTrackingArchive vs LixTrackingArchive).
+    // Extracted before shouldUpdateAspect so both the early-return (no-op) and update paths
+    // carry the canonical URN — needed when alwaysEmitAuditEvent=true emits MAE even for no-ops.
+    final Urn canonicalUrn = latest.getExtraInfo() != null ? latest.getExtraInfo().getUrn() : urn;
+
     // Unified logic determines whether an update to aspect should be persisted (includes backfill, equality, version, mode checks)
     if (!shouldUpdateAspect(ingestionParams.getIngestionMode(), urn, oldValue, newValue, aspectClass, auditStamp, equalityTester,
         oldAuditStamp, optimisticLockAuditStamp, trackingContext, oldEmitTime, latest.isSoftDeleted())) {
-      return new AddResult<>(oldValue, oldValue, aspectClass);
+      return new AddResult<>(oldValue, oldValue, aspectClass, canonicalUrn);
     }
 
     // Save the newValue as the latest version
@@ -562,7 +572,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     // Apply retention policy
     applyRetention(urn, aspectClass, getRetention(aspectClass), largestVersion);
 
-    return new AddResult<>(oldValue, newValue, aspectClass);
+    return new AddResult<>(oldValue, newValue, aspectClass, canonicalUrn);
   }
 
   /**
@@ -684,7 +694,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     }
 
     // send the audit events etc
-    return results.stream().map(x -> unwrapAddResultToUnion(urn, x, auditStamp, trackingContext)).collect(Collectors.toList());
+    return results.stream().map(x -> unwrapAddResultToUnion(x, auditStamp, trackingContext)).collect(Collectors.toList());
   }
 
   public List<ASPECT_UNION> addMany(@Nonnull URN urn, @Nonnull List<? extends RecordTemplate> aspectValues, @Nonnull AuditStamp auditStamp) {
@@ -762,10 +772,10 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    *
    * <p><b>Aspect Skip Reasons:</b> An aspect may be skipped from processing/writing for the following reasons:
    * <ul>
-   *   <li><b>Callback skip:</b> {@code aspectCallbackHelper()} returns {@code isSkipProcessing() == true} - 
+   *   <li><b>Callback skip:</b> {@code aspectCallbackHelper()} returns {@code isSkipProcessing() == true} -
    *       the registered {@link AspectCallbackRoutingClient} explicitly requests skipping this aspect.</li>
    *   <li><b>Callback returns null:</b> {@code aspectCallbackHelper()} returns a null updated aspect.</li>
-   *   <li><b>shouldUpdateAspect returns false:</b> See {@link #shouldUpdateAspect} for details on equality, 
+   *   <li><b>shouldUpdateAspect returns false:</b> See {@link #shouldUpdateAspect} for details on equality,
    *       backfill, version, and timestamp skip conditions.</li>
    * </ul>
    */
@@ -788,7 +798,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     }
 
     // STEP 1: Batched read of old values with extra info (1 query)
-    Map<Class<? extends RecordTemplate>, AspectWithExtraInfo<RecordTemplate>> oldValuesWithInfo = 
+    Map<Class<? extends RecordTemplate>, AspectWithExtraInfo<RecordTemplate>> oldValuesWithInfo =
         batchGetOldValuesWithExtraInfo(urn, aspectUpdateLambdas);
 
     // STEP 2: Process all aspects through callbacks/validation pipeline
@@ -798,7 +808,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     for (AspectUpdateLambda<? extends RecordTemplate> updateLambda : aspectUpdateLambdas) {
       Class<RecordTemplate> aspectClass = (Class<RecordTemplate>) updateLambda.getAspectClass();
       IngestionParams ingestionParams = updateLambda.getIngestionParams();
-      
+
       // Extract old value and extra info from batched results
       AspectWithExtraInfo<RecordTemplate> oldInfo = oldValuesWithInfo.get(aspectClass);
       RecordTemplate oldAspect = oldInfo != null ? oldInfo.getAspect() : null;
@@ -835,11 +845,15 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       AuditStamp eTagAuditStamp = extractOptimisticLockForAspectFromIngestionParamsIfPossible(
           ingestionParams, aspectClass, urn);
 
+      // Extract canonical URN before shouldUpdateAspect — no-op path also needs it
+      // (alwaysEmitAuditEvent=true emits MAE even when old == new)
+      final Urn batchCanonicalUrn = oldExtraInfo != null ? oldExtraInfo.getUrn() : urn;
+
       if (!shouldUpdateAspect(ingestionParams.getIngestionMode(), urn, oldAspect, newValue,
                               aspectClass, auditStamp, equalityTester, oldAuditStamp, eTagAuditStamp,
                               trackingContext, oldEmitTime, false /* isSoftDeleted not tracked in batch path */)) {
         // Skip this aspect - add as unchanged for MAE skip logic
-        processedResults.add(new AddResult<RecordTemplate>(oldAspect, oldAspect, aspectClass));
+        processedResults.add(new AddResult<>(oldAspect, oldAspect, aspectClass, batchCanonicalUrn));
         continue;
       }
 
@@ -854,7 +868,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       }
 
       // Package context for batch write
-      processedResults.add(new AddResult<RecordTemplate>(oldAspect, newValue, aspectClass));
+      processedResults.add(new AddResult<>(oldAspect, newValue, aspectClass, batchCanonicalUrn));
       contextsToWrite.add(new AspectUpdateContext<>(oldAspect, newValue, (AspectUpdateLambda<RecordTemplate>) updateLambda));
     }
 
@@ -874,7 +888,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     List<ASPECT_UNION> results = new ArrayList<>();
     for (AddResult<RecordTemplate> addResult : processedResults) {
       // unwrapAddResultToUnion() checks equality internally - won't emit MAE if old == new
-      ASPECT_UNION result = unwrapAddResultToUnion(urn, addResult, auditStamp, trackingContext);
+      ASPECT_UNION result = unwrapAddResultToUnion(addResult, auditStamp, trackingContext);
       results.add(result);
     }
 
@@ -885,20 +899,20 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Batch read old values with extra info (audit stamps, emit time) for equality testing and backfill.
    * Uses existing getWithExtraInfo() which performs a single batched query.
    */
-  private Map<Class<? extends RecordTemplate>, AspectWithExtraInfo<RecordTemplate>> 
+  private Map<Class<? extends RecordTemplate>, AspectWithExtraInfo<RecordTemplate>>
       batchGetOldValuesWithExtraInfo(
           @Nonnull URN urn,
           @Nonnull List<AspectUpdateLambda<? extends RecordTemplate>> aspectUpdateLambdas) {
-    
+
     // Build aspect keys for batch get
     Set<AspectKey<URN, ? extends RecordTemplate>> keys = aspectUpdateLambdas.stream()
         .map(lambda -> new AspectKey<>(lambda.getAspectClass(), urn, LATEST_VERSION))
         .collect(Collectors.toSet());
-    
+
     // Single batched query - uses existing infrastructure
-    Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> results = 
+    Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> results =
         getWithExtraInfo(keys);
-    
+
     // Convert to class-based map for easier lookup
     Map<Class<? extends RecordTemplate>, AspectWithExtraInfo<RecordTemplate>> byClass = new HashMap<>();
     for (AspectUpdateLambda lambda : aspectUpdateLambdas) {
@@ -908,7 +922,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         byClass.put(lambda.getAspectClass(), info);
       }
     }
-    
+
     return byClass;
   }
 
@@ -1010,27 +1024,27 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     for (RecordTemplate aspectValue : aspectValues) {
       // For each aspect, we need to trigger emit MAE
       // In new asset creation, old value is null
-      unwrapAddResult(urn, new AddResult<>(null, aspectValue, (Class<RecordTemplate>) aspectValue.getClass()),
+      unwrapAddResult(new AddResult<>(null, aspectValue, (Class<RecordTemplate>) aspectValue.getClass(), urn),
           auditStamp, trackingContext);
     }
     return numRows > 0 ? urn : null;
   }
 
-  private <ASPECT extends RecordTemplate> ASPECT_UNION unwrapAddResultToUnion(URN urn, AddResult<ASPECT> result,
+  private <ASPECT extends RecordTemplate> ASPECT_UNION unwrapAddResultToUnion(AddResult<ASPECT> result,
       @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext) {
     // handle post-update hooks and emit MAE + return the newValue
-    ASPECT rawResult = unwrapAddResult(urn, result, auditStamp, trackingContext);
+    ASPECT rawResult = unwrapAddResult(result, auditStamp, trackingContext);
 
     // package it into a union
     return ModelUtils.newEntityUnion(_aspectUnionClass, rawResult);
   }
 
-  private <ASPECT extends RecordTemplate> ASPECT unwrapAddResult(URN urn, AddResult<ASPECT> result, @Nonnull AuditStamp auditStamp,
+  private <ASPECT extends RecordTemplate> ASPECT unwrapAddResult(AddResult<ASPECT> result, @Nonnull AuditStamp auditStamp,
       @Nullable IngestionTrackingContext trackingContext) {
-    return unwrapAddResult(urn, result, auditStamp, trackingContext, false);
+    return unwrapAddResult(result, auditStamp, trackingContext, false);
   }
 
-  private <ASPECT extends RecordTemplate> ASPECT unwrapAddResult(URN urn, @Nonnull AddResult<ASPECT> result, @Nonnull AuditStamp auditStamp,
+  private <ASPECT extends RecordTemplate> ASPECT unwrapAddResult(@Nonnull AddResult<ASPECT> result, @Nonnull AuditStamp auditStamp,
       @Nullable IngestionTrackingContext trackingContext, boolean isDeletion) {
     if (trackingContext != null) {
       trackingContext.setBackfill(false); // reset backfill since MAE won't be a backfill event
@@ -1043,11 +1057,16 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     final boolean oldAndNewEqual = (oldValue == null && newValue == null)
         || (oldValue != null && newValue != null && equalityTester.equals(oldValue, newValue));
 
+    // Use the canonical URN from the DB if available (it may differ in case from the incoming MCE URN).
+    // Falls back to the incoming urn for new entities — canonicalUrn is always non-null.
+    @SuppressWarnings("unchecked")
+    final URN maeUrn = (URN) result.getCanonicalUrn();
+
     // Invoke post-update hooks if there's any
     // Note that we do NOT support post-update (or pre-update) hooks for deletion operations (yet). However, since
     //   newValue can in theory be NULL outside of deletion operations, we need to check for that here.
     if (_aspectPostUpdateHooksMap.containsKey(aspectClass) && !isDeletion) {
-      _aspectPostUpdateHooksMap.get(aspectClass).forEach(hook -> hook.accept(urn, newValue));
+      _aspectPostUpdateHooksMap.get(aspectClass).forEach(hook -> hook.accept(maeUrn, newValue));
     }
 
     // Produce MAE after a successful update
@@ -1055,9 +1074,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       // https://jira01.corp.linkedin.com:8443/browse/APA-80115
       if (_alwaysEmitAuditEvent || !oldAndNewEqual) {
         if (_trackingProducer != null) {
-          _trackingProducer.produceMetadataAuditEvent(urn, oldValue, newValue);
+          _trackingProducer.produceMetadataAuditEvent(maeUrn, oldValue, newValue);
         } else {
-          _producer.produceMetadataAuditEvent(urn, oldValue, newValue);
+          _producer.produceMetadataAuditEvent(maeUrn, oldValue, newValue);
         }
       }
     }
@@ -1067,10 +1086,10 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     if (_emitAspectSpecificAuditEvent) {
       if (_alwaysEmitAspectSpecificAuditEvent || !oldAndNewEqual) {
         if (_trackingProducer != null) {
-          _trackingProducer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, aspectClass, auditStamp,
+          _trackingProducer.produceAspectSpecificMetadataAuditEvent(maeUrn, oldValue, newValue, aspectClass, auditStamp,
               trackingContext, IngestionMode.LIVE);
         } else {
-          _producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue, aspectClass, auditStamp, IngestionMode.LIVE);
+          _producer.produceAspectSpecificMetadataAuditEvent(maeUrn, oldValue, newValue, aspectClass, auditStamp, IngestionMode.LIVE);
         }
       }
     }
@@ -1199,7 +1218,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     // skip MAE producing and post update hook in test mode or if the result is null (no actual update with addCommon)
     return result == null ? null : (updateLambda.getIngestionParams().isTestMode() ? result.newValue
-        : unwrapAddResult(urn, result, auditStamp, trackingContext));
+        : unwrapAddResult(result, auditStamp, trackingContext));
   }
 
   /**
@@ -1443,7 +1462,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     // TODO: add support for sending MAE for soft deleted aspects
     // FY25H2 Note: When performing an Aspect UPDATE, unwrapAddResultToUnion() is called, which emits MAE and does post-update hooks.
     //    When doing similar for DELETE, we should end up doing something similar, but specific to deletion.
-    return unwrapAddResult(urn, result, auditStamp, trackingContext, true);
+    return unwrapAddResult(result, auditStamp, trackingContext, true);
   }
 
   /**
@@ -2295,18 +2314,18 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
   /**
    * Determines if an aspect update should be persisted to the database.
-   * 
+   *
    * <p><b>Returns false (skip write) when:</b>
    * <ul>
-   *   <li><b>Backfill with older data:</b> This is a backfill event ({@code trackingContext.isBackfill() == true}) 
+   *   <li><b>Backfill with older data:</b> This is a backfill event ({@code trackingContext.isBackfill() == true})
    *       and the new emit time is older than the existing data's emit time or audit stamp.</li>
    *   <li><b>Equality check:</b> Old and new values are equal according to the {@link EqualityTester}.</li>
-   *   <li><b>Version skip:</b> New aspect has a lower version than the existing aspect 
+   *   <li><b>Version skip:</b> New aspect has a lower version than the existing aspect
    *       (see {@link #aspectVersionSkipWrite}).</li>
-   *   <li><b>Timestamp/ETag skip:</b> Optimistic locking check fails - the eTag timestamp is older than 
+   *   <li><b>Timestamp/ETag skip:</b> Optimistic locking check fails - the eTag timestamp is older than
    *       the existing aspect's timestamp (see {@link #aspectTimestampSkipWrite}).</li>
    * </ul>
-   * 
+   *
    * <p><b>Returns true (force write) when:</b>
    * <ul>
    *   <li>{@code IngestionMode.LIVE_OVERRIDE} is set - forces the write regardless of other conditions.</li>

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -14,8 +14,6 @@ import com.linkedin.metadata.dao.ingestion.AspectCallbackRoutingClient;
 import com.linkedin.metadata.dao.ingestion.SampleAspectCallbackRoutingClient;
 import com.linkedin.metadata.dao.ingestion.SampleLambdaFunctionRegistryImpl;
 import com.linkedin.metadata.dao.producer.BaseMetadataEventProducer;
-import com.linkedin.metadata.dao.AspectWithExtraInfo;
-import com.linkedin.metadata.dao.ListResult;
 import com.linkedin.metadata.dao.producer.BaseTrackingMetadataEventProducer;
 import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
@@ -301,14 +299,20 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected int permanentDelete(@Nonnull BurgerUrn urn, boolean isTestMode) { return 1; }
+    protected int permanentDelete(@Nonnull BurgerUrn urn, boolean isTestMode) {
+      return 1;
+    }
 
     @Override
-    public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull BurgerUrn urn, @Nonnull Class<ASPECT> aspectClass) {}
+    public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull BurgerUrn urn,
+        @Nonnull Class<ASPECT> aspectClass) {
+    }
 
     @Override
     public <ASPECT extends RecordTemplate> List<LocalRelationshipUpdates> backfillLocalRelationships(
-        @Nonnull BurgerUrn urn, @Nonnull Class<ASPECT> aspectClass) { return null; }
+        @Nonnull BurgerUrn urn, @Nonnull Class<ASPECT> aspectClass) {
+      return null;
+    }
 
     @Nonnull
     @Override
@@ -322,68 +326,103 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> long getNextVersion(BurgerUrn urn, Class<ASPECT> aspectClass) { return 0; }
+    protected <ASPECT extends RecordTemplate> long getNextVersion(BurgerUrn urn, Class<ASPECT> aspectClass) {
+      return 0;
+    }
 
     @Override
     protected <ASPECT extends RecordTemplate> void applyVersionBasedRetention(Class<ASPECT> aspectClass, BurgerUrn urn,
-        VersionBasedRetention retention, long largestVersion) {}
+        VersionBasedRetention retention, long largestVersion) {
+    }
 
     @Override
     protected <ASPECT extends RecordTemplate> void applyTimeBasedRetention(Class<ASPECT> aspectClass, BurgerUrn urn,
-        TimeBasedRetention retention, long currentTime) {}
+        TimeBasedRetention retention, long currentTime) {
+    }
 
     @Override
-    public <ASPECT extends RecordTemplate> ListResult<Long> listVersions(Class<ASPECT> aspectClass, BurgerUrn urn, int start, int pageSize) { return null; }
+    public <ASPECT extends RecordTemplate> ListResult<Long> listVersions(Class<ASPECT> aspectClass, BurgerUrn urn,
+        int start, int pageSize) {
+      return null;
+    }
 
     @Override
-    public <ASPECT extends RecordTemplate> ListResult<BurgerUrn> listUrns(Class<ASPECT> aspectClass, int start, int pageSize) { return null; }
+    public <ASPECT extends RecordTemplate> ListResult<BurgerUrn> listUrns(Class<ASPECT> aspectClass, int start,
+        int pageSize) {
+      return null;
+    }
 
     @Override
     public List<BurgerUrn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
-        @Nullable BurgerUrn lastUrn, int pageSize) { return null; }
+        @Nullable BurgerUrn lastUrn, int pageSize) {
+      return null;
+    }
 
     @Override
     public ListResult<BurgerUrn> listUrns(@Nonnull IndexFilter indexFilter,
-        @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) { return ListResult.<BurgerUrn>builder().build(); }
+        @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
+      return ListResult.<BurgerUrn>builder().build();
+    }
 
     @Override
-    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, BurgerUrn urn, int start, int pageSize) { return null; }
+    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, BurgerUrn urn, int start,
+        int pageSize) {
+      return null;
+    }
 
     @Override
-    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, long version, int start, int pageSize) { return null; }
+    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, long version, int start,
+        int pageSize) {
+      return null;
+    }
 
     @Override
-    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, int start, int pageSize) { return null; }
+    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, int start, int pageSize) {
+      return null;
+    }
 
     @Override
-    public Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter, @Nonnull IndexGroupByCriterion groupCriterion) { return Collections.emptyMap(); }
+    public Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter,
+        @Nonnull IndexGroupByCriterion groupCriterion) {
+      return Collections.emptyMap();
+    }
 
     @Override
-    public long newNumericId(String namespace, int maxTransactionRetry) { return 0; }
+    public long newNumericId(String namespace, int maxTransactionRetry) {
+      return 0;
+    }
 
     @Override
     protected <ASPECT extends RecordTemplate> void insert(@Nonnull BurgerUrn urn, @Nullable RecordTemplate value,
         @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp, long version,
-        @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {}
+        @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
+    }
 
     @Override
-    public boolean exists(@Nonnull BurgerUrn urn) { return false; }
+    public boolean exists(@Nonnull BurgerUrn urn) {
+      return false;
+    }
 
     @Override
     protected <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull BurgerUrn urn,
         @Nullable RecordTemplate value, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp newAuditStamp,
         long version, @Nonnull Timestamp oldTimestamp, @Nullable IngestionTrackingContext trackingContext,
-        boolean isTestMode) {}
+        boolean isTestMode) {
+    }
 
     @Override
     @Nonnull
     public Map<AspectKey<BurgerUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
-        Set<AspectKey<BurgerUrn, ? extends RecordTemplate>> aspectKeys) { return Collections.emptyMap(); }
+        Set<AspectKey<BurgerUrn, ? extends RecordTemplate>> aspectKeys) {
+      return Collections.emptyMap();
+    }
 
     @Override
     @Nonnull
     public Map<AspectKey<BurgerUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
-        @Nonnull Set<AspectKey<BurgerUrn, ? extends RecordTemplate>> keys) { return Collections.emptyMap(); }
+        @Nonnull Set<AspectKey<BurgerUrn, ? extends RecordTemplate>> keys) {
+      return Collections.emptyMap();
+    }
   }
 
   private DummyLocalDAO<EntityAspectUnion> _dummyLocalDAO;
@@ -1322,7 +1361,7 @@ public class BaseLocalDAOTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
     _dummyLocalDAO.setAlwaysEmitAuditEvent(true);
-    
+
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
         .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(null, null));
     when(_mockGetLatestFunction.apply(any(), eq(AspectBar.class)))
@@ -1344,7 +1383,7 @@ public class BaseLocalDAOTest {
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
     _dummyLocalDAO.setAlwaysEmitAuditEvent(false);
-    
+
     // foo already exists with same value, bar is new
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
         .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(foo, null));
@@ -1367,7 +1406,7 @@ public class BaseLocalDAOTest {
     AspectBar bar = new AspectBar().setValue("bar");
     BiConsumer<FooUrn, AspectFoo> fooHook = mock(BiConsumer.class);
     BiConsumer<FooUrn, AspectBar> barHook = mock(BiConsumer.class);
-    
+
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
         .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(null, null));
     when(_mockGetLatestFunction.apply(any(), eq(AspectBar.class)))
@@ -1389,7 +1428,7 @@ public class BaseLocalDAOTest {
     AspectBar bar = new AspectBar().setValue("bar");
     BiConsumer<FooUrn, AspectFoo> fooHook = mock(BiConsumer.class);
     BiConsumer<FooUrn, AspectBar> barHook = mock(BiConsumer.class);
-    
+
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
         .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(null, null));
     when(_mockGetLatestFunction.apply(any(), eq(AspectBar.class)))
@@ -1409,7 +1448,7 @@ public class BaseLocalDAOTest {
     FooUrn urn = new FooUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
-    
+
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
         .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(null, null));
     when(_mockGetLatestFunction.apply(any(), eq(AspectBar.class)))
@@ -1433,7 +1472,7 @@ public class BaseLocalDAOTest {
     dummyLocalDAO.setAlwaysEmitAuditEvent(true);
     dummyLocalDAO.setEmitAspectSpecificAuditEvent(true);
     dummyLocalDAO.setAlwaysEmitAspectSpecificAuditEvent(true);
-    
+
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
         .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(null, null));
 
@@ -1449,7 +1488,7 @@ public class BaseLocalDAOTest {
     FooUrn urn = new FooUrn(1);
     AspectFoo foo1 = new AspectFoo().setValue("foo1");
     AspectFoo foo2 = new AspectFoo().setValue("foo2");
-    
+
     // Should throw IllegalArgumentException due to duplicate aspect class
     _dummyLocalDAO.addManyBatch(urn, Arrays.asList(foo1, foo2), _dummyAuditStamp, null);
   }
@@ -1459,7 +1498,7 @@ public class BaseLocalDAOTest {
     FooUrn urn = new FooUrn(1);
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectBar bar = new AspectBar().setValue("bar");
-    
+
     // Both aspects already exist with same values
     when(_mockGetLatestFunction.apply(any(), eq(AspectFoo.class)))
         .thenReturn(new BaseLocalDAO.AspectEntry<AspectFoo>(foo, null));
@@ -1509,7 +1548,7 @@ public class BaseLocalDAOTest {
     // Create a skip-processing callback client
     AspectCallbackRoutingClient<AspectFoo> skipClient = new AspectCallbackRoutingClient<AspectFoo>() {
       @Override
-      public AspectCallbackResponse<AspectFoo> routeAspectCallback(com.linkedin.common.urn.Urn urn, 
+      public AspectCallbackResponse<AspectFoo> routeAspectCallback(com.linkedin.common.urn.Urn urn,
           AspectFoo newAspectValue, Optional<AspectFoo> existingAspectValue) {
         return new AspectCallbackResponse<>(newAspectValue);
       }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -14,6 +14,8 @@ import com.linkedin.metadata.dao.ingestion.AspectCallbackRoutingClient;
 import com.linkedin.metadata.dao.ingestion.SampleAspectCallbackRoutingClient;
 import com.linkedin.metadata.dao.ingestion.SampleLambdaFunctionRegistryImpl;
 import com.linkedin.metadata.dao.producer.BaseMetadataEventProducer;
+import com.linkedin.metadata.dao.AspectWithExtraInfo;
+import com.linkedin.metadata.dao.ListResult;
 import com.linkedin.metadata.dao.producer.BaseTrackingMetadataEventProducer;
 import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
@@ -35,6 +37,7 @@ import com.linkedin.testing.MixedRecordArray;
 import com.linkedin.testing.MixedRecordNested;
 import com.linkedin.testing.localrelationship.AspectFooBar;
 import com.linkedin.testing.urn.BarUrn;
+import com.linkedin.testing.urn.BurgerUrn;
 import com.linkedin.testing.urn.FooUrn;
 import java.net.URISyntaxException;
 import java.sql.Timestamp;
@@ -251,6 +254,138 @@ public class BaseLocalDAOTest {
     }
   }
 
+  /**
+   * String-keyed DAO for testing case-insensitive URN canonicalization (e.g. lixTrackingArchive vs LixTrackingArchive).
+   * BurgerUrn uses a String ID, so two instances with different-case names are genuinely distinct objects.
+   */
+  static class DummyBurgerLocalDAO<ENTITY_ASPECT_UNION extends UnionTemplate> extends BaseLocalDAO<ENTITY_ASPECT_UNION, BurgerUrn> {
+
+    private final BiFunction<BurgerUrn, Class<? extends RecordTemplate>, AspectEntry> _getLatestFunction;
+    private final DummyTransactionRunner _transactionRunner;
+
+    public DummyBurgerLocalDAO(Class<ENTITY_ASPECT_UNION> aspectClass,
+        BiFunction<BurgerUrn, Class<? extends RecordTemplate>, AspectEntry> getLatestFunction,
+        BaseMetadataEventProducer eventProducer, DummyTransactionRunner transactionRunner) {
+      super(aspectClass, eventProducer, BurgerUrn.class, new EmptyPathExtractor<>());
+      _getLatestFunction = getLatestFunction;
+      _transactionRunner = transactionRunner;
+    }
+
+    @Nullable
+    @Override
+    public <ASPECT extends RecordTemplate> AuditStamp extractOptimisticLockForAspectFromIngestionParamsIfPossible(
+        @Nullable IngestionParams ingestionParams, @Nonnull Class<ASPECT> aspectClass, @Nonnull BurgerUrn urn) {
+      return null;
+    }
+
+    @Override
+    protected <ASPECT extends RecordTemplate> long saveLatest(BurgerUrn urn, Class<ASPECT> aspectClass, ASPECT oldEntry,
+        AuditStamp optimisticLockAuditStamp, ASPECT newEntry, AuditStamp newAuditStamp, boolean isSoftDeleted,
+        @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
+      return 0;
+    }
+
+    @Override
+    protected <ASPECT_UNION extends RecordTemplate> int createNewAssetWithAspects(@Nonnull BurgerUrn urn,
+        @Nonnull List<AspectCreateLambda<? extends RecordTemplate>> aspectCreateLambdas,
+        @Nonnull List<? extends RecordTemplate> aspectValues, @Nonnull AuditStamp newAuditStamp,
+        @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
+      return aspectValues.size();
+    }
+
+    @Override
+    protected <ASPECT_UNION extends RecordTemplate> int batchUpsertAspects(@Nonnull BurgerUrn urn,
+        @Nonnull List<AspectUpdateContext<RecordTemplate>> updateContexts,
+        @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {
+      return updateContexts.size();
+    }
+
+    @Override
+    protected int permanentDelete(@Nonnull BurgerUrn urn, boolean isTestMode) { return 1; }
+
+    @Override
+    public <ASPECT extends RecordTemplate> void updateEntityTables(@Nonnull BurgerUrn urn, @Nonnull Class<ASPECT> aspectClass) {}
+
+    @Override
+    public <ASPECT extends RecordTemplate> List<LocalRelationshipUpdates> backfillLocalRelationships(
+        @Nonnull BurgerUrn urn, @Nonnull Class<ASPECT> aspectClass) { return null; }
+
+    @Nonnull
+    @Override
+    protected <T> T runInTransactionWithRetry(Supplier<T> block, int maxTransactionRetry) {
+      return _transactionRunner.run(block);
+    }
+
+    @Override
+    protected <ASPECT extends RecordTemplate> AspectEntry<ASPECT> getLatest(BurgerUrn urn, Class<ASPECT> aspectClass, boolean isTestMode) {
+      return _getLatestFunction.apply(urn, aspectClass);
+    }
+
+    @Override
+    protected <ASPECT extends RecordTemplate> long getNextVersion(BurgerUrn urn, Class<ASPECT> aspectClass) { return 0; }
+
+    @Override
+    protected <ASPECT extends RecordTemplate> void applyVersionBasedRetention(Class<ASPECT> aspectClass, BurgerUrn urn,
+        VersionBasedRetention retention, long largestVersion) {}
+
+    @Override
+    protected <ASPECT extends RecordTemplate> void applyTimeBasedRetention(Class<ASPECT> aspectClass, BurgerUrn urn,
+        TimeBasedRetention retention, long currentTime) {}
+
+    @Override
+    public <ASPECT extends RecordTemplate> ListResult<Long> listVersions(Class<ASPECT> aspectClass, BurgerUrn urn, int start, int pageSize) { return null; }
+
+    @Override
+    public <ASPECT extends RecordTemplate> ListResult<BurgerUrn> listUrns(Class<ASPECT> aspectClass, int start, int pageSize) { return null; }
+
+    @Override
+    public List<BurgerUrn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable IndexSortCriterion indexSortCriterion,
+        @Nullable BurgerUrn lastUrn, int pageSize) { return null; }
+
+    @Override
+    public ListResult<BurgerUrn> listUrns(@Nonnull IndexFilter indexFilter,
+        @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) { return ListResult.<BurgerUrn>builder().build(); }
+
+    @Override
+    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, BurgerUrn urn, int start, int pageSize) { return null; }
+
+    @Override
+    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, long version, int start, int pageSize) { return null; }
+
+    @Override
+    public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(Class<ASPECT> aspectClass, int start, int pageSize) { return null; }
+
+    @Override
+    public Map<String, Long> countAggregate(@Nonnull IndexFilter indexFilter, @Nonnull IndexGroupByCriterion groupCriterion) { return Collections.emptyMap(); }
+
+    @Override
+    public long newNumericId(String namespace, int maxTransactionRetry) { return 0; }
+
+    @Override
+    protected <ASPECT extends RecordTemplate> void insert(@Nonnull BurgerUrn urn, @Nullable RecordTemplate value,
+        @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp, long version,
+        @Nullable IngestionTrackingContext trackingContext, boolean isTestMode) {}
+
+    @Override
+    public boolean exists(@Nonnull BurgerUrn urn) { return false; }
+
+    @Override
+    protected <ASPECT extends RecordTemplate> void updateWithOptimisticLocking(@Nonnull BurgerUrn urn,
+        @Nullable RecordTemplate value, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp newAuditStamp,
+        long version, @Nonnull Timestamp oldTimestamp, @Nullable IngestionTrackingContext trackingContext,
+        boolean isTestMode) {}
+
+    @Override
+    @Nonnull
+    public Map<AspectKey<BurgerUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
+        Set<AspectKey<BurgerUrn, ? extends RecordTemplate>> aspectKeys) { return Collections.emptyMap(); }
+
+    @Override
+    @Nonnull
+    public Map<AspectKey<BurgerUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
+        @Nonnull Set<AspectKey<BurgerUrn, ? extends RecordTemplate>> keys) { return Collections.emptyMap(); }
+  }
+
   private DummyLocalDAO<EntityAspectUnion> _dummyLocalDAO;
   private AuditStamp _dummyAuditStamp;
   private BaseMetadataEventProducer _mockEventProducer;
@@ -367,6 +502,59 @@ public class BaseLocalDAOTest {
     verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(urn, foo, null);
     verify(_mockEventProducer, times(1))
         .produceAspectSpecificMetadataAuditEvent(urn, foo, null, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
+    verifyNoMoreInteractions(_mockEventProducer);
+  }
+
+  /**
+   * Realistic test for the case where two HDFS clusters emit MCEs with different-case URNs for the
+   * same entity (e.g. "lixTrackingArchive" vs "LixTrackingArchive"). MySQL CI collation stores one
+   * row keyed on the first URN seen. Without the fix, each MCE would emit a MAE with its own
+   * incoming URN, creating two Elasticsearch documents with different IDs → duplicate browse results.
+   *
+   * <p>The fix: use ExtraInfo.getUrn() (the canonical DB-stored URN) for all MAE emissions.
+   * Both calls must produce MAE with the same canonical URN regardless of incoming case.
+   */
+  @Test
+  public void testBothCaseVariantsProduceSameCanonicalUrnInMAE() {
+    // Two BurgerUrns that differ only in case — exactly like lixTrackingArchive vs LixTrackingArchive
+    BurgerUrn lowerCaseUrn = new BurgerUrn("lixTrackingArchive");   // first MCE — creates the DB row
+    BurgerUrn upperCaseUrn = new BurgerUrn("LixTrackingArchive");   // second MCE — different-case variant
+
+    AspectFoo firstFoo = new AspectFoo().setValue("first");
+    AspectFoo secondFoo = new AspectFoo().setValue("second");
+
+    BiFunction<BurgerUrn, Class<? extends RecordTemplate>, BaseLocalDAO.AspectEntry> burgerGetLatest = mock(BiFunction.class);
+    DummyBurgerLocalDAO<EntityAspectUnion> burgerDAO = new DummyBurgerLocalDAO<>(
+        EntityAspectUnion.class, burgerGetLatest, _mockEventProducer, _mockTransactionRunner);
+    burgerDAO.setEmitAuditEvent(true);
+    burgerDAO.setEmitAspectSpecificAuditEvent(true);
+
+    // DB always stores lowerCaseUrn as the canonical URN in ExtraInfo
+    ExtraInfo extraInfoWithCanonical = new ExtraInfo().setAudit(_dummyAuditStamp).setUrn(lowerCaseUrn);
+    BaseLocalDAO.AspectEntry<AspectFoo> existingEntry = new BaseLocalDAO.AspectEntry<>(firstFoo, extraInfoWithCanonical);
+
+    // First call (lowerCaseUrn): no DB row yet → ExtraInfo is null → fallback to incoming urn
+    when(burgerGetLatest.apply(lowerCaseUrn, AspectFoo.class))
+        .thenReturn(new BaseLocalDAO.AspectEntry<>(null, null));
+    // Second call (upperCaseUrn): DB row exists → ExtraInfo.urn = lowerCaseUrn (canonical)
+    when(burgerGetLatest.apply(upperCaseUrn, AspectFoo.class))
+        .thenReturn(existingEntry);
+
+    burgerDAO.add(lowerCaseUrn, firstFoo, _dummyAuditStamp);   // creates the row
+    burgerDAO.add(upperCaseUrn, secondFoo, _dummyAuditStamp);  // upper-case variant updates same row
+
+    // First MAE: no ExtraInfo → falls back to incoming lowerCaseUrn ✓
+    verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(lowerCaseUrn, null, firstFoo);
+    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        lowerCaseUrn, null, firstFoo, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
+    // Second MAE: ExtraInfo.urn = lowerCaseUrn → canonical URN used, NOT upperCaseUrn ✓
+    verify(_mockEventProducer, times(1)).produceMetadataAuditEvent(lowerCaseUrn, firstFoo, secondFoo);
+    verify(_mockEventProducer, times(1)).produceAspectSpecificMetadataAuditEvent(
+        lowerCaseUrn, firstFoo, secondFoo, AspectFoo.class, _dummyAuditStamp, IngestionMode.LIVE);
+    // The upper-case URN must never appear in any MAE
+    verify(_mockEventProducer, never()).produceMetadataAuditEvent(eq(upperCaseUrn), any(), any());
+    verify(_mockEventProducer, never()).produceAspectSpecificMetadataAuditEvent(
+        eq(upperCaseUrn), any(), any(), any(), any(), any(IngestionMode.class));
     verifyNoMoreInteractions(_mockEventProducer);
   }
 


### PR DESCRIPTION
## :octocat: What is this change?
Use the canonical DB-stored URN (from `ExtraInfo.getUrn()`) when emitting MAE events in `BaseLocalDAO`, instead of the incoming MCE URN. This fix applies to **all entity types and all indexes** since it is in the core DAO layer.

## :point_right: Why is this required?
Two HDFS clusters (WAR and Holdem) emit MCEs with different casing for the same dataset path (e.g. `LixTrackingArchive` vs `lixTrackingArchive`). Because the Hosted Search document ID is derived from the URN, two different document IDs were created → duplicate browse results in Datahub.

The root cause: `addCommon()` was emitting MAE with the **incoming** MCE URN instead of the **canonical** URN stored in the DB. The DB (MySQL) normalises casing via CI collation, so there is only ever one row — but two different HS documents were being created.

## :white_check_mark: How was this tested?
- Added `testBothCaseVariantsProduceSameCanonicalUrnInMAE` in `BaseLocalDAOTest` using a string-keyed `BurgerUrn` to simulate two MCEs with different-case URNs arriving for the same entity. Verifies that both MAEs are emitted with the canonical (DB-stored) URN and the upper-case URN never appears.
- Updated `makeAspectEntry()` test helper in `BaseLocalDAOTest` and `BaseLocalDAOAspectVersionTest` to require an explicit `@Nullable Urn` parameter, mirroring production behaviour where `ExtraInfo` always carries the stored URN for existing entities. This eliminated `RequiredFieldNotPresentException` failures in existing tests.
- Consolidated duplicate `makeAspectEntry` helper into a single static method in `BaseLocalDAOTest`, shared via static import.
- Full `dao-api` test suite passes (244 tests).