### PR TITLE
feat(dao-api): add pluggable usage events on DAO read, write, and delete paths

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -2157,12 +2157,15 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * Similar to {@link #getWithExtraInfo(Set)} but only using only one {@link AspectKey}.
    */
   @Nonnull
+  @SuppressWarnings("unchecked")
   public <ASPECT extends RecordTemplate> Optional<AspectWithExtraInfo<ASPECT>> getWithExtraInfo(
       @Nonnull AspectKey<URN, ASPECT> key) {
-    if (getWithExtraInfo(Collections.singleton(key)).containsKey(key)) {
-      return Optional.of((AspectWithExtraInfo<ASPECT>) getWithExtraInfo(Collections.singleton(key)).get(key));
-    }
-    return Optional.empty();
+    // Query once and null-check the result. Calling getWithExtraInfo twice (once to test
+    // containsKey, once to read) issued a redundant round trip for every single-key read, and with
+    // usage tracking enabled it emitted two READ events for one logical read.
+    final AspectWithExtraInfo<? extends RecordTemplate> result =
+        getWithExtraInfo(Collections.singleton(key)).get(key);
+    return result == null ? Optional.empty() : Optional.of((AspectWithExtraInfo<ASPECT>) result);
   }
 
   /**

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -912,12 +912,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
     // Single batched query - uses existing infrastructure.
     // Mark as an internal read-before-write so usage instrumentation does not count it as a consumer read.
-    DaoReadContext.markInternalRead();
     final Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> results;
-    try {
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
       results = getWithExtraInfo(keys);
-    } finally {
-      DaoReadContext.clear();
     }
 
     // Convert to class-based map for easier lookup

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -35,6 +35,7 @@ import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.dao.storage.LocalDAOStorageConfig;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
+import com.linkedin.metadata.dao.tracking.DaoReadContext;
 import com.linkedin.metadata.dao.tracking.TrackingUtils;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.utils.ModelUtils;
@@ -909,9 +910,15 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         .map(lambda -> new AspectKey<>(lambda.getAspectClass(), urn, LATEST_VERSION))
         .collect(Collectors.toSet());
 
-    // Single batched query - uses existing infrastructure
-    Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> results =
-        getWithExtraInfo(keys);
+    // Single batched query - uses existing infrastructure.
+    // Mark as an internal read-before-write so usage instrumentation does not count it as a consumer read.
+    DaoReadContext.markInternalRead();
+    final Map<AspectKey<URN, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> results;
+    try {
+      results = getWithExtraInfo(keys);
+    } finally {
+      DaoReadContext.clear();
+    }
 
     // Convert to class-based map for easier lookup
     Map<Class<? extends RecordTemplate>, AspectWithExtraInfo<RecordTemplate>> byClass = new HashMap<>();

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -1925,7 +1925,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   private <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull BackfillMode mode,
       @Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn) {
     checkValidAspect(aspectClass);
-    Optional<ASPECT> aspect = get(aspectClass, urn, LATEST_VERSION);
+    // Backfill is a system operation, not consumer traffic, so its read is not counted as usage.
+    final Optional<ASPECT> aspect;
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+      aspect = get(aspectClass, urn, LATEST_VERSION);
+    }
     aspect.ifPresent(value -> backfill(mode, value, urn));
     return aspect;
   }
@@ -1972,8 +1976,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     Set<Class<? extends RecordTemplate>> aspectToBackfill =
         aspectClasses == null ? getValidAspectTypes(_aspectUnionClass) : aspectClasses;
     checkValidAspects(aspectToBackfill);
-    final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnToAspects =
-        get(aspectToBackfill, urns);
+    // Backfill is a system operation, not consumer traffic, so its read is not counted as usage.
+    final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnToAspects;
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+      urnToAspects = get(aspectToBackfill, urns);
+    }
     urnToAspects.forEach((urn, aspects) -> {
       aspects.forEach((aspectClass, aspect) -> aspect.ifPresent(value -> backfill(mode, value, urn)));
     });
@@ -2012,7 +2019,10 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfillEntityTables(
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
     urns.forEach(urn -> aspectClasses.forEach(aspect -> updateEntityTables(urn, aspect)));
-    return get(aspectClasses, urns);
+    // Backfill is a system operation, not consumer traffic, so its read is not counted as usage.
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+      return get(aspectClasses, urns);
+    }
   }
 
   /**

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoUsageEmitter.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoUsageEmitter.java
@@ -1,0 +1,46 @@
+package com.linkedin.metadata.dao.tracking;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+/**
+ * Interface for emitting a Metadata Graph usage event once per successful DAO operation
+ * (read / write / delete). Emission is an observability side-channel and MUST be
+ * fire-and-forget: implementations are required to be asynchronous, non-blocking, and to
+ * never throw back into the DAO call path.
+ *
+ * <p>The kernel passes only neutral primitives ({@link String} and {@link DaoUsageTarget})
+ * so it does not depend on any Avro / event-schema module (keeps
+ * {@code checkGmaDoesNotDependOnModels} green). A no-op implementation
+ * ({@link NoOpDaoUsageEmitter}) lives in the kernel; the concrete producer-backed
+ * implementation lives in the service layer.
+ */
+public interface BaseDaoUsageEmitter {
+
+  /**
+   * Record a completed DAO usage operation. Implementations MUST NOT block and MUST NOT
+   * propagate exceptions to the caller.
+   *
+   * @param operationType    one of {@code "READ"}, {@code "WRITE"}, {@code "DELETE"},
+   *                         {@code "DELETE_ALL"}
+   * @param entityType       entity type derived from the URN class (e.g. {@code "dataset"})
+   * @param sourceOperation  pure DAO method name (e.g. {@code "batchGetUnion"})
+   * @param actorUrn         string form of the caller URN for writes; {@code null} for reads
+   *                         (no audit stamp is available on the read path in v1)
+   * @param impersonatorUrn  string form of the service-on-behalf-of URN, or {@code null}
+   * @param targets          per-URN targets ({@code {urn, aspects[]}}); {@code aspects} is
+   *                         empty for a whole-entity {@code DELETE_ALL}
+   */
+  void emit(@Nonnull String operationType, @Nonnull String entityType,
+      @Nonnull String sourceOperation, @Nullable String actorUrn,
+      @Nullable String impersonatorUrn, @Nonnull List<DaoUsageTarget> targets);
+
+  /**
+   * Whether usage emission is enabled. Callers short-circuit all instrumentation (building
+   * targets, deriving the caller, etc.) when this returns {@code false}, giving zero
+   * overhead in the default / disabled configuration.
+   */
+  boolean isEnabled();
+}

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoUsageEmitter.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoUsageEmitter.java
@@ -29,17 +29,26 @@ public interface BaseDaoUsageEmitter {
    * @param actorUrn         string form of the caller URN for writes; {@code null} for reads
    *                         (no audit stamp is available on the read path in v1)
    * @param impersonatorUrn  string form of the service-on-behalf-of URN, or {@code null}
-   * @param targets          per-URN targets ({@code {urn, aspects[]}}); {@code aspects} is
-   *                         empty for a whole-entity {@code DELETE_ALL}
+   * @param targets          per-URN targets ({@code {urn, aspects[]}}); {@code aspects} may be
+   *                         empty (whole-entity {@code DELETE_ALL}, or a {@code create} with no
+   *                         aspects) -- use {@code operationType}, not an empty list, to identify
+   *                         the operation kind
    */
   void emit(@Nonnull String operationType, @Nonnull String entityType,
       @Nonnull String sourceOperation, @Nullable String actorUrn,
       @Nullable String impersonatorUrn, @Nonnull List<DaoUsageTarget> targets);
 
   /**
-   * Whether usage emission is enabled. Callers short-circuit all instrumentation (building
-   * targets, deriving the caller, etc.) when this returns {@code false}, giving zero
-   * overhead in the default / disabled configuration.
+   * Whether usage emission is enabled.
+   *
+   * <p>Invoked on every captured DAO operation, synchronously on the caller's thread and -- on
+   * write paths -- inside an open transaction. Implementations MUST therefore be a cheap local
+   * read, e.g. a {@code volatile boolean} field refreshed out of band. They MUST NOT perform
+   * I/O, acquire locks, or consult a remote config or feature-flag service on this call path.
+   *
+   * <p>Callers short-circuit all instrumentation (building targets, deriving the caller) when
+   * this returns {@code false}. The "zero overhead when disabled" property of the DAO depends
+   * on this method honoring the above.
    */
   boolean isEnabled();
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoUsageEmitter.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/BaseDaoUsageEmitter.java
@@ -12,8 +12,7 @@ import javax.annotation.Nullable;
  * never throw back into the DAO call path.
  *
  * <p>The kernel passes only neutral primitives ({@link String} and {@link DaoUsageTarget})
- * so it does not depend on any Avro / event-schema module (keeps
- * {@code checkGmaDoesNotDependOnModels} green). A no-op implementation
+ * so it does not depend on any Avro / event-schema module. A no-op implementation
  * ({@link NoOpDaoUsageEmitter}) lives in the kernel; the concrete producer-backed
  * implementation lives in the service layer.
  */

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoReadContext.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoReadContext.java
@@ -1,0 +1,46 @@
+package com.linkedin.metadata.dao.tracking;
+
+/**
+ * A thread-local marker that flags the current thread as executing an internal read-before-write,
+ * so usage instrumentation can distinguish it from a genuine consumer read.
+ *
+ * <p>Every aspect write/delete performs a read-modify-write: the write path reads the current value
+ * before writing. In new-schema mode that internal read flows through the same access layer as
+ * consumer reads and would otherwise be counted as one. The write path sets this flag around the
+ * internal read (clearing it in a {@code finally}); the usage decorator skips emission for reads
+ * while the flag is set. The set / read / clear all happen synchronously on one thread with no
+ * asynchronous boundary, so the flag is reliable and cannot leak across operations.
+ *
+ * <p>Consumer reads take a different path and never set this flag, so they are still recorded.
+ */
+public final class DaoReadContext {
+
+  private static final ThreadLocal<Boolean> INTERNAL_READ = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+  private DaoReadContext() {
+  }
+
+  /**
+   * Marks the current thread as executing an internal read-before-write.
+   */
+  public static void markInternalRead() {
+    INTERNAL_READ.set(Boolean.TRUE);
+  }
+
+  /**
+   * Clears the internal-read marker for the current thread. Callers MUST invoke this in a
+   * {@code finally} block so the marker cannot leak to a subsequent operation on a pooled thread.
+   */
+  public static void clear() {
+    INTERNAL_READ.remove();
+  }
+
+  /**
+   * Returns whether the current thread is executing an internal read-before-write.
+   *
+   * @return {@code true} if the current thread is executing an internal read-before-write
+   */
+  public static boolean isInternalRead() {
+    return INTERNAL_READ.get();
+  }
+}

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoReadContext.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoReadContext.java
@@ -6,33 +6,59 @@ package com.linkedin.metadata.dao.tracking;
  *
  * <p>Every aspect write/delete performs a read-modify-write: the write path reads the current value
  * before writing. In new-schema mode that internal read flows through the same access layer as
- * consumer reads and would otherwise be counted as one. The write path sets this flag around the
- * internal read (clearing it in a {@code finally}); the usage decorator skips emission for reads
- * while the flag is set. The set / read / clear all happen synchronously on one thread with no
- * asynchronous boundary, so the flag is reliable and cannot leak across operations.
+ * consumer reads and would otherwise be counted as one. The write path marks the region around the
+ * internal read; the usage decorator skips emission for reads while the marker is set. The mark /
+ * read / restore all happen synchronously on one thread with no asynchronous boundary, so the
+ * marker is reliable and cannot leak across operations.
  *
- * <p>Consumer reads take a different path and never set this flag, so they are still recorded.
+ * <p>Consumer reads take a different path and never set this marker, so they are still recorded.
+ *
+ * <p>Marked regions may safely nest: {@link #markInternalRead()} returns a {@link Scope} that
+ * restores the <em>previous</em> state on close rather than unconditionally clearing, so an inner
+ * region can never unmark an enclosing one. Always use it with try-with-resources:
+ *
+ * <pre>{@code
+ * try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+ *   return readSomething();
+ * }
+ * }</pre>
  */
 public final class DaoReadContext {
 
-  private static final ThreadLocal<Boolean> INTERNAL_READ = ThreadLocal.withInitial(() -> Boolean.FALSE);
+  private static final ThreadLocal<Boolean> INTERNAL_READ = new ThreadLocal<>();
 
   private DaoReadContext() {
   }
 
   /**
-   * Marks the current thread as executing an internal read-before-write.
+   * An active internal-read marker. Closing restores the marker to the state it had before the
+   * corresponding {@link #markInternalRead()} call, which is what makes marked regions nestable.
+   *
+   * <p>{@link AutoCloseable#close()} is narrowed to declare no checked exception so
+   * try-with-resources call sites do not need to catch anything.
    */
-  public static void markInternalRead() {
-    INTERNAL_READ.set(Boolean.TRUE);
+  public interface Scope extends AutoCloseable {
+    @Override
+    void close();
   }
 
   /**
-   * Clears the internal-read marker for the current thread. Callers MUST invoke this in a
-   * {@code finally} block so the marker cannot leak to a subsequent operation on a pooled thread.
+   * Marks the current thread as executing an internal read-before-write until the returned scope
+   * is closed. Callers MUST use try-with-resources (or close the scope in a {@code finally}) so
+   * the marker cannot leak to a subsequent operation on a pooled thread.
+   *
+   * @return a scope that restores the previous marker state when closed
    */
-  public static void clear() {
-    INTERNAL_READ.remove();
+  public static Scope markInternalRead() {
+    final boolean previous = isInternalRead();
+    INTERNAL_READ.set(Boolean.TRUE);
+    return () -> {
+      if (previous) {
+        INTERNAL_READ.set(Boolean.TRUE);
+      } else {
+        INTERNAL_READ.remove();
+      }
+    };
   }
 
   /**
@@ -41,6 +67,6 @@ public final class DaoReadContext {
    * @return {@code true} if the current thread is executing an internal read-before-write
    */
   public static boolean isInternalRead() {
-    return INTERNAL_READ.get();
+    return Boolean.TRUE.equals(INTERNAL_READ.get());
   }
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageBuffer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageBuffer.java
@@ -22,8 +22,9 @@ import javax.annotation.Nonnull;
  * later write rolls back.
  *
  * <p>Callers MUST pair {@link #enter()} with {@link #exit} in a {@code finally}, with nothing that
- * can throw in between: a frame that is never exited leaves the thread buffering forever, silently
- * dropping every later emission on it.
+ * can throw in between: a frame that is never exited stays open on the thread forever, so every
+ * later {@link #record} on that pooled thread keeps appending to {@code pending} and nothing ever
+ * flushes -- an unbounded memory leak, not merely lost emissions.
  */
 public final class DaoUsageBuffer {
 
@@ -35,16 +36,37 @@ public final class DaoUsageBuffer {
 
   private static final ThreadLocal<Frame> STATE = new ThreadLocal<>();
 
+  /**
+   * Process-wide gate. Stays {@code false} until an emitter is installed on any DAO
+   * ({@code EbeanLocalDAO#setUsageEmitter} calls {@link #arm()}), so a process that never enables
+   * usage tracking pays nothing: {@link #enter()} returns before touching the thread-local or
+   * allocating a {@link Frame}. Never disarmed -- installation is a one-time startup event.
+   */
+  private static volatile boolean armed = false;
+
   private DaoUsageBuffer() {
+  }
+
+  /**
+   * Arms the buffer so subsequent {@link #enter()} calls actually buffer. Idempotent; called once
+   * when the first usage emitter is installed on a DAO.
+   */
+  public static void arm() {
+    armed = true;
   }
 
   /**
    * Opens a transaction frame on the current thread.
    *
    * @return the mark for {@link #truncateTo} and {@link #exit}: the number of emissions already
-   *         buffered by enclosing frames, which this frame must not discard
+   *         buffered by enclosing frames, which this frame must not discard; {@code -1} when the
+   *         buffer is disarmed, which both {@link #truncateTo} and {@link #exit} treat as a no-op
    */
   public static int enter() {
+    if (!armed) {
+      // No emitter installed in this process: skip the thread-local and the Frame allocation.
+      return -1;
+    }
     Frame frame = STATE.get();
     if (frame == null) {
       frame = new Frame();

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageBuffer.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageBuffer.java
@@ -1,0 +1,121 @@
+package com.linkedin.metadata.dao.tracking;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+
+/**
+ * A thread-local buffer that holds usage emissions until the enclosing transaction commits.
+ *
+ * <p>The usage decorator wraps the access layer, which sits below the transaction boundary: it sees
+ * a write before the transaction commits. Emitting there reports writes that later roll back, and
+ * reports them again on every retry. Transactional writes therefore record here instead.
+ *
+ * <p>Only the outermost frame releases anything: Ebean implements nested transactions with
+ * savepoints, so an inner commit is undone if the outer transaction rolls back. See
+ * {@code EbeanLocalDAO#runInTransactionWithRetry} for the enter/truncate/exit/flush sequence.
+ *
+ * <p>{@link #record} runs immediately when no frame is active, so non-transactional paths are
+ * unchanged. Reads are not buffered -- a read that was served happened regardless of whether a
+ * later write rolls back.
+ *
+ * <p>Callers MUST pair {@link #enter()} with {@link #exit} in a {@code finally}, with nothing that
+ * can throw in between: a frame that is never exited leaves the thread buffering forever, silently
+ * dropping every later emission on it.
+ */
+public final class DaoUsageBuffer {
+
+  /** Nesting depth and the emissions waiting on the outermost commit. */
+  private static final class Frame {
+    private final List<Runnable> pending = new ArrayList<>();
+    private int depth;
+  }
+
+  private static final ThreadLocal<Frame> STATE = new ThreadLocal<>();
+
+  private DaoUsageBuffer() {
+  }
+
+  /**
+   * Opens a transaction frame on the current thread.
+   *
+   * @return the mark for {@link #truncateTo} and {@link #exit}: the number of emissions already
+   *         buffered by enclosing frames, which this frame must not discard
+   */
+  public static int enter() {
+    Frame frame = STATE.get();
+    if (frame == null) {
+      frame = new Frame();
+      STATE.set(frame);
+    }
+    frame.depth++;
+    return frame.pending.size();
+  }
+
+  /**
+   * Drops everything buffered since {@code mark}, leaving enclosing frames untouched.
+   *
+   * @param mark the value returned by {@link #enter()}
+   */
+  public static void truncateTo(int mark) {
+    final Frame frame = STATE.get();
+    if (frame == null || mark < 0) {
+      return;
+    }
+    while (frame.pending.size() > mark) {
+      frame.pending.remove(frame.pending.size() - 1);
+    }
+  }
+
+  /**
+   * Closes the current frame.
+   *
+   * @param mark      the value returned by the matching {@link #enter()}
+   * @param committed whether this frame's transaction committed; if not, its emissions are dropped
+   * @return the emissions to run, empty unless this was the outermost frame
+   */
+  @Nonnull
+  public static List<Runnable> exit(int mark, boolean committed) {
+    final Frame frame = STATE.get();
+    if (frame == null) {
+      return Collections.emptyList();
+    }
+    if (!committed) {
+      truncateTo(mark);
+    }
+    frame.depth--;
+    if (frame.depth > 0) {
+      return Collections.emptyList();
+    }
+    // Outermost frame: clear the thread-local so pooled threads retain nothing.
+    STATE.remove();
+    return frame.pending.isEmpty() ? Collections.emptyList() : frame.pending;
+  }
+
+  /**
+   * Buffers an emission until the outermost transaction commits, or runs it immediately when no
+   * frame is active. Never throws.
+   *
+   * @param emission the emission to run; must not throw
+   */
+  public static void record(@Nonnull Runnable emission) {
+    final Frame frame = STATE.get();
+    if (frame == null || frame.depth <= 0) {
+      emission.run();
+      return;
+    }
+    frame.pending.add(emission);
+  }
+
+  /**
+   * Whether a transaction frame is currently open on this thread. For tests and diagnostics.
+   *
+   * @return {@code true} if emissions on this thread are currently buffered
+   */
+  public static boolean isBuffering() {
+    final Frame frame = STATE.get();
+    return frame != null && frame.depth > 0;
+  }
+}

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
@@ -1,0 +1,37 @@
+package com.linkedin.metadata.dao.tracking;
+
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.Value;
+
+
+/**
+ * A neutral, model-agnostic descriptor of one entity touched by a DAO operation.
+ *
+ * <p>Holds only strings so the kernel stays free of any Avro / event-schema dependency
+ * (see {@code checkGmaDoesNotDependOnModels}). The concrete
+ * {@link BaseDaoUsageEmitter} implementation in the service layer maps these fields onto
+ * the wire event.
+ */
+@Value
+public class DaoUsageTarget {
+
+  /**
+   * String form of the entity URN that was read or written.
+   */
+  @Nonnull
+  String urn;
+
+  /**
+   * Simple names of the aspects touched for this URN. Empty for a whole-entity delete
+   * ({@code DELETE_ALL}) where no specific aspect applies.
+   */
+  @Nonnull
+  List<String> aspects;
+
+  public DaoUsageTarget(@Nonnull String urn, @Nonnull List<String> aspects) {
+    this.urn = urn;
+    this.aspects = Collections.unmodifiableList(aspects);
+  }
+}

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.dao.tracking;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -31,6 +32,9 @@ public class DaoUsageTarget {
 
   public DaoUsageTarget(@Nonnull String urn, @Nonnull List<String> aspects) {
     this.urn = urn;
-    this.aspects = Collections.unmodifiableList(aspects);
+    // Copy before wrapping: unmodifiableList is only a view, so without the copy the caller could
+    // still mutate the list afterwards. Targets are handed to an asynchronous emitter, so they may
+    // be read on another thread well after construction.
+    this.aspects = Collections.unmodifiableList(new ArrayList<>(aspects));
   }
 }

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
@@ -9,10 +9,9 @@ import lombok.Value;
 /**
  * A neutral, model-agnostic descriptor of one entity touched by a DAO operation.
  *
- * <p>Holds only strings so the kernel stays free of any Avro / event-schema dependency
- * (see {@code checkGmaDoesNotDependOnModels}). The concrete
- * {@link BaseDaoUsageEmitter} implementation in the service layer maps these fields onto
- * the wire event.
+ * <p>Holds only strings so the kernel stays free of any Avro / event-schema dependency.
+ * The concrete {@link BaseDaoUsageEmitter} implementation in the service layer maps these
+ * fields onto the wire event.
  */
 @Value
 public class DaoUsageTarget {

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/DaoUsageTarget.java
@@ -24,8 +24,10 @@ public class DaoUsageTarget {
   String urn;
 
   /**
-   * Simple names of the aspects touched for this URN. Empty for a whole-entity delete
-   * ({@code DELETE_ALL}) where no specific aspect applies.
+   * Simple names of the aspects touched for this URN. May be empty -- e.g. a whole-entity
+   * {@code DELETE_ALL}, or a {@code create} with no aspect values. Do NOT infer the operation
+   * kind from an empty list; use the event's {@code operationType} as the authoritative
+   * discriminator.
    */
   @Nonnull
   List<String> aspects;

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/NoOpDaoUsageEmitter.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/NoOpDaoUsageEmitter.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
  * A no-op implementation of {@link BaseDaoUsageEmitter} that discards all usage events.
  *
  * <p>Used as the default when no producer-backed emitter is configured. With this
- * implementation the {@link UsageTrackingEbeanLocalAccess} decorator (and any other
+ * implementation the {@code UsageTrackingEbeanLocalAccess} decorator (and any other
  * caller) short-circuits on {@link #isEnabled()} and does zero work.
  */
 public class NoOpDaoUsageEmitter implements BaseDaoUsageEmitter {

--- a/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/NoOpDaoUsageEmitter.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/tracking/NoOpDaoUsageEmitter.java
@@ -1,0 +1,28 @@
+package com.linkedin.metadata.dao.tracking;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+/**
+ * A no-op implementation of {@link BaseDaoUsageEmitter} that discards all usage events.
+ *
+ * <p>Used as the default when no producer-backed emitter is configured. With this
+ * implementation the {@link UsageTrackingEbeanLocalAccess} decorator (and any other
+ * caller) short-circuits on {@link #isEnabled()} and does zero work.
+ */
+public class NoOpDaoUsageEmitter implements BaseDaoUsageEmitter {
+
+  @Override
+  public void emit(@Nonnull String operationType, @Nonnull String entityType,
+      @Nonnull String sourceOperation, @Nullable String actorUrn,
+      @Nullable String impersonatorUrn, @Nonnull List<DaoUsageTarget> targets) {
+    // Do nothing
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+}

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -249,6 +250,33 @@ public class BaseLocalDAOTest {
     public Map<AspectKey<FooUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
         @Nonnull Set<AspectKey<FooUrn, ? extends RecordTemplate>> keys) {
       return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Counts calls to the batch {@link BaseLocalDAO#getWithExtraInfo(Set)} so tests can assert that a
+   * single-key read issues exactly one query.
+   */
+  static class CountingGetWithExtraInfoLocalDAO<ENTITY_ASPECT_UNION extends UnionTemplate>
+      extends DummyLocalDAO<ENTITY_ASPECT_UNION> {
+
+    final AtomicInteger _batchCallCount = new AtomicInteger(0);
+    private final Map<AspectKey<FooUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> _canned;
+
+    CountingGetWithExtraInfoLocalDAO(Class<ENTITY_ASPECT_UNION> aspectClass,
+        BiFunction<FooUrn, Class<? extends RecordTemplate>, AspectEntry> getLatestFunction,
+        BaseMetadataEventProducer eventProducer, DummyTransactionRunner transactionRunner,
+        Map<AspectKey<FooUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> canned) {
+      super(aspectClass, getLatestFunction, eventProducer, transactionRunner);
+      _canned = canned;
+    }
+
+    @Override
+    @Nonnull
+    public Map<AspectKey<FooUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
+        @Nonnull Set<AspectKey<FooUrn, ? extends RecordTemplate>> keys) {
+      _batchCallCount.incrementAndGet();
+      return _canned;
     }
   }
 
@@ -1773,5 +1801,39 @@ public class BaseLocalDAOTest {
     } catch (IllegalArgumentException e) {
       assertTrue(e instanceof InvalidUrnException);
     }
+  }
+
+  @Test
+  public void testSingleKeyGetWithExtraInfoIssuesOneQueryWhenFound() throws Exception {
+    FooUrn urn = new FooUrn(1);
+    AspectKey<FooUrn, AspectFoo> key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+    AspectWithExtraInfo<AspectFoo> expected =
+        new AspectWithExtraInfo<>(new AspectFoo().setValue("bar"), new ExtraInfo());
+
+    CountingGetWithExtraInfoLocalDAO<EntityAspectUnion> dao =
+        new CountingGetWithExtraInfoLocalDAO<>(EntityAspectUnion.class, _mockGetLatestFunction, _mockEventProducer,
+            _mockTransactionRunner, Collections.singletonMap(key, expected));
+
+    Optional<AspectWithExtraInfo<AspectFoo>> result = dao.getWithExtraInfo(key);
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get(), expected);
+    // Previously this method called the batch overload twice: once for containsKey, once to read.
+    assertEquals(dao._batchCallCount.get(), 1);
+  }
+
+  @Test
+  public void testSingleKeyGetWithExtraInfoIssuesOneQueryWhenMissing() throws Exception {
+    FooUrn urn = new FooUrn(1);
+    AspectKey<FooUrn, AspectFoo> key = new AspectKey<>(AspectFoo.class, urn, LATEST_VERSION);
+
+    CountingGetWithExtraInfoLocalDAO<EntityAspectUnion> dao =
+        new CountingGetWithExtraInfoLocalDAO<>(EntityAspectUnion.class, _mockGetLatestFunction, _mockEventProducer,
+            _mockTransactionRunner, Collections.emptyMap());
+
+    Optional<AspectWithExtraInfo<AspectFoo>> result = dao.getWithExtraInfo(key);
+
+    assertFalse(result.isPresent());
+    assertEquals(dao._batchCallCount.get(), 1);
   }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.dao.producer.BaseTrackingMetadataEventProducer;
 import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
+import com.linkedin.metadata.dao.tracking.DaoReadContext;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.events.IngestionMode;
 import com.linkedin.metadata.events.IngestionTrackingContext;
@@ -250,6 +251,35 @@ public class BaseLocalDAOTest {
     public Map<AspectKey<FooUrn, ? extends RecordTemplate>, AspectWithExtraInfo<? extends RecordTemplate>> getWithExtraInfo(
         @Nonnull Set<AspectKey<FooUrn, ? extends RecordTemplate>> keys) {
       return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Records whether the internal-read marker was set while the DAO performed its read, so tests can
+   * assert that backfill reads are marked and ordinary consumer reads are not.
+   */
+  static class MarkerRecordingLocalDAO<ENTITY_ASPECT_UNION extends UnionTemplate>
+      extends DummyLocalDAO<ENTITY_ASPECT_UNION> {
+
+    final List<Boolean> _markerDuringGet = new ArrayList<>();
+
+    MarkerRecordingLocalDAO(Class<ENTITY_ASPECT_UNION> aspectClass,
+        BiFunction<FooUrn, Class<? extends RecordTemplate>, AspectEntry> getLatestFunction,
+        BaseMetadataEventProducer eventProducer, DummyTransactionRunner transactionRunner) {
+      super(aspectClass, getLatestFunction, eventProducer, transactionRunner);
+    }
+
+    @Override
+    @Nonnull
+    public Map<AspectKey<FooUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> get(
+        Set<AspectKey<FooUrn, ? extends RecordTemplate>> aspectKeys) {
+      _markerDuringGet.add(DaoReadContext.isInternalRead());
+      // Mirror the real implementations, which map every requested key (to an empty Optional when
+      // absent) rather than omitting it.
+      Map<AspectKey<FooUrn, ? extends RecordTemplate>, Optional<? extends RecordTemplate>> results =
+          new HashMap<>();
+      aspectKeys.forEach(key -> results.put(key, Optional.empty()));
+      return results;
     }
   }
 
@@ -1801,6 +1831,59 @@ public class BaseLocalDAOTest {
     } catch (IllegalArgumentException e) {
       assertTrue(e instanceof InvalidUrnException);
     }
+  }
+
+  @Test
+  public void testBackfillReadsAreMarkedInternal() throws Exception {
+    MarkerRecordingLocalDAO<EntityAspectUnion> dao =
+        new MarkerRecordingLocalDAO<>(EntityAspectUnion.class, _mockGetLatestFunction, _mockEventProducer,
+            _mockTransactionRunner);
+    FooUrn urn = new FooUrn(1);
+
+    dao.backfill(Collections.singleton(AspectFoo.class), Collections.singleton(urn));
+
+    // Backfill is a system operation; its read must not be counted as consumer usage.
+    assertEquals(dao._markerDuringGet, Collections.singletonList(true));
+  }
+
+  @Test
+  public void testSingleAspectBackfillReadIsMarkedInternal() throws Exception {
+    MarkerRecordingLocalDAO<EntityAspectUnion> dao =
+        new MarkerRecordingLocalDAO<>(EntityAspectUnion.class, _mockGetLatestFunction, _mockEventProducer,
+            _mockTransactionRunner);
+    FooUrn urn = new FooUrn(1);
+
+    dao.backfill(AspectFoo.class, urn);
+
+    assertEquals(dao._markerDuringGet, Collections.singletonList(true));
+  }
+
+  @Test
+  public void testConsumerReadIsNotMarkedInternal() throws Exception {
+    MarkerRecordingLocalDAO<EntityAspectUnion> dao =
+        new MarkerRecordingLocalDAO<>(EntityAspectUnion.class, _mockGetLatestFunction, _mockEventProducer,
+            _mockTransactionRunner);
+    FooUrn urn = new FooUrn(1);
+
+    dao.get(Collections.singleton(AspectFoo.class), Collections.singleton(urn));
+
+    // An ordinary read is genuine consumer traffic and stays unmarked.
+    assertEquals(dao._markerDuringGet, Collections.singletonList(false));
+  }
+
+  @Test
+  public void testMarkerDoesNotLeakAfterBackfill() throws Exception {
+    MarkerRecordingLocalDAO<EntityAspectUnion> dao =
+        new MarkerRecordingLocalDAO<>(EntityAspectUnion.class, _mockGetLatestFunction, _mockEventProducer,
+            _mockTransactionRunner);
+    FooUrn urn = new FooUrn(1);
+
+    dao.backfill(Collections.singleton(AspectFoo.class), Collections.singleton(urn));
+    dao.get(Collections.singleton(AspectFoo.class), Collections.singleton(urn));
+
+    // The scope closes on the way out of backfill, so the following consumer read is still counted.
+    assertEquals(dao._markerDuringGet, Arrays.asList(true, false));
+    assertFalse(DaoReadContext.isInternalRead());
   }
 
   @Test

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoReadContextTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoReadContextTest.java
@@ -1,0 +1,36 @@
+package com.linkedin.metadata.dao.tracking;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class DaoReadContextTest {
+
+  @AfterMethod
+  public void tearDown() {
+    DaoReadContext.clear();
+  }
+
+  @Test
+  public void testDefaultsToFalse() {
+    assertFalse(DaoReadContext.isInternalRead());
+  }
+
+  @Test
+  public void testMarkThenClear() {
+    DaoReadContext.markInternalRead();
+    assertTrue(DaoReadContext.isInternalRead());
+
+    DaoReadContext.clear();
+    assertFalse(DaoReadContext.isInternalRead());
+  }
+
+  @Test
+  public void testClearIsIdempotent() {
+    DaoReadContext.clear();
+    DaoReadContext.clear();
+    assertFalse(DaoReadContext.isInternalRead());
+  }
+}

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoReadContextTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoReadContextTest.java
@@ -1,6 +1,6 @@
 package com.linkedin.metadata.dao.tracking;
 
-import org.testng.annotations.AfterMethod;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -8,29 +8,134 @@ import static org.testng.Assert.*;
 
 public class DaoReadContextTest {
 
-  @AfterMethod
-  public void tearDown() {
-    DaoReadContext.clear();
-  }
-
   @Test
   public void testDefaultsToFalse() {
     assertFalse(DaoReadContext.isInternalRead());
   }
 
   @Test
-  public void testMarkThenClear() {
-    DaoReadContext.markInternalRead();
-    assertTrue(DaoReadContext.isInternalRead());
+  public void testMarkThenClose() {
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+      assertTrue(DaoReadContext.isInternalRead());
+    }
+    assertFalse(DaoReadContext.isInternalRead());
+  }
 
-    DaoReadContext.clear();
+  /**
+   * An inner marked region must not unmark the enclosing one when it closes. Before the scope API
+   * the inner {@code clear()} removed the marker outright and the rest of the outer region was
+   * silently billed as consumer reads.
+   */
+  @Test
+  public void testNestedScopesRestorePreviousState() {
+    try (DaoReadContext.Scope outer = DaoReadContext.markInternalRead()) {
+      assertTrue(DaoReadContext.isInternalRead());
+
+      try (DaoReadContext.Scope inner = DaoReadContext.markInternalRead()) {
+        assertTrue(DaoReadContext.isInternalRead());
+      }
+
+      // The outer region is still active.
+      assertTrue(DaoReadContext.isInternalRead());
+    }
     assertFalse(DaoReadContext.isInternalRead());
   }
 
   @Test
-  public void testClearIsIdempotent() {
-    DaoReadContext.clear();
-    DaoReadContext.clear();
+  public void testDeeplyNestedScopes() {
+    try (DaoReadContext.Scope first = DaoReadContext.markInternalRead()) {
+      try (DaoReadContext.Scope second = DaoReadContext.markInternalRead()) {
+        try (DaoReadContext.Scope third = DaoReadContext.markInternalRead()) {
+          assertTrue(DaoReadContext.isInternalRead());
+        }
+        assertTrue(DaoReadContext.isInternalRead());
+      }
+      assertTrue(DaoReadContext.isInternalRead());
+    }
+    assertFalse(DaoReadContext.isInternalRead());
+  }
+
+  @Test
+  public void testScopeIsRestoredWhenBodyThrows() {
+    try {
+      try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+        assertTrue(DaoReadContext.isInternalRead());
+        throw new IllegalStateException("boom");
+      }
+    } catch (IllegalStateException expected) {
+      // expected
+    }
+    assertFalse(DaoReadContext.isInternalRead());
+  }
+
+  @Test
+  public void testNestedScopeIsRestoredWhenInnerBodyThrows() {
+    try (DaoReadContext.Scope outer = DaoReadContext.markInternalRead()) {
+      try {
+        try (DaoReadContext.Scope inner = DaoReadContext.markInternalRead()) {
+          throw new IllegalStateException("boom");
+        }
+      } catch (IllegalStateException expected) {
+        // expected
+      }
+      assertTrue(DaoReadContext.isInternalRead());
+    }
+    assertFalse(DaoReadContext.isInternalRead());
+  }
+
+  /**
+   * The marker is backed by a bare {@link ThreadLocal}, so a thread that has never marked reads
+   * {@code null} internally. The accessor must treat that as {@code false} rather than throwing
+   * on unboxing -- it is evaluated outside the emitter's fail-open guard, so an exception here
+   * would propagate into the DAO read path.
+   */
+  @Test
+  public void testIsInternalReadIsNullSafeOnUntouchedThread() throws Exception {
+    final AtomicBoolean observed = new AtomicBoolean(true);
+    final AtomicBoolean threw = new AtomicBoolean(false);
+
+    final Thread thread = new Thread(() -> {
+      try {
+        observed.set(DaoReadContext.isInternalRead());
+      } catch (RuntimeException e) {
+        threw.set(true);
+      }
+    });
+    thread.start();
+    thread.join();
+
+    assertFalse(threw.get());
+    assertFalse(observed.get());
+  }
+
+  @Test
+  public void testMarkerIsNotVisibleToOtherThreads() throws Exception {
+    final AtomicBoolean observedOnOtherThread = new AtomicBoolean(true);
+
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+      assertTrue(DaoReadContext.isInternalRead());
+
+      final Thread thread = new Thread(() -> observedOnOtherThread.set(DaoReadContext.isInternalRead()));
+      thread.start();
+      thread.join();
+    }
+
+    assertFalse(observedOnOtherThread.get());
+  }
+
+  /**
+   * Closing twice must not resurrect or corrupt the marker, since try-with-resources on a scope
+   * held in a variable can be closed explicitly as well.
+   */
+  @Test
+  public void testCloseIsIdempotent() {
+    final DaoReadContext.Scope scope = DaoReadContext.markInternalRead();
+    assertTrue(DaoReadContext.isInternalRead());
+
+    scope.close();
+    assertFalse(DaoReadContext.isInternalRead());
+
+    scope.close();
     assertFalse(DaoReadContext.isInternalRead());
   }
 }

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoUsageBufferTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoUsageBufferTest.java
@@ -4,12 +4,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 
 public class DaoUsageBufferTest {
+
+  @BeforeMethod
+  public void setUp() {
+    // The buffer only buffers once an emitter has been installed; these tests drive it directly.
+    DaoUsageBuffer.arm();
+  }
 
   @Test
   public void testRecordRunsImmediatelyWhenNoTransaction() {
@@ -137,9 +144,9 @@ public class DaoUsageBufferTest {
   }
 
   /**
-   * A frame that is entered but never exited would leave the thread buffering forever, silently
-   * dropping every later emission on it. The transaction runner pairs enter/exit in a finally, so
-   * an exception escaping the block must still close the frame.
+   * A frame that is entered but never exited would stay open on the thread forever, so every later
+   * emission on it keeps buffering and never flushes (a leak). The transaction runner pairs
+   * enter/exit in a finally, so an exception escaping the block must still close the frame.
    */
   @Test
   public void testFrameIsClosedWhenBlockThrows() {

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoUsageBufferTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoUsageBufferTest.java
@@ -1,0 +1,191 @@
+package com.linkedin.metadata.dao.tracking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class DaoUsageBufferTest {
+
+  @Test
+  public void testRecordRunsImmediatelyWhenNoTransaction() {
+    final List<String> emitted = new ArrayList<>();
+
+    DaoUsageBuffer.record(() -> emitted.add("write"));
+
+    // Non-transactional paths behave exactly as before.
+    assertEquals(emitted, Collections.singletonList("write"));
+    assertFalse(DaoUsageBuffer.isBuffering());
+  }
+
+  @Test
+  public void testCommitReleasesBufferedEmission() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int mark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("write"));
+    // Nothing is emitted while the transaction is still open.
+    assertTrue(emitted.isEmpty());
+    final List<Runnable> pending = DaoUsageBuffer.exit(mark, true);
+
+    assertEquals(pending.size(), 1);
+    pending.forEach(Runnable::run);
+    assertEquals(emitted, Collections.singletonList("write"));
+    assertFalse(DaoUsageBuffer.isBuffering());
+  }
+
+  @Test
+  public void testRollbackDiscardsBufferedEmission() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int mark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("write"));
+    final List<Runnable> pending = DaoUsageBuffer.exit(mark, false);
+
+    // The write never became durable, so it must not be reported.
+    assertTrue(pending.isEmpty());
+    pending.forEach(Runnable::run);
+    assertTrue(emitted.isEmpty());
+    assertFalse(DaoUsageBuffer.isBuffering());
+  }
+
+  @Test
+  public void testRetryReportsTheWriteOnce() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int mark = DaoUsageBuffer.enter();
+    // Attempt 1 buffers, then fails.
+    DaoUsageBuffer.truncateTo(mark);
+    DaoUsageBuffer.record(() -> emitted.add("write"));
+    // Attempt 2 discards attempt 1's emission, buffers its own, and commits.
+    DaoUsageBuffer.truncateTo(mark);
+    DaoUsageBuffer.record(() -> emitted.add("write"));
+    final List<Runnable> pending = DaoUsageBuffer.exit(mark, true);
+
+    pending.forEach(Runnable::run);
+    assertEquals(emitted, Collections.singletonList("write"));
+  }
+
+  @Test
+  public void testInnerCommitIsNotReleasedUntilOuterCommits() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int outerMark = DaoUsageBuffer.enter();
+    final int innerMark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("inner-write"));
+    final List<Runnable> innerPending = DaoUsageBuffer.exit(innerMark, true);
+
+    // Ebean implements the inner transaction with a savepoint, so its commit is not durable yet.
+    assertTrue(innerPending.isEmpty());
+    assertTrue(DaoUsageBuffer.isBuffering());
+
+    final List<Runnable> outerPending = DaoUsageBuffer.exit(outerMark, true);
+    outerPending.forEach(Runnable::run);
+    assertEquals(emitted, Collections.singletonList("inner-write"));
+    assertFalse(DaoUsageBuffer.isBuffering());
+  }
+
+  @Test
+  public void testInnerCommitIsDiscardedWhenOuterRollsBack() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int outerMark = DaoUsageBuffer.enter();
+    final int innerMark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("inner-write"));
+    DaoUsageBuffer.exit(innerMark, true);
+    final List<Runnable> outerPending = DaoUsageBuffer.exit(outerMark, false);
+
+    // The outer rollback takes the inner write with it, so nothing is reported.
+    assertTrue(outerPending.isEmpty());
+    outerPending.forEach(Runnable::run);
+    assertTrue(emitted.isEmpty());
+    assertFalse(DaoUsageBuffer.isBuffering());
+  }
+
+  @Test
+  public void testInnerRollbackDoesNotDiscardOuterEmission() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int outerMark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("outer-write"));
+
+    final int innerMark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("inner-write"));
+    DaoUsageBuffer.exit(innerMark, false);
+
+    final List<Runnable> pending = DaoUsageBuffer.exit(outerMark, true);
+    pending.forEach(Runnable::run);
+
+    // The inner frame drops only what it buffered.
+    assertEquals(emitted, Collections.singletonList("outer-write"));
+  }
+
+  @Test
+  public void testEmissionsAreReleasedInOrder() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int mark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("first"));
+    DaoUsageBuffer.record(() -> emitted.add("second"));
+    DaoUsageBuffer.exit(mark, true).forEach(Runnable::run);
+
+    assertEquals(emitted, Arrays.asList("first", "second"));
+  }
+
+  /**
+   * A frame that is entered but never exited would leave the thread buffering forever, silently
+   * dropping every later emission on it. The transaction runner pairs enter/exit in a finally, so
+   * an exception escaping the block must still close the frame.
+   */
+  @Test
+  public void testFrameIsClosedWhenBlockThrows() {
+    final List<String> emitted = new ArrayList<>();
+
+    final int mark = DaoUsageBuffer.enter();
+    try {
+      DaoUsageBuffer.record(() -> emitted.add("write"));
+      throw new IllegalStateException("boom");
+    } catch (IllegalStateException expected) {
+      // expected
+    } finally {
+      DaoUsageBuffer.exit(mark, false);
+    }
+
+    assertFalse(DaoUsageBuffer.isBuffering());
+    assertTrue(emitted.isEmpty());
+
+    // The thread is usable again: the next emission is not swallowed by a stranded frame.
+    DaoUsageBuffer.record(() -> emitted.add("later"));
+    assertEquals(emitted, Collections.singletonList("later"));
+  }
+
+  @Test
+  public void testExitWithoutEnterIsHarmless() {
+    final List<Runnable> pending = DaoUsageBuffer.exit(0, true);
+
+    assertTrue(pending.isEmpty());
+    assertFalse(DaoUsageBuffer.isBuffering());
+  }
+
+  @Test
+  public void testBufferIsNotSharedAcrossThreads() throws Exception {
+    final List<String> emitted = Collections.synchronizedList(new ArrayList<>());
+
+    final int mark = DaoUsageBuffer.enter();
+    DaoUsageBuffer.record(() -> emitted.add("main-thread-write"));
+
+    // Another thread has no frame, so its emission runs immediately.
+    final Thread thread = new Thread(() -> DaoUsageBuffer.record(() -> emitted.add("other-thread-write")));
+    thread.start();
+    thread.join();
+
+    assertEquals(emitted, Collections.singletonList("other-thread-write"));
+
+    DaoUsageBuffer.exit(mark, true).forEach(Runnable::run);
+    assertEquals(emitted, Arrays.asList("other-thread-write", "main-thread-write"));
+  }
+}

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoUsageTargetTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/DaoUsageTargetTest.java
@@ -1,0 +1,25 @@
+package com.linkedin.metadata.dao.tracking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class DaoUsageTargetTest {
+
+  @Test
+  public void testAspectsAreCopiedNotWrapped() {
+    List<String> source = new ArrayList<>(Arrays.asList("AspectFoo", "AspectBar"));
+    DaoUsageTarget target = new DaoUsageTarget("urn:li:foo:1", source);
+
+    // unmodifiableList alone is only a view, so mutating the caller's list would change the
+    // already-constructed target. Targets are handed to an asynchronous emitter, so they can be
+    // read on another thread well after the DAO call returns.
+    source.add("AspectBaz");
+
+    assertEquals(target.getAspects(), Arrays.asList("AspectFoo", "AspectBar"));
+  }
+}

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/NoOpDaoUsageEmitterTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/tracking/NoOpDaoUsageEmitterTest.java
@@ -1,0 +1,24 @@
+package com.linkedin.metadata.dao.tracking;
+
+import java.util.Collections;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class NoOpDaoUsageEmitterTest {
+
+  @Test
+  public void testNoOpBehavior() {
+    NoOpDaoUsageEmitter emitter = new NoOpDaoUsageEmitter();
+
+    // Should not throw for any operation shape, including null caller and empty targets.
+    emitter.emit("READ", "dataset", "batchGetUnion", null, null,
+        Collections.singletonList(new DaoUsageTarget("urn:li:dataset:foo",
+            Collections.singletonList("AspectFoo"))));
+    emitter.emit("WRITE", "corpuser", "add", "urn:li:corpuser:bar", "urn:li:service:baz",
+        Collections.emptyList());
+
+    assertFalse(emitter.isEnabled());
+  }
+}

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -921,14 +921,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     } else {
       // for new schema, get latest data from the new schema entity table. (Resolving the read de-coupling issue)
       // Mark this as an internal read-before-write so usage instrumentation does not count it as a consumer read.
-      DaoReadContext.markInternalRead();
       final List<EbeanMetadataAspect> results;
-      try {
+      try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
         results =
             _localAccess.batchGetUnion(Collections.singletonList(new AspectKey<>(aspectClass, urn, LATEST_VERSION)), 1, 0,
                 true, isTestMode);
-      } finally {
-        DaoReadContext.clear();
       }
       result = results.isEmpty() ? null : results.get(0);
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -23,6 +23,7 @@ import com.linkedin.metadata.dao.tracking.BaseDaoBenchmarkMetrics;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
 import com.linkedin.metadata.dao.tracking.DaoReadContext;
+import com.linkedin.metadata.dao.tracking.DaoUsageBuffer;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
@@ -634,22 +635,40 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   @Override
   protected <T> T runInTransactionWithRetry(@Nonnull Supplier<T> block, int maxTransactionRetry) {
     int retryCount = 0;
-    Exception lastException;
+    Exception lastException = null;
 
     T result = null;
-    do {
-      try (Transaction transaction = _server.beginTransaction()) {
-        result = block.get();
-        transaction.commit();
-        lastException = null;
-        break;
-      } catch (RollbackException | DuplicateKeyException | OptimisticLockException exception) {
-        lastException = exception;
-      }
-    } while (++retryCount <= maxTransactionRetry);
+    boolean committed = false;
+    // Usage emissions from this transaction are buffered and released only after the outermost
+    // commit, so a rolled-back write is never reported and a retry is reported once.
+    // enter() and exit() must stay paired with nothing between them that can throw.
+    final int usageMark = DaoUsageBuffer.enter();
+    List<Runnable> pendingUsage = Collections.emptyList();
+    try {
+      do {
+        // Drop whatever the previous attempt buffered before trying again.
+        DaoUsageBuffer.truncateTo(usageMark);
+        try (Transaction transaction = _server.beginTransaction()) {
+          result = block.get();
+          transaction.commit();
+          committed = true;
+          lastException = null;
+          break;
+        } catch (RollbackException | DuplicateKeyException | OptimisticLockException exception) {
+          lastException = exception;
+        }
+      } while (++retryCount <= maxTransactionRetry);
+    } finally {
+      pendingUsage = DaoUsageBuffer.exit(usageMark, committed);
+    }
 
     if (lastException != null) {
       throw new RetryLimitReached("Failed to add after " + maxTransactionRetry + " retries", lastException);
+    }
+
+    // Flush outside the transaction: emission must not be able to affect it, or vice versa.
+    for (Runnable emission : pendingUsage) {
+      emission.run();
     }
 
     return result;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -94,6 +94,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   private final static int DEFAULT_BATCH_SIZE = 50;
   private int _queryKeysCount = DEFAULT_BATCH_SIZE;
   private IEbeanLocalAccess<URN> _localAccess;
+  // Tracks whether the usage decorator has been installed. A structural check on _localAccess only
+  // sees the outermost layer, so it misses a usage decorator buried under another decorator.
+  private boolean _usageTrackingInstalled = false;
   private EbeanLocalRelationshipWriterDAO _localRelationshipWriterDAO;
   private LocalRelationshipBuilderRegistry _localRelationshipBuilderRegistry = null;
   private SchemaConfig _schemaConfig = SchemaConfig.OLD_SCHEMA_ONLY;
@@ -600,18 +603,19 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    *
    * <p>Purely additive: when this is never called the DAO behaves exactly as before, and the
    * emitter is fire-and-forget (never throws into the call path). Composes with
-   * {@link #setBenchmarkMetrics} -- both decorate {@code _localAccess}.
+   * {@link #setBenchmarkMetrics} -- both decorate {@code _localAccess}, in either order.
    *
    * @param usageEmitter the usage emitter implementation to use
    */
   public void setUsageEmitter(@Nonnull BaseDaoUsageEmitter usageEmitter) {
-    if (_localAccess instanceof UsageTrackingEbeanLocalAccess) {
-      // Already decorated. Stacking a second decorator would emit every event twice.
+    if (_usageTrackingInstalled) {
+      // Stacking a second decorator would emit every event twice.
       log.warn("Usage emitter is already set on this DAO; ignoring the repeat call.");
       return;
     }
     if (_localAccess != null) {
-      _localAccess = new UsageTrackingEbeanLocalAccess<>(_localAccess, usageEmitter, _urnClass);
+      _localAccess = new UsageTrackingEbeanLocalAccess<>(_localAccess, usageEmitter);
+      _usageTrackingInstalled = true;
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -22,6 +22,7 @@ import com.linkedin.metadata.dao.storage.LocalDAOStorageConfig;
 import com.linkedin.metadata.dao.tracking.BaseDaoBenchmarkMetrics;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
+import com.linkedin.metadata.dao.tracking.DaoReadContext;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
@@ -919,9 +920,16 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       }
     } else {
       // for new schema, get latest data from the new schema entity table. (Resolving the read de-coupling issue)
-      final List<EbeanMetadataAspect> results =
-          _localAccess.batchGetUnion(Collections.singletonList(new AspectKey<>(aspectClass, urn, LATEST_VERSION)), 1, 0,
-              true, isTestMode);
+      // Mark this as an internal read-before-write so usage instrumentation does not count it as a consumer read.
+      DaoReadContext.markInternalRead();
+      final List<EbeanMetadataAspect> results;
+      try {
+        results =
+            _localAccess.batchGetUnion(Collections.singletonList(new AspectKey<>(aspectClass, urn, LATEST_VERSION)), 1, 0,
+                true, isTestMode);
+      } finally {
+        DaoReadContext.clear();
+      }
       result = results.isEmpty() ? null : results.get(0);
     }
     return result;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -20,6 +20,7 @@ import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.dao.storage.LocalDAOStorageConfig;
 import com.linkedin.metadata.dao.tracking.BaseDaoBenchmarkMetrics;
+import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
@@ -587,6 +588,24 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   public void setBenchmarkMetrics(@Nonnull BaseDaoBenchmarkMetrics metrics) {
     if (_localAccess != null) {
       _localAccess = new InstrumentedEbeanLocalAccess<>(_localAccess, metrics, _urnClass);
+    }
+  }
+
+  /**
+   * Set the usage emitter for DAO usage tracking. Wraps the underlying
+   * {@link IEbeanLocalAccess} with a {@link UsageTrackingEbeanLocalAccess} decorator that
+   * emits a usage event once per successful read / write / delete.
+   * No-op when {@code _localAccess} is {@code null} (OLD_SCHEMA_ONLY mode).
+   *
+   * <p>Purely additive: when this is never called the DAO behaves exactly as before, and the
+   * emitter is fire-and-forget (never throws into the call path). Composes with
+   * {@link #setBenchmarkMetrics} -- both decorate {@code _localAccess}.
+   *
+   * @param usageEmitter the usage emitter implementation to use
+   */
+  public void setUsageEmitter(@Nonnull BaseDaoUsageEmitter usageEmitter) {
+    if (_localAccess != null) {
+      _localAccess = new UsageTrackingEbeanLocalAccess<>(_localAccess, usageEmitter, _urnClass);
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -871,7 +871,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       if (_noisyLogsEnabled) {
         log.info("Backfilling local relationships for urn: {}, aspectClass: {}", urn, aspectClass);
       }
-          List<EbeanMetadataAspect> results = batchGet(Collections.singleton(key), 1);
+      // Backfill is a system operation, not consumer traffic, so its read is not counted as usage.
+      final List<EbeanMetadataAspect> results;
+      try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+        results = batchGet(Collections.singleton(key), 1);
+      }
       if (results.isEmpty()) {
         if (_noisyLogsEnabled) {
           log.info("Not backfilling any relationships because no aspect data was found for urn: {}, aspectClass: {}", urn, aspectClass);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -604,6 +604,11 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * @param usageEmitter the usage emitter implementation to use
    */
   public void setUsageEmitter(@Nonnull BaseDaoUsageEmitter usageEmitter) {
+    if (_localAccess instanceof UsageTrackingEbeanLocalAccess) {
+      // Already decorated. Stacking a second decorator would emit every event twice.
+      log.warn("Usage emitter is already set on this DAO; ignoring the repeat call.");
+      return;
+    }
     if (_localAccess != null) {
       _localAccess = new UsageTrackingEbeanLocalAccess<>(_localAccess, usageEmitter, _urnClass);
     }
@@ -844,7 +849,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       }
       AuditStamp auditStamp = makeAuditStamp(result);
       ASPECT aspect = toRecordTemplate(aspectClass, result).orElse(null);
-      _localAccess.add(urn, aspect, aspectClass, auditStamp, null, false);
+      // Mark as backfill so this old->new schema migration is not reported as organic usage.
+      final IngestionTrackingContext backfillContext = new IngestionTrackingContext().setBackfill(true);
+      _localAccess.add(urn, aspect, aspectClass, auditStamp, backfillContext, false);
 
       // also insert any relationships associated with this aspect
       handleRelationshipIngestion(urn, aspect, null, aspectClass, false);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -617,6 +617,9 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     if (_localAccess != null) {
       _localAccess = new UsageTrackingEbeanLocalAccess<>(_localAccess, usageEmitter);
       _usageTrackingInstalled = true;
+      // Arm the transaction buffer now that this process has a live emitter; until this call
+      // runInTransactionWithRetry's enter()/exit() are no-ops (zero overhead when never installed).
+      DaoUsageBuffer.arm();
     }
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
@@ -37,6 +37,10 @@ import lombok.extern.slf4j.Slf4j;
  * captured; global scans, discovery and maintenance are delegated without emission. Writes carry
  * the caller from the {@link AuditStamp}; reads have none.
  *
+ * <p>The entity type is taken from {@link Urn#getEntityType()} on the URN being operated on, so it
+ * matches the canonical entity type used elsewhere (e.g. {@code mlModel}) rather than a value
+ * derived from the URN class name.
+ *
  * @param <URN> the URN type for this entity
  */
 @Slf4j
@@ -49,21 +53,17 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
 
   private final IEbeanLocalAccess<URN> _delegate;
   private final BaseDaoUsageEmitter _usageEmitter;
-  private final String _entityType;
 
   /**
    * Creates a usage-tracking wrapper around the given local-access implementation.
    *
    * @param delegate     the real local-access implementation to wrap
    * @param usageEmitter the usage emitter (may be a no-op)
-   * @param urnClass     the URN class, used to derive the entity type name once at construction
    */
   public UsageTrackingEbeanLocalAccess(@Nonnull IEbeanLocalAccess<URN> delegate,
-      @Nonnull BaseDaoUsageEmitter usageEmitter, @Nonnull Class<URN> urnClass) {
+      @Nonnull BaseDaoUsageEmitter usageEmitter) {
     _delegate = delegate;
     _usageEmitter = usageEmitter;
-    // Same derivation as InstrumentedEbeanLocalAccess to keep the entity dimension consistent.
-    _entityType = urnClass.getSimpleName().replace("Urn", "").toLowerCase();
   }
 
   // ---------------------------------------------------------------------------------------
@@ -149,7 +149,8 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final List<EbeanMetadataAspect> result =
         _delegate.batchGetUnion(keys, keysCount, position, includeSoftDeleted, isTestMode);
     if (_usageEmitter.isEnabled() && !isTestMode && !DaoReadContext.isInternalRead()) {
-      safeEmit(OP_READ, "batchGetUnion", null, () -> targetsFromKeys(keys, keysCount, position));
+      safeEmit(OP_READ, "batchGetUnion", null, () -> entityTypeFromKeys(keys, keysCount, position),
+          () -> targetsFromKeys(keys, keysCount, position));
     }
     return result;
   }
@@ -160,7 +161,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       @Nonnull URN urn, int start, int pageSize) {
     final ListResult<ASPECT> result = _delegate.list(aspectClass, urn, start, pageSize);
     if (_usageEmitter.isEnabled()) {
-      safeEmit(OP_READ, "list", null,
+      safeEmit(OP_READ, "list", null, urn::getEntityType,
           () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
@@ -177,7 +178,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result =
         _delegate.add(urn, newValue, aspectClass, auditStamp, ingestionTrackingContext, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "add", auditStamp,
+      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "add", auditStamp, urn::getEntityType,
           () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
@@ -192,7 +193,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
         oldTimestamp, ingestionTrackingContext, isTestMode, softDeleteOverwrite);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
       safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "addWithOptimisticLocking",
-          auditStamp, () -> singleTarget(urn, aspectClass.getSimpleName()));
+          auditStamp, urn::getEntityType, () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
   }
@@ -206,7 +207,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result = _delegate.create(urn, aspectValues, aspectCreateLambdas, auditStamp,
         ingestionTrackingContext, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(OP_WRITE, "create", auditStamp,
+      safeEmit(OP_WRITE, "create", auditStamp, urn::getEntityType,
           () -> singleTarget(urn, aspectSimpleNames(aspectValues)));
     }
     return result;
@@ -220,7 +221,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result =
         _delegate.batchUpsert(urn, updateContexts, auditStamp, ingestionTrackingContext, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(OP_WRITE, "batchUpsert", auditStamp,
+      safeEmit(OP_WRITE, "batchUpsert", auditStamp, urn::getEntityType,
           () -> singleTarget(urn, aspectNamesFromContexts(updateContexts)));
     }
     return result;
@@ -231,7 +232,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result = _delegate.softDeleteAsset(urn, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode) {
       // Whole-entity delete: no audit stamp on this path (actor null), empty aspect list.
-      safeEmit(OP_DELETE_ALL, "softDeleteAsset", null,
+      safeEmit(OP_DELETE_ALL, "softDeleteAsset", null, urn::getEntityType,
           () -> Collections.singletonList(
               new DaoUsageTarget(urn.toString(), Collections.emptyList())));
     }
@@ -249,21 +250,37 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
    * {@link BaseDaoUsageEmitter#isEnabled()} has already been checked.
    */
   private void safeEmit(@Nonnull String operationType, @Nonnull String sourceOperation,
-      @Nullable AuditStamp auditStamp,
+      @Nullable AuditStamp auditStamp, @Nonnull Supplier<String> entityTypeSupplier,
       @Nonnull Supplier<List<DaoUsageTarget>> targetsSupplier) {
     try {
       final List<DaoUsageTarget> targets = targetsSupplier.get();
       if (targets.isEmpty()) {
         return;
       }
+      final String entityType = entityTypeSupplier.get();
+      if (entityType == null) {
+        return;
+      }
       final String actorUrn = auditStamp == null ? null : actorOf(auditStamp);
       final String impersonatorUrn = auditStamp == null ? null : impersonatorOf(auditStamp);
-      _usageEmitter.emit(operationType, _entityType, sourceOperation, actorUrn, impersonatorUrn,
+      _usageEmitter.emit(operationType, entityType, sourceOperation, actorUrn, impersonatorUrn,
           targets);
     } catch (Exception e) {
       // Fire-and-forget: never propagate an emission failure to the caller.
       log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, e);
     }
+  }
+
+  /**
+   * Entity type for a read, taken from the first key in the window the delegate actually read.
+   * Returns {@code null} when the window is empty, in which case there is nothing to report.
+   */
+  @Nullable
+  private static <URN extends Urn> String entityTypeFromKeys(
+      @Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys, int keysCount, int position) {
+    final int start = Math.max(0, position);
+    final int end = Math.min(keys.size(), start + Math.max(0, keysCount));
+    return start < end ? keys.get(start).getUrn().getEntityType() : null;
   }
 
   private static boolean isBackfill(@Nullable IngestionTrackingContext ingestionTrackingContext) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
@@ -4,6 +4,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
+import com.linkedin.metadata.dao.tracking.DaoReadContext;
 import com.linkedin.metadata.dao.tracking.DaoUsageTarget;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.events.IngestionTrackingContext;
@@ -147,7 +148,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean includeSoftDeleted, boolean isTestMode) {
     final List<EbeanMetadataAspect> result =
         _delegate.batchGetUnion(keys, keysCount, position, includeSoftDeleted, isTestMode);
-    if (_usageEmitter.isEnabled() && !isTestMode) {
+    if (_usageEmitter.isEnabled() && !isTestMode && !DaoReadContext.isInternalRead()) {
       safeEmit(OP_READ, "batchGetUnion", null, () -> targetsFromKeys(keys, keysCount, position));
     }
     return result;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
@@ -30,10 +30,11 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>Fire-and-forget: each method delegates first and returns/throws exactly what the delegate
  * does; emission happens only after success and is wrapped so it can never alter the result or
- * throw. It short-circuits with zero overhead when the emitter is disabled, and skips test-mode
- * and backfill. Reads and writes/deletes are captured; global scans, discovery and maintenance
- * are delegated without emission. Writes carry the caller from the {@link AuditStamp}; reads
- * have none.
+ * throw. Writes and deletes emit only when the delegate reports at least one affected row, so a
+ * lost optimistic-locking race is not reported as a write. It short-circuits with zero overhead
+ * when the emitter is disabled, and skips test-mode and backfill. Reads and writes/deletes are
+ * captured; global scans, discovery and maintenance are delegated without emission. Writes carry
+ * the caller from the {@link AuditStamp}; reads have none.
  *
  * @param <URN> the URN type for this entity
  */
@@ -147,7 +148,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final List<EbeanMetadataAspect> result =
         _delegate.batchGetUnion(keys, keysCount, position, includeSoftDeleted, isTestMode);
     if (_usageEmitter.isEnabled() && !isTestMode) {
-      safeEmit(OP_READ, "batchGetUnion", null, null, () -> targetsFromKeys(keys));
+      safeEmit(OP_READ, "batchGetUnion", null, () -> targetsFromKeys(keys, keysCount, position));
     }
     return result;
   }
@@ -158,7 +159,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       @Nonnull URN urn, int start, int pageSize) {
     final ListResult<ASPECT> result = _delegate.list(aspectClass, urn, start, pageSize);
     if (_usageEmitter.isEnabled()) {
-      safeEmit(OP_READ, "list", null, null,
+      safeEmit(OP_READ, "list", null,
           () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
@@ -174,9 +175,9 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode) {
     final int result =
         _delegate.add(urn, newValue, aspectClass, auditStamp, ingestionTrackingContext, isTestMode);
-    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "add", actorOf(auditStamp),
-          impersonatorOf(auditStamp), () -> singleTarget(urn, aspectClass.getSimpleName()));
+    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "add", auditStamp,
+          () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
   }
@@ -188,10 +189,9 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean isTestMode, boolean softDeleteOverwrite) {
     final int result = _delegate.addWithOptimisticLocking(urn, newValue, aspectClass, auditStamp,
         oldTimestamp, ingestionTrackingContext, isTestMode, softDeleteOverwrite);
-    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
       safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "addWithOptimisticLocking",
-          actorOf(auditStamp), impersonatorOf(auditStamp),
-          () -> singleTarget(urn, aspectClass.getSimpleName()));
+          auditStamp, () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
   }
@@ -204,8 +204,8 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean isTestMode) {
     final int result = _delegate.create(urn, aspectValues, aspectCreateLambdas, auditStamp,
         ingestionTrackingContext, isTestMode);
-    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(OP_WRITE, "create", actorOf(auditStamp), impersonatorOf(auditStamp),
+    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+      safeEmit(OP_WRITE, "create", auditStamp,
           () -> singleTarget(urn, aspectSimpleNames(aspectValues)));
     }
     return result;
@@ -218,8 +218,8 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean isTestMode) {
     final int result =
         _delegate.batchUpsert(urn, updateContexts, auditStamp, ingestionTrackingContext, isTestMode);
-    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(OP_WRITE, "batchUpsert", actorOf(auditStamp), impersonatorOf(auditStamp),
+    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+      safeEmit(OP_WRITE, "batchUpsert", auditStamp,
           () -> singleTarget(urn, aspectNamesFromContexts(updateContexts)));
     }
     return result;
@@ -228,9 +228,9 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
   @Override
   public int softDeleteAsset(@Nonnull URN urn, boolean isTestMode) {
     final int result = _delegate.softDeleteAsset(urn, isTestMode);
-    if (_usageEmitter.isEnabled() && !isTestMode) {
+    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode) {
       // Whole-entity delete: no audit stamp on this path (actor null), empty aspect list.
-      safeEmit(OP_DELETE_ALL, "softDeleteAsset", null, null,
+      safeEmit(OP_DELETE_ALL, "softDeleteAsset", null,
           () -> Collections.singletonList(
               new DaoUsageTarget(urn.toString(), Collections.emptyList())));
     }
@@ -243,16 +243,20 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
 
   /**
    * Builds the targets and emits, swallowing any exception so usage capture can never affect
-   * the DAO call. Assumes {@link BaseDaoUsageEmitter#isEnabled()} has already been checked.
+   * the DAO call. The caller is derived from the audit stamp inside the try block so a
+   * malformed stamp cannot propagate into the DAO call path. Assumes
+   * {@link BaseDaoUsageEmitter#isEnabled()} has already been checked.
    */
   private void safeEmit(@Nonnull String operationType, @Nonnull String sourceOperation,
-      @Nullable String actorUrn, @Nullable String impersonatorUrn,
+      @Nullable AuditStamp auditStamp,
       @Nonnull Supplier<List<DaoUsageTarget>> targetsSupplier) {
     try {
       final List<DaoUsageTarget> targets = targetsSupplier.get();
       if (targets.isEmpty()) {
         return;
       }
+      final String actorUrn = auditStamp == null ? null : actorOf(auditStamp);
+      final String impersonatorUrn = auditStamp == null ? null : impersonatorOf(auditStamp);
       _usageEmitter.emit(operationType, _entityType, sourceOperation, actorUrn, impersonatorUrn,
           targets);
     } catch (Exception e) {
@@ -309,12 +313,20 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
   /**
    * Groups the read keys by URN, collecting the aspect simple names per URN so a multi-URN
    * {@code batchGetUnion} produces one {@link DaoUsageTarget} per distinct URN.
+   *
+   * <p>Only the {@code [position, position + keysCount)} window is walked, mirroring the page
+   * the delegate actually reads. Callers page over the same full key list, so emitting every
+   * key on every page would report {@code keys.size()} targets per page instead of one target
+   * set per key.
    */
   @Nonnull
   private static <URN extends Urn> List<DaoUsageTarget> targetsFromKeys(
-      @Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys) {
+      @Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys, int keysCount, int position) {
+    final int start = Math.max(0, position);
+    final int end = Math.min(keys.size(), start + Math.max(0, keysCount));
     final Map<String, List<String>> byUrn = new LinkedHashMap<>();
-    for (AspectKey<URN, ? extends RecordTemplate> key : keys) {
+    for (int index = start; index < end; index++) {
+      final AspectKey<URN, ? extends RecordTemplate> key = keys.get(index);
       byUrn.computeIfAbsent(key.getUrn().toString(), k -> new ArrayList<>())
           .add(key.getAspectClass().getSimpleName());
     }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
@@ -1,0 +1,327 @@
+package com.linkedin.metadata.dao;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
+import com.linkedin.metadata.dao.tracking.DaoUsageTarget;
+import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
+import com.linkedin.metadata.events.IngestionTrackingContext;
+import com.linkedin.metadata.query.IndexFilter;
+import com.linkedin.metadata.query.IndexGroupByCriterion;
+import com.linkedin.metadata.query.IndexSortCriterion;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A decorator around {@link IEbeanLocalAccess} that emits one usage event per successful
+ * read / write / delete via a {@link BaseDaoUsageEmitter}. Wrapping the model-agnostic access
+ * layer lets a single instance capture usage for every {@link EbeanLocalDAO} consumer with no
+ * per-service code.
+ *
+ * <p>Fire-and-forget: each method delegates first and returns/throws exactly what the delegate
+ * does; emission happens only after success and is wrapped so it can never alter the result or
+ * throw. It short-circuits with zero overhead when the emitter is disabled, and skips test-mode
+ * and backfill. Reads and writes/deletes are captured; global scans, discovery and maintenance
+ * are delegated without emission. Writes carry the caller from the {@link AuditStamp}; reads
+ * have none.
+ *
+ * @param <URN> the URN type for this entity
+ */
+@Slf4j
+public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLocalAccess<URN> {
+
+  static final String OP_READ = "READ";
+  static final String OP_WRITE = "WRITE";
+  static final String OP_DELETE = "DELETE";
+  static final String OP_DELETE_ALL = "DELETE_ALL";
+
+  private final IEbeanLocalAccess<URN> _delegate;
+  private final BaseDaoUsageEmitter _usageEmitter;
+  private final String _entityType;
+
+  /**
+   * Creates a usage-tracking wrapper around the given local-access implementation.
+   *
+   * @param delegate     the real local-access implementation to wrap
+   * @param usageEmitter the usage emitter (may be a no-op)
+   * @param urnClass     the URN class, used to derive the entity type name once at construction
+   */
+  public UsageTrackingEbeanLocalAccess(@Nonnull IEbeanLocalAccess<URN> delegate,
+      @Nonnull BaseDaoUsageEmitter usageEmitter, @Nonnull Class<URN> urnClass) {
+    _delegate = delegate;
+    _usageEmitter = usageEmitter;
+    // Same derivation as InstrumentedEbeanLocalAccess to keep the entity dimension consistent.
+    _entityType = urnClass.getSimpleName().replace("Urn", "").toLowerCase();
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Pass-through (not usage-relevant): configuration / discovery / maintenance / admin
+  // ---------------------------------------------------------------------------------------
+
+  @Override
+  public void setUrnPathExtractor(@Nonnull UrnPathExtractor<URN> urnPathExtractor) {
+    _delegate.setUrnPathExtractor(urnPathExtractor);
+  }
+
+  @Override
+  public void configureOptionalForceIndex(@Nullable String indexName,
+      @Nullable Map<Class<?>, String> requiredCriteria) {
+    _delegate.configureOptionalForceIndex(indexName, requiredCriteria);
+  }
+
+  @Override
+  public Map<URN, EntityDeletionInfo> readDeletionInfoBatch(@Nonnull List<URN> urns,
+      boolean isTestMode) {
+    return _delegate.readDeletionInfoBatch(urns, isTestMode);
+  }
+
+  @Override
+  public int batchSoftDeleteAssets(@Nonnull List<URN> urns, @Nonnull String cutoffTimestamp,
+      boolean isTestMode) {
+    return _delegate.batchSoftDeleteAssets(urns, cutoffTimestamp, isTestMode);
+  }
+
+  @Override
+  public List<URN> listUrns(@Nullable IndexFilter indexFilter,
+      @Nullable IndexSortCriterion indexSortCriterion, @Nullable URN lastUrn, int pageSize) {
+    return _delegate.listUrns(indexFilter, indexSortCriterion, lastUrn, pageSize);
+  }
+
+  @Override
+  public ListResult<URN> listUrns(@Nullable IndexFilter indexFilter,
+      @Nullable IndexSortCriterion indexSortCriterion, int start, int pageSize) {
+    return _delegate.listUrns(indexFilter, indexSortCriterion, start, pageSize);
+  }
+
+  @Override
+  public boolean exists(@Nonnull URN urn) {
+    return _delegate.exists(urn);
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, Long> countAggregate(@Nullable IndexFilter indexFilter,
+      @Nonnull IndexGroupByCriterion indexGroupByCriterion) {
+    return _delegate.countAggregate(indexFilter, indexGroupByCriterion);
+  }
+
+  @Nonnull
+  @Override
+  public <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull Class<ASPECT> aspectClass,
+      int start, int pageSize) {
+    return _delegate.listUrns(aspectClass, start, pageSize);
+  }
+
+  @Nonnull
+  @Override
+  public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
+      int start, int pageSize) {
+    // Global cross-URN scan -- no single-entity target, not captured as usage.
+    return _delegate.list(aspectClass, start, pageSize);
+  }
+
+  @Override
+  public void ensureSchemaUpToDate() {
+    _delegate.ensureSchemaUpToDate();
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------------------
+
+  @Nonnull
+  @Override
+  public <ASPECT extends RecordTemplate> List<EbeanMetadataAspect> batchGetUnion(
+      @Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys, int keysCount, int position,
+      boolean includeSoftDeleted, boolean isTestMode) {
+    final List<EbeanMetadataAspect> result =
+        _delegate.batchGetUnion(keys, keysCount, position, includeSoftDeleted, isTestMode);
+    if (_usageEmitter.isEnabled() && !isTestMode) {
+      safeEmit(OP_READ, "batchGetUnion", null, null, () -> targetsFromKeys(keys));
+    }
+    return result;
+  }
+
+  @Nonnull
+  @Override
+  public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
+      @Nonnull URN urn, int start, int pageSize) {
+    final ListResult<ASPECT> result = _delegate.list(aspectClass, urn, start, pageSize);
+    if (_usageEmitter.isEnabled()) {
+      safeEmit(OP_READ, "list", null, null,
+          () -> singleTarget(urn, aspectClass.getSimpleName()));
+    }
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Writes / deletes
+  // ---------------------------------------------------------------------------------------
+
+  @Override
+  public <ASPECT extends RecordTemplate> int add(@Nonnull URN urn, @Nullable ASPECT newValue,
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp,
+      @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode) {
+    final int result =
+        _delegate.add(urn, newValue, aspectClass, auditStamp, ingestionTrackingContext, isTestMode);
+    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "add", actorOf(auditStamp),
+          impersonatorOf(auditStamp), () -> singleTarget(urn, aspectClass.getSimpleName()));
+    }
+    return result;
+  }
+
+  @Override
+  public <ASPECT extends RecordTemplate> int addWithOptimisticLocking(@Nonnull URN urn,
+      @Nullable ASPECT newValue, @Nonnull Class<ASPECT> aspectClass, @Nonnull AuditStamp auditStamp,
+      @Nullable Timestamp oldTimestamp, @Nullable IngestionTrackingContext ingestionTrackingContext,
+      boolean isTestMode, boolean softDeleteOverwrite) {
+    final int result = _delegate.addWithOptimisticLocking(urn, newValue, aspectClass, auditStamp,
+        oldTimestamp, ingestionTrackingContext, isTestMode, softDeleteOverwrite);
+    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "addWithOptimisticLocking",
+          actorOf(auditStamp), impersonatorOf(auditStamp),
+          () -> singleTarget(urn, aspectClass.getSimpleName()));
+    }
+    return result;
+  }
+
+  @Override
+  public <ASPECT_UNION extends RecordTemplate> int create(@Nonnull URN urn,
+      @Nonnull List<? extends RecordTemplate> aspectValues,
+      @Nonnull List<BaseLocalDAO.AspectCreateLambda<? extends RecordTemplate>> aspectCreateLambdas,
+      @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext ingestionTrackingContext,
+      boolean isTestMode) {
+    final int result = _delegate.create(urn, aspectValues, aspectCreateLambdas, auditStamp,
+        ingestionTrackingContext, isTestMode);
+    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+      safeEmit(OP_WRITE, "create", actorOf(auditStamp), impersonatorOf(auditStamp),
+          () -> singleTarget(urn, aspectSimpleNames(aspectValues)));
+    }
+    return result;
+  }
+
+  @Override
+  public <ASPECT_UNION extends RecordTemplate> int batchUpsert(@Nonnull URN urn,
+      @Nonnull List<BaseLocalDAO.AspectUpdateContext<RecordTemplate>> updateContexts,
+      @Nonnull AuditStamp auditStamp, @Nullable IngestionTrackingContext ingestionTrackingContext,
+      boolean isTestMode) {
+    final int result =
+        _delegate.batchUpsert(urn, updateContexts, auditStamp, ingestionTrackingContext, isTestMode);
+    if (_usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+      safeEmit(OP_WRITE, "batchUpsert", actorOf(auditStamp), impersonatorOf(auditStamp),
+          () -> singleTarget(urn, aspectNamesFromContexts(updateContexts)));
+    }
+    return result;
+  }
+
+  @Override
+  public int softDeleteAsset(@Nonnull URN urn, boolean isTestMode) {
+    final int result = _delegate.softDeleteAsset(urn, isTestMode);
+    if (_usageEmitter.isEnabled() && !isTestMode) {
+      // Whole-entity delete: no audit stamp on this path (actor null), empty aspect list.
+      safeEmit(OP_DELETE_ALL, "softDeleteAsset", null, null,
+          () -> Collections.singletonList(
+              new DaoUsageTarget(urn.toString(), Collections.emptyList())));
+    }
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * Builds the targets and emits, swallowing any exception so usage capture can never affect
+   * the DAO call. Assumes {@link BaseDaoUsageEmitter#isEnabled()} has already been checked.
+   */
+  private void safeEmit(@Nonnull String operationType, @Nonnull String sourceOperation,
+      @Nullable String actorUrn, @Nullable String impersonatorUrn,
+      @Nonnull Supplier<List<DaoUsageTarget>> targetsSupplier) {
+    try {
+      final List<DaoUsageTarget> targets = targetsSupplier.get();
+      if (targets.isEmpty()) {
+        return;
+      }
+      _usageEmitter.emit(operationType, _entityType, sourceOperation, actorUrn, impersonatorUrn,
+          targets);
+    } catch (Exception e) {
+      // Fire-and-forget: never propagate an emission failure to the caller.
+      log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, e);
+    }
+  }
+
+  private static boolean isBackfill(@Nullable IngestionTrackingContext ingestionTrackingContext) {
+    return ingestionTrackingContext != null && ingestionTrackingContext.isBackfill();
+  }
+
+  @Nonnull
+  private static String actorOf(@Nonnull AuditStamp auditStamp) {
+    return auditStamp.getActor().toString();
+  }
+
+  @Nullable
+  private static String impersonatorOf(@Nonnull AuditStamp auditStamp) {
+    return auditStamp.hasImpersonator() ? auditStamp.getImpersonator().toString() : null;
+  }
+
+  @Nonnull
+  private List<DaoUsageTarget> singleTarget(@Nonnull URN urn, @Nonnull String aspectSimpleName) {
+    return Collections.singletonList(
+        new DaoUsageTarget(urn.toString(), Collections.singletonList(aspectSimpleName)));
+  }
+
+  @Nonnull
+  private List<DaoUsageTarget> singleTarget(@Nonnull URN urn, @Nonnull List<String> aspectNames) {
+    return Collections.singletonList(new DaoUsageTarget(urn.toString(), aspectNames));
+  }
+
+  @Nonnull
+  private static List<String> aspectSimpleNames(
+      @Nonnull List<? extends RecordTemplate> aspectValues) {
+    final List<String> names = new ArrayList<>(aspectValues.size());
+    for (RecordTemplate aspect : aspectValues) {
+      names.add(aspect.getClass().getSimpleName());
+    }
+    return names;
+  }
+
+  @Nonnull
+  private static List<String> aspectNamesFromContexts(
+      @Nonnull List<BaseLocalDAO.AspectUpdateContext<RecordTemplate>> updateContexts) {
+    final List<String> names = new ArrayList<>(updateContexts.size());
+    for (BaseLocalDAO.AspectUpdateContext<RecordTemplate> context : updateContexts) {
+      names.add(context.getLambda().getAspectClass().getSimpleName());
+    }
+    return names;
+  }
+
+  /**
+   * Groups the read keys by URN, collecting the aspect simple names per URN so a multi-URN
+   * {@code batchGetUnion} produces one {@link DaoUsageTarget} per distinct URN.
+   */
+  @Nonnull
+  private static <URN extends Urn> List<DaoUsageTarget> targetsFromKeys(
+      @Nonnull List<AspectKey<URN, ? extends RecordTemplate>> keys) {
+    final Map<String, List<String>> byUrn = new LinkedHashMap<>();
+    for (AspectKey<URN, ? extends RecordTemplate> key : keys) {
+      byUrn.computeIfAbsent(key.getUrn().toString(), k -> new ArrayList<>())
+          .add(key.getAspectClass().getSimpleName());
+    }
+    final List<DaoUsageTarget> targets = new ArrayList<>(byUrn.size());
+    for (Map.Entry<String, List<String>> entry : byUrn.entrySet()) {
+      targets.add(new DaoUsageTarget(entry.getKey(), entry.getValue()));
+    }
+    return targets;
+  }
+}

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
@@ -5,6 +5,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.DaoReadContext;
+import com.linkedin.metadata.dao.tracking.DaoUsageBuffer;
 import com.linkedin.metadata.dao.tracking.DaoUsageTarget;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.events.IngestionTrackingContext;
@@ -153,7 +154,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final List<EbeanMetadataAspect> result =
         _delegate.batchGetUnion(keys, keysCount, position, includeSoftDeleted, isTestMode);
     if (_usageEmitter.isEnabled() && !isTestMode && !DaoReadContext.isInternalRead()) {
-      safeEmit(OP_READ, "batchGetUnion", null, () -> entityTypeFromKeys(keys, keysCount, position),
+      emitRead("batchGetUnion", () -> entityTypeFromKeys(keys, keysCount, position),
           () -> targetsFromKeys(keys, keysCount, position));
     }
     return result;
@@ -165,7 +166,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       @Nonnull URN urn, int start, int pageSize) {
     final ListResult<ASPECT> result = _delegate.list(aspectClass, urn, start, pageSize);
     if (_usageEmitter.isEnabled() && !DaoReadContext.isInternalRead()) {
-      safeEmit(OP_READ, "list", null, urn::getEntityType,
+      emitRead("list", urn::getEntityType,
           () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
@@ -182,8 +183,8 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result =
         _delegate.add(urn, newValue, aspectClass, auditStamp, ingestionTrackingContext, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "add", auditStamp, urn::getEntityType,
-          () -> singleTarget(urn, aspectClass.getSimpleName()));
+      emitWriteOnCommit(newValue != null ? OP_WRITE : OP_DELETE, "add", auditStamp,
+          urn::getEntityType, () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
   }
@@ -196,7 +197,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result = _delegate.addWithOptimisticLocking(urn, newValue, aspectClass, auditStamp,
         oldTimestamp, ingestionTrackingContext, isTestMode, softDeleteOverwrite);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(newValue != null ? OP_WRITE : OP_DELETE, "addWithOptimisticLocking",
+      emitWriteOnCommit(newValue != null ? OP_WRITE : OP_DELETE, "addWithOptimisticLocking",
           auditStamp, urn::getEntityType, () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
     return result;
@@ -211,7 +212,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result = _delegate.create(urn, aspectValues, aspectCreateLambdas, auditStamp,
         ingestionTrackingContext, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(OP_WRITE, "create", auditStamp, urn::getEntityType,
+      emitWriteOnCommit(OP_WRITE, "create", auditStamp, urn::getEntityType,
           () -> singleTarget(urn, aspectSimpleNames(aspectValues)));
     }
     return result;
@@ -225,7 +226,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result =
         _delegate.batchUpsert(urn, updateContexts, auditStamp, ingestionTrackingContext, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
-      safeEmit(OP_WRITE, "batchUpsert", auditStamp, urn::getEntityType,
+      emitWriteOnCommit(OP_WRITE, "batchUpsert", auditStamp, urn::getEntityType,
           () -> singleTarget(urn, aspectNamesFromContexts(updateContexts)));
     }
     return result;
@@ -236,7 +237,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     final int result = _delegate.softDeleteAsset(urn, isTestMode);
     if (result > 0 && _usageEmitter.isEnabled() && !isTestMode) {
       // Whole-entity delete: no audit stamp on this path (actor null), empty aspect list.
-      safeEmit(OP_DELETE_ALL, "softDeleteAsset", null, urn::getEntityType,
+      emitWriteOnCommit(OP_DELETE_ALL, "softDeleteAsset", null, urn::getEntityType,
           () -> Collections.singletonList(
               new DaoUsageTarget(urn.toString(), Collections.emptyList())));
     }
@@ -252,10 +253,12 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
    * the DAO call. The caller is derived from the audit stamp inside the try block so a
    * malformed stamp cannot propagate into the DAO call path. Assumes
    * {@link BaseDaoUsageEmitter#isEnabled()} has already been checked.
+   *
+   * @param deferUntilCommit when true the emission is held until the enclosing transaction commits
    */
   private void safeEmit(@Nonnull String operationType, @Nonnull String sourceOperation,
       @Nullable AuditStamp auditStamp, @Nonnull Supplier<String> entityTypeSupplier,
-      @Nonnull Supplier<List<DaoUsageTarget>> targetsSupplier) {
+      @Nonnull Supplier<List<DaoUsageTarget>> targetsSupplier, boolean deferUntilCommit) {
     try {
       final List<DaoUsageTarget> targets = targetsSupplier.get();
       if (targets.isEmpty()) {
@@ -267,10 +270,52 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       }
       final String actorUrn = auditStamp == null ? null : actorOf(auditStamp);
       final String impersonatorUrn = auditStamp == null ? null : impersonatorOf(auditStamp);
+      // Everything is resolved eagerly here so a deferred emission cannot observe state that
+      // changed between the write and the commit.
+      final Runnable emission =
+          () -> emitQuietly(operationType, entityType, sourceOperation, actorUrn, impersonatorUrn,
+              targets);
+      if (deferUntilCommit) {
+        DaoUsageBuffer.record(emission);
+      } else {
+        emission.run();
+      }
+    } catch (Exception e) {
+      // Fire-and-forget: never propagate an emission failure to the caller.
+      log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, e);
+    }
+  }
+
+  /**
+   * Emits a read immediately. A read that was served happened regardless of whether a later write
+   * in the same transaction rolls back.
+   */
+  private void emitRead(@Nonnull String sourceOperation, @Nonnull Supplier<String> entityTypeSupplier,
+      @Nonnull Supplier<List<DaoUsageTarget>> targetsSupplier) {
+    safeEmit(OP_READ, sourceOperation, null, entityTypeSupplier, targetsSupplier, false);
+  }
+
+  /**
+   * Holds a write or delete until the enclosing transaction commits, so a rolled-back write is
+   * never reported and a retried transaction is reported once.
+   */
+  private void emitWriteOnCommit(@Nonnull String operationType, @Nonnull String sourceOperation,
+      @Nullable AuditStamp auditStamp, @Nonnull Supplier<String> entityTypeSupplier,
+      @Nonnull Supplier<List<DaoUsageTarget>> targetsSupplier) {
+    safeEmit(operationType, sourceOperation, auditStamp, entityTypeSupplier, targetsSupplier, true);
+  }
+
+  /**
+   * Performs the actual emission, guarded so a failure can never escape -- including when it runs
+   * later at transaction-commit time, away from the original call site.
+   */
+  private void emitQuietly(@Nonnull String operationType, @Nonnull String entityType,
+      @Nonnull String sourceOperation, @Nullable String actorUrn, @Nullable String impersonatorUrn,
+      @Nonnull List<DaoUsageTarget> targets) {
+    try {
       _usageEmitter.emit(operationType, entityType, sourceOperation, actorUrn, impersonatorUrn,
           targets);
     } catch (Exception e) {
-      // Fire-and-forget: never propagate an emission failure to the caller.
       log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, e);
     }
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
@@ -37,6 +37,10 @@ import lombok.extern.slf4j.Slf4j;
  * captured; global scans, discovery and maintenance are delegated without emission. Writes carry
  * the caller from the {@link AuditStamp}; reads have none.
  *
+ * <p>All captured reads honor {@link DaoReadContext}: a read taken inside a marked scope is not
+ * attributable to a consumer (read-before-write, backfill) and is skipped, so the rule is the same
+ * for every read method rather than special-cased per method.
+ *
  * <p>The entity type is taken from {@link Urn#getEntityType()} on the URN being operated on, so it
  * matches the canonical entity type used elsewhere (e.g. {@code mlModel}) rather than a value
  * derived from the URN class name.
@@ -160,7 +164,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
   public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull URN urn, int start, int pageSize) {
     final ListResult<ASPECT> result = _delegate.list(aspectClass, urn, start, pageSize);
-    if (_usageEmitter.isEnabled()) {
+    if (_usageEmitter.isEnabled() && !DaoReadContext.isInternalRead()) {
       safeEmit(OP_READ, "list", null, urn::getEntityType,
           () -> singleTarget(urn, aspectClass.getSimpleName()));
     }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -31,6 +31,7 @@ import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.dao.storage.LocalDAOStorageConfig;
 import com.linkedin.metadata.dao.tracking.BaseDaoBenchmarkMetrics;
+import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.utils.BarUrnPathExtractor;
@@ -327,6 +328,29 @@ public class EbeanLocalDAOTest {
     dao.setBenchmarkMetrics(mockMetrics);
 
     // In OLD_SCHEMA_ONLY, setBenchmarkMetrics is a no-op — no exception, no effect
+  }
+
+  @Test
+  public void testSetUsageEmitterIsIdempotentUnderOtherDecorators() throws Exception {
+    if (_schemaConfig != SchemaConfig.NEW_SCHEMA_ONLY) {
+      // Only the new-schema path routes writes through _localAccess, where the decorator lives.
+      return;
+    }
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+    BaseDaoUsageEmitter mockEmitter = mock(BaseDaoUsageEmitter.class);
+    when(mockEmitter.isEnabled()).thenReturn(true);
+    BaseDaoBenchmarkMetrics mockMetrics = mock(BaseDaoBenchmarkMetrics.class);
+    when(mockMetrics.isEnabled()).thenReturn(false);
+
+    // setBenchmarkMetrics buries the usage decorator one layer down, so a structural instanceof
+    // check on the outermost layer would miss it and stack a second usage decorator.
+    dao.setUsageEmitter(mockEmitter);
+    dao.setBenchmarkMetrics(mockMetrics);
+    dao.setUsageEmitter(mockEmitter);
+
+    dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
+
+    verify(mockEmitter, times(1)).emit(eq("WRITE"), anyString(), anyString(), any(), any(), any());
   }
 
   @Test(expectedExceptions = InvalidMetadataType.class)

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.mockito.ArgumentCaptor;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -70,12 +69,6 @@ public class UsageTrackingEbeanLocalAccessTest {
     return ArgumentCaptor.forClass(List.class);
   }
 
-  @AfterMethod
-  public void tearDown() {
-    // Defensive: never let an internal-read marker leak into the next test on a reused thread.
-    DaoReadContext.clear();
-  }
-
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void testInternalReadIsNotEmitted() {
@@ -84,11 +77,8 @@ public class UsageTrackingEbeanLocalAccessTest {
     List<AspectKey<FooUrn, ? extends RecordTemplate>> keys =
         (List) Collections.singletonList(new AspectKey<>(AspectFoo.class, _urn1, 0L));
 
-    DaoReadContext.markInternalRead();
-    try {
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
       _usage.batchGetUnion(keys, 1, 0, true, false);
-    } finally {
-      DaoReadContext.clear();
     }
 
     // Read-before-write is marked internal, so it is not counted as a consumer read.
@@ -97,16 +87,40 @@ public class UsageTrackingEbeanLocalAccessTest {
 
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public void testConsumerReadStillEmittedAfterInternalMarkerCleared() {
+  public void testConsumerReadStillEmittedAfterInternalScopeCloses() {
     when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
         .thenReturn(Collections.emptyList());
     List<AspectKey<FooUrn, ? extends RecordTemplate>> keys =
         (List) Collections.singletonList(new AspectKey<>(AspectFoo.class, _urn1, 0L));
 
-    // Once the marker is cleared, a genuine consumer read is emitted as normal.
+    // A read-before-write inside the scope is skipped...
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+      _usage.batchGetUnion(keys, 1, 0, true, false);
+    }
+    // ...and once the scope closes, a genuine consumer read is emitted as normal.
     _usage.batchGetUnion(keys, 1, 0, false, false);
 
-    verify(_mockEmitter).emit(eq("READ"), eq("foo"), eq("batchGetUnion"), isNull(), isNull(), any());
+    verify(_mockEmitter, times(1))
+        .emit(eq("READ"), eq("foo"), eq("batchGetUnion"), isNull(), isNull(), any());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testNestedInternalScopesDoNotUnmarkOuterRead() {
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys =
+        (List) Collections.singletonList(new AspectKey<>(AspectFoo.class, _urn1, 0L));
+
+    try (DaoReadContext.Scope outer = DaoReadContext.markInternalRead()) {
+      try (DaoReadContext.Scope inner = DaoReadContext.markInternalRead()) {
+        _usage.batchGetUnion(keys, 1, 0, true, false);
+      }
+      // The inner scope closing must not unmark the outer region, so this read is still internal.
+      _usage.batchGetUnion(keys, 1, 0, true, false);
+    }
+
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
   }
 
   // ---------------------------------------------------------------------------------------

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -188,6 +188,23 @@ public class UsageTrackingEbeanLocalAccessTest {
 
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testListByUrnIsNotEmittedInsideInternalScope() {
+    ListResult<AspectFoo> expected = mock(ListResult.class);
+    when(_mockDelegate.list(any(Class.class), any(), anyInt(), anyInt())).thenReturn(expected);
+
+    // Every captured read honors the marker, not just batchGetUnion, so a read taken inside a
+    // marked region (e.g. backfill) is never billed to a consumer.
+    ListResult<AspectFoo> result;
+    try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead()) {
+      result = _usage.list(AspectFoo.class, _urn1, 0, 10);
+    }
+
+    assertSame(result, expected);
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
   public void testBatchGetUnionEmitsOnlyThePagedWindow() {
     // Callers page over the SAME full key list, advancing only position (see
     // EbeanLocalDAO#batchGet). Each page must report only the window the delegate reads,

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -11,9 +11,12 @@ import com.linkedin.metadata.query.IndexSortCriterion;
 import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.urn.FooUrn;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -108,6 +111,65 @@ public class UsageTrackingEbeanLocalAccessTest {
         targets.capture());
     assertEquals(targets.getValue().get(0).getUrn(), _urn1.toString());
     assertEquals(targets.getValue().get(0).getAspects(), Collections.singletonList("AspectFoo"));
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testBatchGetUnionEmitsOnlyThePagedWindow() {
+    // Callers page over the SAME full key list, advancing only position (see
+    // EbeanLocalDAO#batchGet). Each page must report only the window the delegate reads,
+    // otherwise every key is re-reported on every page.
+    final int totalKeys = 120;
+    final int keysCount = 50;
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = new ArrayList<>();
+    for (int i = 0; i < totalKeys; i++) {
+      keys.add(new AspectKey<>(AspectFoo.class, makeFooUrn(i), 0L));
+    }
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+
+    for (int position = 0; position < totalKeys; position += keysCount) {
+      _usage.batchGetUnion((List) keys, keysCount, position, false, false);
+    }
+
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter, times(3)).emit(eq("READ"), eq("foo"), eq("batchGetUnion"), isNull(),
+        isNull(), targets.capture());
+
+    List<List<DaoUsageTarget>> pages = targets.getAllValues();
+    assertEquals(pages.get(0).size(), keysCount);
+    assertEquals(pages.get(1).size(), keysCount);
+    assertEquals(pages.get(2).size(), totalKeys - (2 * keysCount));
+
+    // Every key reported exactly once across all pages.
+    Set<String> seen = new HashSet<>();
+    for (List<DaoUsageTarget> page : pages) {
+      for (DaoUsageTarget target : page) {
+        assertTrue(seen.add(target.getUrn()), "urn reported on more than one page: " + target.getUrn());
+      }
+    }
+    assertEquals(seen.size(), totalKeys);
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testBatchGetUnionWindowIsClampedToKeyList() {
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = (List) Arrays.asList(
+        new AspectKey<>(AspectFoo.class, _urn1, 0L),
+        new AspectKey<>(AspectFoo.class, _urn2, 0L));
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+
+    // Position past the end: nothing was read, so nothing is emitted.
+    _usage.batchGetUnion((List) keys, 50, 100, false, false);
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+
+    // keysCount larger than the list: clamps to the available keys.
+    _usage.batchGetUnion((List) keys, 50, 0, false, false);
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter).emit(eq("READ"), eq("foo"), eq("batchGetUnion"), isNull(), isNull(),
+        targets.capture());
+    assertEquals(targets.getValue().size(), 2);
   }
 
   // ---------------------------------------------------------------------------------------
@@ -281,6 +343,21 @@ public class UsageTrackingEbeanLocalAccessTest {
     int result = _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null, false);
 
     assertEquals(result, 3);
+  }
+
+  @Test
+  public void testPartialAuditStampDoesNotPropagate() {
+    // actor is a required field: AuditStamp#getActor() uses GetMode.STRICT and throws on a
+    // partial record. Deriving the caller must stay inside the emitter's failure boundary so a
+    // malformed stamp cannot surface after the write has already succeeded.
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(5);
+    AuditStamp partial = new AuditStamp().setTime(0L);
+
+    int result = _usage.add(_urn1, new AspectFoo(), AspectFoo.class, partial, null, false);
+
+    assertEquals(result, 5);
+    verify(_mockDelegate).add(any(), any(), any(), any(), any(), anyBoolean());
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -59,6 +59,9 @@ public class UsageTrackingEbeanLocalAccessTest {
     when(_mockEmitter.isEnabled()).thenReturn(true);
 
     _usage = new UsageTrackingEbeanLocalAccess<>(_mockDelegate, _mockEmitter);
+    // Installing an emitter arms the transaction buffer; these tests drive enter()/exit() directly,
+    // so arm it here to mirror a DAO that has had setUsageEmitter() called.
+    DaoUsageBuffer.arm();
 
     _urn1 = makeFooUrn(1);
     _urn2 = makeFooUrn(2);
@@ -401,6 +404,37 @@ public class UsageTrackingEbeanLocalAccessTest {
         isNull(), targets.capture());
     assertEquals(targets.getValue().get(0).getUrn(), _urn1.toString());
     assertTrue(targets.getValue().get(0).getAspects().isEmpty());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testZeroAffectedRowsSuppressesEmission() {
+    // Every write/delete method gates emission on the delegate reporting an affected row
+    // (result > 0). A no-op operation (result == 0) must not emit. Covers all five gated methods:
+    // add, addWithOptimisticLocking, create, batchUpsert, softDeleteAsset.
+    AspectFoo value = new AspectFoo();
+    BaseLocalDAO.AspectUpdateLambda lambda = new BaseLocalDAO.AspectUpdateLambda(value);
+    BaseLocalDAO.AspectUpdateContext ctx = new BaseLocalDAO.AspectUpdateContext(null, value, lambda);
+    List<BaseLocalDAO.AspectUpdateContext<RecordTemplate>> contexts =
+        (List) Collections.singletonList(ctx);
+
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(0);
+    when(_mockDelegate.addWithOptimisticLocking(any(), any(), any(), any(), any(), any(),
+        anyBoolean(), anyBoolean())).thenReturn(0);
+    when(_mockDelegate.create(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(0);
+    when(_mockDelegate.batchUpsert(any(), any(), any(), any(), anyBoolean())).thenReturn(0);
+    when(_mockDelegate.softDeleteAsset(any(), anyBoolean())).thenReturn(0);
+
+    _usage.add(_urn1, value, AspectFoo.class, _auditStamp, null, false);
+    _usage.addWithOptimisticLocking(_urn1, value, AspectFoo.class, _auditStamp, null, null, false,
+        false);
+    _usage.create(_urn1, Collections.singletonList(value), Collections.emptyList(), _auditStamp,
+        null, false);
+    _usage.batchUpsert(_urn1, contexts, _auditStamp, null, false);
+    _usage.softDeleteAsset(_urn1, false);
+
+    // No affected rows on any path -> no usage events at all.
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
   }
 
   @Test

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -1,0 +1,296 @@
+package com.linkedin.metadata.dao;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
+import com.linkedin.metadata.dao.tracking.DaoUsageTarget;
+import com.linkedin.metadata.events.IngestionTrackingContext;
+import com.linkedin.metadata.query.IndexFilter;
+import com.linkedin.metadata.query.IndexGroupByCriterion;
+import com.linkedin.metadata.query.IndexSortCriterion;
+import com.linkedin.testing.AspectBar;
+import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.urn.FooUrn;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.linkedin.testing.TestUtils.makeFooUrn;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests for {@link UsageTrackingEbeanLocalAccess}. Verifies:
+ * <ul>
+ *   <li>Each captured operation maps to the right operationType, entityType, source and targets</li>
+ *   <li>batchGetUnion groups aspects per URN</li>
+ *   <li>Writes/deletes carry the caller from the audit stamp; reads and DELETE_ALL do not</li>
+ *   <li>Excluded, test-mode and backfill operations do not emit</li>
+ *   <li>The emitter is fail-open (its exceptions never propagate) and disabled = zero interaction</li>
+ *   <li>The delegate's return value is always passed through unchanged</li>
+ * </ul>
+ */
+public class UsageTrackingEbeanLocalAccessTest {
+
+  private IEbeanLocalAccess<FooUrn> _mockDelegate;
+  private BaseDaoUsageEmitter _mockEmitter;
+  private UsageTrackingEbeanLocalAccess<FooUrn> _usage;
+
+  private FooUrn _urn1;
+  private FooUrn _urn2;
+  private FooUrn _actor;
+  private AuditStamp _auditStamp;
+
+  @SuppressWarnings("unchecked")
+  @BeforeMethod
+  public void setUp() {
+    _mockDelegate = mock(IEbeanLocalAccess.class);
+    _mockEmitter = mock(BaseDaoUsageEmitter.class);
+    when(_mockEmitter.isEnabled()).thenReturn(true);
+
+    _usage = new UsageTrackingEbeanLocalAccess<>(_mockDelegate, _mockEmitter, FooUrn.class);
+
+    _urn1 = makeFooUrn(1);
+    _urn2 = makeFooUrn(2);
+    _actor = makeFooUrn(99);
+    _auditStamp = new AuditStamp().setActor(_actor).setTime(0L);
+  }
+
+  @SuppressWarnings("unchecked")
+  private ArgumentCaptor<List<DaoUsageTarget>> targetsCaptor() {
+    return ArgumentCaptor.forClass(List.class);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testBatchGetUnionEmitsReadGroupedByUrn() {
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys = (List) Arrays.asList(
+        new AspectKey<>(AspectFoo.class, _urn1, 0L),
+        new AspectKey<>(AspectBar.class, _urn1, 0L),
+        new AspectKey<>(AspectFoo.class, _urn2, 0L));
+    List<EbeanMetadataAspect> expected = Collections.emptyList();
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(expected);
+
+    List<EbeanMetadataAspect> result = _usage.batchGetUnion(keys, 3, 0, false, false);
+
+    assertSame(result, expected);
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter).emit(eq("READ"), eq("foo"), eq("batchGetUnion"), isNull(), isNull(),
+        targets.capture());
+    List<DaoUsageTarget> captured = targets.getValue();
+    assertEquals(captured.size(), 2);
+    assertEquals(captured.get(0).getUrn(), _urn1.toString());
+    assertEquals(captured.get(0).getAspects(), Arrays.asList("AspectFoo", "AspectBar"));
+    assertEquals(captured.get(1).getUrn(), _urn2.toString());
+    assertEquals(captured.get(1).getAspects(), Collections.singletonList("AspectFoo"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testListByUrnEmitsRead() {
+    ListResult<AspectFoo> expected = mock(ListResult.class);
+    when(_mockDelegate.list(any(Class.class), any(), anyInt(), anyInt())).thenReturn(expected);
+
+    ListResult<AspectFoo> result = _usage.list(AspectFoo.class, _urn1, 0, 10);
+
+    assertSame(result, expected);
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter).emit(eq("READ"), eq("foo"), eq("list"), isNull(), isNull(),
+        targets.capture());
+    assertEquals(targets.getValue().get(0).getUrn(), _urn1.toString());
+    assertEquals(targets.getValue().get(0).getAspects(), Collections.singletonList("AspectFoo"));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Writes / deletes
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  public void testAddWithValueEmitsWriteWithActor() {
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    int result = _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null, false);
+
+    assertEquals(result, 1);
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter).emit(eq("WRITE"), eq("foo"), eq("add"), eq(_actor.toString()), isNull(),
+        targets.capture());
+    assertEquals(targets.getValue().get(0).getUrn(), _urn1.toString());
+    assertEquals(targets.getValue().get(0).getAspects(), Collections.singletonList("AspectFoo"));
+  }
+
+  @Test
+  public void testAddNullValueEmitsDelete() {
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    _usage.add(_urn1, null, AspectFoo.class, _auditStamp, null, false);
+
+    verify(_mockEmitter).emit(eq("DELETE"), eq("foo"), eq("add"), eq(_actor.toString()), isNull(),
+        any());
+  }
+
+  @Test
+  public void testAddWithOptimisticLockingEmitsWrite() {
+    when(_mockDelegate.addWithOptimisticLocking(any(), any(), any(), any(), any(), any(),
+        anyBoolean(), anyBoolean())).thenReturn(1);
+
+    _usage.addWithOptimisticLocking(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null,
+        null, false, false);
+
+    verify(_mockEmitter).emit(eq("WRITE"), eq("foo"), eq("addWithOptimisticLocking"),
+        eq(_actor.toString()), isNull(), any());
+  }
+
+  @Test
+  public void testCreateEmitsWrite() {
+    when(_mockDelegate.create(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    int result = _usage.create(_urn1, Collections.singletonList(new AspectFoo()),
+        Collections.emptyList(), _auditStamp, null, false);
+
+    assertEquals(result, 1);
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter).emit(eq("WRITE"), eq("foo"), eq("create"), eq(_actor.toString()), isNull(),
+        targets.capture());
+    assertEquals(targets.getValue().get(0).getAspects(), Collections.singletonList("AspectFoo"));
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testBatchUpsertEmitsWrite() {
+    AspectFoo value = new AspectFoo();
+    BaseLocalDAO.AspectUpdateLambda lambda = new BaseLocalDAO.AspectUpdateLambda(value);
+    BaseLocalDAO.AspectUpdateContext ctx = new BaseLocalDAO.AspectUpdateContext(null, value, lambda);
+    List<BaseLocalDAO.AspectUpdateContext<RecordTemplate>> contexts =
+        (List) Collections.singletonList(ctx);
+    when(_mockDelegate.batchUpsert(any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    int result = _usage.batchUpsert(_urn1, contexts, _auditStamp, null, false);
+
+    assertEquals(result, 1);
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter).emit(eq("WRITE"), eq("foo"), eq("batchUpsert"), eq(_actor.toString()),
+        isNull(), targets.capture());
+    assertEquals(targets.getValue().get(0).getUrn(), _urn1.toString());
+    assertEquals(targets.getValue().get(0).getAspects(), Collections.singletonList("AspectFoo"));
+  }
+
+  @Test
+  public void testSoftDeleteAssetEmitsDeleteAllWithEmptyAspects() {
+    when(_mockDelegate.softDeleteAsset(any(), anyBoolean())).thenReturn(1);
+
+    _usage.softDeleteAsset(_urn1, false);
+
+    ArgumentCaptor<List<DaoUsageTarget>> targets = targetsCaptor();
+    verify(_mockEmitter).emit(eq("DELETE_ALL"), eq("foo"), eq("softDeleteAsset"), isNull(),
+        isNull(), targets.capture());
+    assertEquals(targets.getValue().get(0).getUrn(), _urn1.toString());
+    assertTrue(targets.getValue().get(0).getAspects().isEmpty());
+  }
+
+  @Test
+  public void testImpersonatorPopulatedOnWrite() {
+    FooUrn impersonator = makeFooUrn(500);
+    AuditStamp stamp = new AuditStamp().setActor(_actor).setImpersonator(impersonator).setTime(0L);
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    _usage.add(_urn1, new AspectFoo(), AspectFoo.class, stamp, null, false);
+
+    verify(_mockEmitter).emit(eq("WRITE"), eq("foo"), eq("add"), eq(_actor.toString()),
+        eq(impersonator.toString()), any());
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Exclusions and safety
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testTestModeSkipsEmission() {
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+
+    _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null, true);
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys =
+        (List) Collections.singletonList(new AspectKey<>(AspectFoo.class, _urn1, 0L));
+    _usage.batchGetUnion(keys, 1, 0, false, true);
+
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  public void testBackfillSkipsEmission() {
+    IngestionTrackingContext backfillContext = new IngestionTrackingContext().setBackfill(true);
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, backfillContext, false);
+
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testExcludedMethodsDoNotEmit() {
+    when(_mockDelegate.exists(any())).thenReturn(true);
+    when(_mockDelegate.list(any(Class.class), anyInt(), anyInt())).thenReturn(mock(ListResult.class));
+    when(_mockDelegate.countAggregate(any(), any())).thenReturn(Collections.emptyMap());
+    when(_mockDelegate.batchSoftDeleteAssets(any(), any(), anyBoolean())).thenReturn(0);
+    when(_mockDelegate.readDeletionInfoBatch(any(), anyBoolean())).thenReturn(Collections.emptyMap());
+    when(_mockDelegate.listUrns(any(IndexFilter.class), any(IndexSortCriterion.class), anyInt(),
+        anyInt())).thenReturn(mock(ListResult.class));
+
+    _usage.exists(_urn1);
+    _usage.list(AspectFoo.class, 0, 10);
+    _usage.countAggregate(null, mock(IndexGroupByCriterion.class));
+    _usage.batchSoftDeleteAssets(Collections.singletonList(_urn1), "2026-01-01", false);
+    _usage.readDeletionInfoBatch(Collections.singletonList(_urn1), false);
+    _usage.listUrns(mock(IndexFilter.class), mock(IndexSortCriterion.class), 0, 10);
+    _usage.ensureSchemaUpToDate();
+
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  public void testDisabledEmitterSkipsEmissionButDelegates() {
+    when(_mockEmitter.isEnabled()).thenReturn(false);
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(7);
+
+    int result = _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null, false);
+
+    assertEquals(result, 7);
+    verify(_mockDelegate).add(any(), any(), any(), any(), any(), anyBoolean());
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  public void testEmitterExceptionDoesNotPropagate() {
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(3);
+    doThrow(new RuntimeException("boom")).when(_mockEmitter)
+        .emit(anyString(), anyString(), anyString(), any(), any(), any());
+
+    int result = _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null, false);
+
+    assertEquals(result, 3);
+  }
+
+  @Test
+  public void testConfigAndPassThroughMethodsDelegate() {
+    _usage.setUrnPathExtractor(null);
+    verify(_mockDelegate).setUrnPathExtractor(null);
+
+    _usage.configureOptionalForceIndex("PRIMARY", null);
+    verify(_mockDelegate).configureOptionalForceIndex("PRIMARY", null);
+
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+}

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.dao;
 
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.DaoReadContext;
@@ -56,7 +57,7 @@ public class UsageTrackingEbeanLocalAccessTest {
     _mockEmitter = mock(BaseDaoUsageEmitter.class);
     when(_mockEmitter.isEnabled()).thenReturn(true);
 
-    _usage = new UsageTrackingEbeanLocalAccess<>(_mockDelegate, _mockEmitter, FooUrn.class);
+    _usage = new UsageTrackingEbeanLocalAccess<>(_mockDelegate, _mockEmitter);
 
     _urn1 = makeFooUrn(1);
     _urn2 = makeFooUrn(2);
@@ -121,6 +122,23 @@ public class UsageTrackingEbeanLocalAccessTest {
     }
 
     verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testEntityTypeComesFromUrnNotUrnClassName() throws Exception {
+    // A camelCase entity type distinguishes urn.getEntityType() from the old derivation, which
+    // lowercased the URN class name and would have produced "mlmodel" (and "" for a raw Urn).
+    IEbeanLocalAccess<Urn> mockDelegate = mock(IEbeanLocalAccess.class);
+    UsageTrackingEbeanLocalAccess<Urn> usage =
+        new UsageTrackingEbeanLocalAccess<>(mockDelegate, _mockEmitter);
+    Urn mlModelUrn = new Urn("mlModel", "some-model");
+
+    when(mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    usage.add(mlModelUrn, new AspectFoo().setValue("v"), AspectFoo.class, _auditStamp, null, false);
+
+    verify(_mockEmitter).emit(eq("WRITE"), eq("mlModel"), eq("add"), any(), any(), any());
   }
 
   // ---------------------------------------------------------------------------------------

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
+import com.linkedin.metadata.dao.tracking.DaoReadContext;
 import com.linkedin.metadata.dao.tracking.DaoUsageTarget;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import com.linkedin.metadata.query.IndexFilter;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -66,6 +68,45 @@ public class UsageTrackingEbeanLocalAccessTest {
   @SuppressWarnings("unchecked")
   private ArgumentCaptor<List<DaoUsageTarget>> targetsCaptor() {
     return ArgumentCaptor.forClass(List.class);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    // Defensive: never let an internal-read marker leak into the next test on a reused thread.
+    DaoReadContext.clear();
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testInternalReadIsNotEmitted() {
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys =
+        (List) Collections.singletonList(new AspectKey<>(AspectFoo.class, _urn1, 0L));
+
+    DaoReadContext.markInternalRead();
+    try {
+      _usage.batchGetUnion(keys, 1, 0, true, false);
+    } finally {
+      DaoReadContext.clear();
+    }
+
+    // Read-before-write is marked internal, so it is not counted as a consumer read.
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testConsumerReadStillEmittedAfterInternalMarkerCleared() {
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys =
+        (List) Collections.singletonList(new AspectKey<>(AspectFoo.class, _urn1, 0L));
+
+    // Once the marker is cleared, a genuine consumer read is emitted as normal.
+    _usage.batchGetUnion(keys, 1, 0, false, false);
+
+    verify(_mockEmitter).emit(eq("READ"), eq("foo"), eq("batchGetUnion"), isNull(), isNull(), any());
   }
 
   // ---------------------------------------------------------------------------------------

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -5,6 +5,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.DaoReadContext;
+import com.linkedin.metadata.dao.tracking.DaoUsageBuffer;
 import com.linkedin.metadata.dao.tracking.DaoUsageTarget;
 import com.linkedin.metadata.events.IngestionTrackingContext;
 import com.linkedin.metadata.query.IndexFilter;
@@ -139,6 +140,59 @@ public class UsageTrackingEbeanLocalAccessTest {
     usage.add(mlModelUrn, new AspectFoo().setValue("v"), AspectFoo.class, _auditStamp, null, false);
 
     verify(_mockEmitter).emit(eq("WRITE"), eq("mlModel"), eq("add"), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testWriteIsHeldUntilTransactionCommits() {
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    final int mark = DaoUsageBuffer.enter();
+    try {
+      _usage.add(_urn1, new AspectFoo().setValue("v"), AspectFoo.class, _auditStamp, null, false);
+      // The write has run but the transaction has not committed, so nothing is reported yet.
+      verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+    } finally {
+      DaoUsageBuffer.exit(mark, true).forEach(Runnable::run);
+    }
+
+    verify(_mockEmitter, times(1)).emit(eq("WRITE"), eq("foo"), eq("add"), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testWriteIsNotEmittedWhenTransactionRollsBack() {
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(1);
+
+    final int mark = DaoUsageBuffer.enter();
+    try {
+      _usage.add(_urn1, new AspectFoo().setValue("v"), AspectFoo.class, _auditStamp, null, false);
+    } finally {
+      DaoUsageBuffer.exit(mark, false).forEach(Runnable::run);
+    }
+
+    // A rolled-back write never happened, so it must not be reported.
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testReadIsEmittedImmediatelyInsideTransaction() {
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+    List<AspectKey<FooUrn, ? extends RecordTemplate>> keys =
+        (List) Collections.singletonList(new AspectKey<>(AspectFoo.class, _urn1, 0L));
+
+    final int mark = DaoUsageBuffer.enter();
+    try {
+      _usage.batchGetUnion(keys, 1, 0, false, false);
+      // A read that was served happened, whether or not a later write in the same transaction
+      // rolls back, so reads are not deferred.
+      verify(_mockEmitter, times(1))
+          .emit(eq("READ"), eq("foo"), eq("batchGetUnion"), isNull(), isNull(), any());
+    } finally {
+      DaoUsageBuffer.exit(mark, false);
+    }
   }
 
   // ---------------------------------------------------------------------------------------

--- a/docs/rfc/active/dao-usage-event-instrumentation.md
+++ b/docs/rfc/active/dao-usage-event-instrumentation.md
@@ -48,6 +48,19 @@ name at construction (same as `InstrumentedEbeanLocalAccess`). Test-mode and bac
 A setter that wraps the internal `_localAccess` with the decorator. No-op when `_localAccess` is `null` (OLD_SCHEMA_ONLY
 mode). Composes with `setBenchmarkMetrics` — both decorate `_localAccess`. Consistent with existing setter patterns.
 
+### `DaoReadContext` (internal read-before-write filter)
+
+Located in `dao-api/.../tracking/DaoReadContext.java`. A thread-local boolean flag that lets the decorator distinguish a
+genuine consumer read from the DAO's own internal read-before-write.
+
+Every aspect write/delete performs a read-modify-write: it reads the current value before writing. In new-schema mode
+that internal read flows through the same decorator as consumer reads and would otherwise be counted as one. The write
+paths set the flag around that internal read (cleared in a `finally`) — `queryLatest` for single-aspect
+add/update/delete and `batchGetOldValuesWithExtraInfo` for `batchUpsert` — and the decorator skips `batchGetUnion`
+emission while the flag is set. The set → read → clear happens synchronously on one thread with no async boundary, so
+the flag is reliable and cannot leak. Consumer reads take a different entry path, never set the flag, and are still
+emitted.
+
 ---
 
 ## Events Emitted
@@ -68,7 +81,28 @@ One event per successful operation, with fields: `operationType` (`READ` / `WRIT
 
 Aspect names use the aspect class simple name. **Not emitted:** global `list`, `listUrns`, `exists`, `countAggregate`,
 `batchSoftDeleteAssets`, `readDeletionInfoBatch`, `ensureSchemaUpToDate`, and config methods — none are organic
-single-entity data access. Test-mode and backfill operations are also skipped.
+single-entity data access. Test-mode, backfill, and internal read-before-write operations are also skipped (see
+`DaoReadContext`).
+
+---
+
+## Known limitations (v1)
+
+The decorator observes only what reaches storage, and only through the new-schema access path. These caveats affect how
+much to trust v1 numbers; none affect write-side data or the safety of the instrumentation.
+
+- **Reads have no caller.** Writes carry an `AuditStamp`; reads do not, so every read event has `actorUrn = null`.
+- **Only new/dual-schema DAOs are instrumented.** The decorator wraps the new-schema access layer, so an
+  `OLD_SCHEMA_ONLY` DAO emits nothing, and historical (non-latest-version) reads served from the legacy path are not
+  emitted.
+- **Read counts are an upper bound on volume.** Internal read-before-writes are excluded via `DaoReadContext`, but the
+  uninstrumented legacy/historical paths above still make read counts incomplete — treat them as a lower bound on
+  distinct consumers.
+- **Writes reflect committed change, not attempts.** Emission is gated on affected-row count (`> 0`) and happens inside
+  the write transaction, so a rolled-back or retried write can over-count and a no-op upsert does not emit.
+
+Read-side caller attribution is a proposed follow-up. Until it lands, treat read events as anonymous and do not use them
+for consumer-dependency decisions.
 
 ---
 

--- a/docs/rfc/active/dao-usage-event-instrumentation.md
+++ b/docs/rfc/active/dao-usage-event-instrumentation.md
@@ -1,0 +1,84 @@
+# DAO Usage Event Instrumentation
+
+## Context
+
+datahub-gma provides the DAO layer for metadata storage. To support usage analytics — which callers read and write which
+entities and aspects — we need one usage event per successful data-access operation (read / write / delete).
+
+This RFC describes the interface, value type, and instrumentation decorator that live in the datahub-gma kernel. The
+kernel defines the usage contract and a no-op default; service layers provide the real emitter backed by their eventing
+infrastructure. Mirrors the existing `BaseDaoBenchmarkMetrics` instrumentation.
+
+---
+
+## Design
+
+### `BaseDaoUsageEmitter` interface
+
+Located in `dao-api/.../tracking/BaseDaoUsageEmitter.java`.
+
+- `emit(operationType, entityType, sourceOperation, actorUrn, impersonatorUrn, targets)`
+- `isEnabled()` — for short-circuiting when disabled
+
+Passes only plain strings and `DaoUsageTarget`, so the kernel stays free of any concrete event-schema dependency.
+Contract: implementations MUST be fire-and-forget — asynchronous, non-blocking, and never throwing back into the caller.
+Same kernel-interface / service-implementation split as `BaseDaoBenchmarkMetrics`.
+
+### `DaoUsageTarget` value type
+
+Located in `dao-api/.../tracking/DaoUsageTarget.java`. Holds `{String urn, List<String> aspects}` — one per distinct URN
+touched by an operation. `aspects` is empty for a whole-entity delete.
+
+### `NoOpDaoUsageEmitter`
+
+Located in `dao-api/.../tracking/NoOpDaoUsageEmitter.java`. All methods no-op; `isEnabled()` returns `false`. The
+default when no emitter is configured. Follows the `NoOpDaoBenchmarkMetrics` pattern.
+
+### `UsageTrackingEbeanLocalAccess` decorator
+
+Located in `dao-impl/ebean-dao/.../UsageTrackingEbeanLocalAccess.java`.
+
+Implements `IEbeanLocalAccess<URN>`, delegates every call to the real implementation first, and emits only **after** a
+successful delegate call — wrapped so emission can never change the return value or propagate an exception. When
+`isEnabled()` returns `false`, delegation is direct with zero overhead. Entity type is derived from the URN class simple
+name at construction (same as `InstrumentedEbeanLocalAccess`). Test-mode and backfill operations are skipped.
+
+### `EbeanLocalDAO.setUsageEmitter()`
+
+A setter that wraps the internal `_localAccess` with the decorator. No-op when `_localAccess` is `null` (OLD_SCHEMA_ONLY
+mode). Composes with `setBenchmarkMetrics` — both decorate `_localAccess`. Consistent with existing setter patterns.
+
+---
+
+## Events Emitted
+
+One event per successful operation, with fields: `operationType` (`READ` / `WRITE` / `DELETE` / `DELETE_ALL`),
+`entityType`, `sourceOperation` (the DAO method), `actorUrn`, `impersonatorUrn`, and `targets` (`[{urn, aspects[]}]`).
+
+### Operation mapping
+
+| Operation                          | operationType                     | targets                           | caller            |
+| ---------------------------------- | --------------------------------- | --------------------------------- | ----------------- |
+| `batchGetUnion`                    | `READ`                            | grouped per URN                   | none              |
+| `list(aspectClass, urn, ...)`      | `READ`                            | single URN                        | none              |
+| `add` / `addWithOptimisticLocking` | `WRITE` (value) / `DELETE` (null) | single URN                        | audit-stamp actor |
+| `create`                           | `WRITE`                           | single URN, aspects from values   | audit-stamp actor |
+| `batchUpsert`                      | `WRITE`                           | single URN, aspects from contexts | audit-stamp actor |
+| `softDeleteAsset`                  | `DELETE_ALL`                      | single URN, empty aspects         | none              |
+
+Aspect names use the aspect class simple name. **Not emitted:** global `list`, `listUrns`, `exists`, `countAggregate`,
+`batchSoftDeleteAssets`, `readDeletionInfoBatch`, `ensureSchemaUpToDate`, and config methods — none are organic
+single-entity data access. Test-mode and backfill operations are also skipped.
+
+---
+
+## Usage
+
+Service layers inject their emitter via the setter:
+
+```java
+BaseDaoUsageEmitter emitter = createYourUsageEmitter();
+dao.setUsageEmitter(emitter);
+```
+
+When no emitter is configured, the DAO operates normally with zero instrumentation overhead and no events.

--- a/docs/rfc/active/dao-usage-event-instrumentation.md
+++ b/docs/rfc/active/dao-usage-event-instrumentation.md
@@ -27,7 +27,8 @@ Same kernel-interface / service-implementation split as `BaseDaoBenchmarkMetrics
 ### `DaoUsageTarget` value type
 
 Located in `dao-api/.../tracking/DaoUsageTarget.java`. Holds `{String urn, List<String> aspects}` — one per distinct URN
-touched by an operation. `aspects` is empty for a whole-entity delete.
+touched by an operation. `aspects` may be empty — a whole-entity `DELETE_ALL`, or a `create` with no aspect values. Do
+not infer the operation kind from an empty `aspects` list; `operationType` is the authoritative discriminator.
 
 ### `NoOpDaoUsageEmitter`
 
@@ -40,26 +41,35 @@ Located in `dao-impl/ebean-dao/.../UsageTrackingEbeanLocalAccess.java`.
 
 Implements `IEbeanLocalAccess<URN>`, delegates every call to the real implementation first, and emits only **after** a
 successful delegate call — wrapped so emission can never change the return value or propagate an exception. When
-`isEnabled()` returns `false`, delegation is direct with zero overhead. Entity type is derived from the URN class simple
-name at construction (same as `InstrumentedEbeanLocalAccess`). Test-mode and backfill operations are skipped.
+`isEnabled()` returns `false`, delegation is direct with zero overhead. Entity type comes from `urn.getEntityType()` on
+each operation. Test-mode, backfill, and internal read-before-write operations are skipped.
 
 ### `EbeanLocalDAO.setUsageEmitter()`
 
 A setter that wraps the internal `_localAccess` with the decorator. No-op when `_localAccess` is `null` (OLD_SCHEMA_ONLY
 mode). Composes with `setBenchmarkMetrics` — both decorate `_localAccess`. Consistent with existing setter patterns.
 
-### `DaoReadContext` (internal read-before-write filter)
+### `DaoReadContext` (internal-read filter)
 
-Located in `dao-api/.../tracking/DaoReadContext.java`. A thread-local boolean flag that lets the decorator distinguish a
-genuine consumer read from the DAO's own internal read-before-write.
+Located in `dao-api/.../tracking/DaoReadContext.java`. A thread-local marker that lets the decorator distinguish a
+genuine consumer read from a read the DAO issues internally — the read-before-write every write/delete performs
+(`queryLatest`, `batchGetOldValuesWithExtraInfo`) and the old→new backfill reads (`backfill`, `backfillEntityTables`,
+`backfillLocalRelationships`). Each is wrapped with
+`try (DaoReadContext.Scope ignored = DaoReadContext.markInternalRead())`, and the decorator skips read emission while
+the marker is set. The `Scope` restores the previous marker state on close rather than clearing unconditionally, so
+nested internal reads compose safely; mark → read → restore runs synchronously on one thread, so the marker cannot leak.
+Consumer reads never set it and are still emitted.
 
-Every aspect write/delete performs a read-modify-write: it reads the current value before writing. In new-schema mode
-that internal read flows through the same decorator as consumer reads and would otherwise be counted as one. The write
-paths set the flag around that internal read (cleared in a `finally`) — `queryLatest` for single-aspect
-add/update/delete and `batchGetOldValuesWithExtraInfo` for `batchUpsert` — and the decorator skips `batchGetUnion`
-emission while the flag is set. The set → read → clear happens synchronously on one thread with no async boundary, so
-the flag is reliable and cannot leak. Consumer reads take a different entry path, never set the flag, and are still
-emitted.
+### `DaoUsageBuffer` (commit-gated write emission)
+
+Located in `dao-api/.../tracking/DaoUsageBuffer.java`. A thread-local buffer that holds write/delete emissions until the
+enclosing transaction commits: the decorator sits below the transaction boundary, so emitting inline would report writes
+that later roll back and re-report them on every retry. `EbeanLocalDAO.runInTransactionWithRetry` brackets the
+transaction with `enter()` / `exit()`; writes `record()` into the open frame (non-transactional paths run immediately,
+reads are never buffered). A depth counter flushes only at the outermost commit (Ebean nests via savepoints), a rollback
+discards the frame, and each retry truncates back to its entry mark so a retried write is reported once. The buffer is
+armed only once an emitter is installed, so it stays zero-overhead otherwise, and `enter()` / `exit()` must stay paired
+in a `finally` or an unexited frame leaks.
 
 ---
 
@@ -95,11 +105,12 @@ much to trust v1 numbers; none affect write-side data or the safety of the instr
 - **Only new/dual-schema DAOs are instrumented.** The decorator wraps the new-schema access layer, so an
   `OLD_SCHEMA_ONLY` DAO emits nothing, and historical (non-latest-version) reads served from the legacy path are not
   emitted.
-- **Read counts are an upper bound on volume.** Internal read-before-writes are excluded via `DaoReadContext`, but the
-  uninstrumented legacy/historical paths above still make read counts incomplete — treat them as a lower bound on
-  distinct consumers.
-- **Writes reflect committed change, not attempts.** Emission is gated on affected-row count (`> 0`) and happens inside
-  the write transaction, so a rolled-back or retried write can over-count and a no-op upsert does not emit.
+- **Read counts are a lower bound.** Internal read-before-writes and backfill reads are excluded via `DaoReadContext`,
+  and the uninstrumented legacy/historical paths above are not captured at all, so recorded read volume undercounts real
+  reads — treat it as a lower bound, especially for distinct consumers.
+- **Writes reflect committed change, not attempts.** Emission is gated on affected-row count (`> 0`) and buffered until
+  the enclosing transaction commits (see `DaoUsageBuffer`), so a rolled-back write is never reported and a retried write
+  is reported once rather than once per attempt. A no-op upsert (zero affected rows) does not emit.
 
 Read-side caller attribution is a proposed follow-up. Until it lands, treat read events as anonymous and do not use them
 for consumer-dependency decisions.


### PR DESCRIPTION
## Summary

Adds an optional, pluggable usage-tracking layer to the Ebean DAO — one usage event per
successful read / write / delete — without the kernel depending on any concrete event schema.

- `BaseDaoUsageEmitter` (dao-api): model-agnostic interface (plain strings + `DaoUsageTarget`)
  with a `NoOpDaoUsageEmitter` default; contract is fire-and-forget (async, non-blocking, never
  throws).
- `UsageTrackingEbeanLocalAccess` (ebean-dao): decorator over `IEbeanLocalAccess` that delegates
  first and emits only after success; installed via `EbeanLocalDAO.setUsageEmitter` (mirrors
  `setBenchmarkMetrics`, no-op in `OLD_SCHEMA_ONLY`).
- `DaoReadContext`: thread-local marker so the internal read-before-write is not counted as a
  consumer read.

Purely additive: no signature changes, and no behavior change until an emitter is installed
(default no-op = zero overhead). Design doc: `docs/rfc/active/dao-usage-event-instrumentation.md`.

## Testing Done

- [x] Compile + Checkstyle (main & test) for `dao-api` and `ebean-dao`
- [x] Unit tests pass: `DaoReadContextTest` (3), `NoOpDaoUsageEmitterTest` (1), `UsageTrackingEbeanLocalAccessTest` (20)
- [x] `BaseLocalDAOTest` (68) passes — covers the modified batch read-before-write path
- [x] `./gradlew spotlessCheck`
- [x] Full `ebean-dao` DB-backed integration suite passes locally (embedded MariaDB per the Apple Silicon setup in `docs/developers.md`)

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (RFC: `docs/rfc/active/dao-usage-event-instrumentation.md`)
