### PR TITLE
feat(ebean-dao): add typed relationship keyset pagination

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -56,6 +56,8 @@ public class EbeanLocalRelationshipQueryDAO {
   public static final String RELATIONSHIP_RETURN_TYPE = "relationship.return.type";
   public static final String MG_INTERNAL_ASSET_RELATIONSHIP_TYPE = "AssetRelationship.proto";
   private static final int FILTER_BATCH_SIZE = 200;
+  // Hard upper bound on keyset page size to keep per-page DB work bounded.
+  private static final int MAX_KEYSET_PAGE_SIZE = 1000;
   private static final String IDX_DESTINATION_DELETED_TS = "idx_destination_deleted_ts";
   private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_destination_deleted_ts) ";
   private static final String DESTINATION_FIELD =  "destination";
@@ -280,6 +282,174 @@ public class EbeanLocalRelationshipQueryDAO {
         .map(row -> RecordUtils.toRecordTemplate(relationshipType, row.getString("metadata")))
         .collect(Collectors.toList());
   }
+
+  /**
+   * Keyset (seek) paginated, current-only ({@code deleted_ts IS NULL}) variant of
+   * {@link #findRelationships(Class, LocalRelationshipFilter, Class, LocalRelationshipFilter, Class,
+   * LocalRelationshipFilter, int, int)} that walks the matching set in bounded pages. Ranked/
+   * non-current pagination is unsupported because it could not bound the per-page DB work.
+   *
+   * <p>First page: pass {@code cursor = null}; the DAO captures {@code maxId}, the largest
+   * relationship row id when paging starts ({@code COALESCE(MAX(id), 0)}), and returns rows with
+   * {@code 0 < rt.id <= maxId} ordered by id, up to {@code pageSize}. Later inserts get larger ids
+   * and are excluded, keeping the scan finite. Continuation: pass the next cursor from the previous
+   * {@link RelationshipKeysetPage}. The combined pages are not a point-in-time snapshot: existing
+   * rows updated or soft-deleted between page calls can change which rows a later page returns (see
+   * {@link RelationshipKeysetCursor}).</p>
+   *
+   * <p>Supported only when {@code SchemaConfig} is {@code NEW_SCHEMA_ONLY} or {@code DUAL_SCHEMA};
+   * {@code OLD_SCHEMA_ONLY} throws {@link UnsupportedOperationException}.</p>
+   *
+   * @param sourceEntityClass the source entity class to query
+   * @param sourceEntityFilter the filter to apply to the source entity when querying
+   * @param destinationEntityClass the destination entity class
+   * @param destinationEntityFilter the filter to apply to the destination entity when querying
+   * @param relationshipType the type of relationship to query
+   * @param relationshipFilter the filter to apply to relationship when querying
+   * @param pageSize the maximum number of relationships to return per page. Must be between 1 and
+   *                 1000 inclusive.
+   * @param cursor the cursor from the previous page, or {@code null} for the first page.
+   * @return a page of relationship records plus a next cursor (null when the scan is exhausted).
+   * @throws UnsupportedOperationException when the DAO is in {@code OLD_SCHEMA_ONLY} mode.
+   */
+  @Nonnull
+  public <SRC_SNAPSHOT extends RecordTemplate, DEST_SNAPSHOT extends RecordTemplate, RELATIONSHIP extends RecordTemplate>
+      RelationshipKeysetPage<RELATIONSHIP> findRelationshipsByKeyset(
+      @Nullable Class<SRC_SNAPSHOT> sourceEntityClass, @Nonnull LocalRelationshipFilter sourceEntityFilter,
+      @Nullable Class<DEST_SNAPSHOT> destinationEntityClass, @Nonnull LocalRelationshipFilter destinationEntityFilter,
+      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter, int pageSize,
+      @Nullable RelationshipKeysetCursor cursor) {
+    validateEntityFilter(sourceEntityFilter, sourceEntityClass);
+    validateEntityFilter(destinationEntityFilter, destinationEntityClass);
+    validateRelationshipFilter(relationshipFilter, false);
+
+    String destTableName = null;
+    if (destinationEntityClass != null) {
+      destTableName = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(destinationEntityClass));
+    }
+
+    String sourceTableName = null;
+    if (sourceEntityClass != null) {
+      sourceTableName = SQLSchemaUtils.getTableName(ModelUtils.getUrnTypeFromSnapshot(sourceEntityClass));
+    }
+
+    final String relationshipTableName = SQLSchemaUtils.getRelationshipTableName(relationshipType);
+
+    final KeysetScanResult scan = findRelationshipsByKeysetCore(relationshipTableName, sourceTableName,
+        sourceEntityFilter, destTableName, destinationEntityFilter, relationshipFilter, pageSize, cursor);
+
+    final List<RELATIONSHIP> relationships = new ArrayList<>(scan.getRows().size());
+    for (SqlRow row : scan.getRows()) {
+      relationships.add(RecordUtils.toRecordTemplate(relationshipType, row.getString(METADATA)));
+    }
+
+    return new RelationshipKeysetPage<>(relationships, scan.getHighWaterId(), scan.getNextCursor());
+  }
+
+  /**
+   * Shared row-level keyset core for {@link #findRelationshipsByKeyset}: captures the first-page
+   * {@code maxId} (largest row id when paging starts), runs the current-only keyset SQL, validates
+   * strictly increasing id progress and computes the next cursor. Callers resolve their own table
+   * names/filters and map the returned rows. Supported only for {@code NEW_SCHEMA_ONLY} and
+   * {@code DUAL_SCHEMA}; {@code OLD_SCHEMA_ONLY} throws {@link UnsupportedOperationException} before
+   * any SQL is built or executed.
+   */
+  @Nonnull
+  private KeysetScanResult findRelationshipsByKeysetCore(@Nonnull final String relationshipTableName,
+      @Nullable final String sourceTableName, @Nullable final LocalRelationshipFilter sourceEntityFilter,
+      @Nullable final String destTableName, @Nullable final LocalRelationshipFilter destinationEntityFilter,
+      @Nonnull final LocalRelationshipFilter relationshipFilter, final int pageSize,
+      @Nullable final RelationshipKeysetCursor cursor) {
+    if (pageSize < 1 || pageSize > MAX_KEYSET_PAGE_SIZE) {
+      throw new IllegalArgumentException(
+          "pageSize must be between 1 and " + MAX_KEYSET_PAGE_SIZE + " but was " + pageSize);
+    }
+    if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
+      throw new UnsupportedOperationException(
+          "Keyset pagination is not supported in OLD_SCHEMA_ONLY mode; use NEW_SCHEMA_ONLY or DUAL_SCHEMA.");
+    }
+
+    final long lastId;
+    final long maxId;
+    if (cursor == null) {
+      lastId = 0L;
+      maxId = fetchHighWaterId(relationshipTableName);
+    } else {
+      lastId = cursor.getLastId();
+      maxId = cursor.getMaxId();
+    }
+
+    // Nothing left to scan (empty table, or the previous page reached maxId).
+    if (lastId >= maxId) {
+      return new KeysetScanResult(Collections.emptyList(), maxId, null);
+    }
+
+    final String sql = buildFindRelationshipKeysetSQL(relationshipTableName, relationshipFilter, sourceTableName,
+        sourceEntityFilter, destTableName, destinationEntityFilter, pageSize, lastId, maxId);
+
+    final List<SqlRow> rows = executeSqlWithIndexCheck(sql, relationshipTableName);
+
+    long previousId = lastId;
+    long lastRowId = lastId;
+    for (SqlRow row : rows) {
+      final long id = row.getLong("id");
+      if (id <= previousId) {
+        throw new IllegalStateException(String.format(
+            "Relationship ids must strictly increase during keyset pagination but saw id %d after %d in table '%s'",
+            id, previousId, relationshipTableName));
+      }
+      previousId = id;
+      lastRowId = id;
+    }
+
+    // A next cursor is only warranted when the page was full and did not reach maxId.
+    RelationshipKeysetCursor nextCursor = null;
+    if (rows.size() == pageSize && lastRowId < maxId) {
+      nextCursor = new RelationshipKeysetCursor(lastRowId, maxId);
+    }
+
+    return new KeysetScanResult(rows, maxId, nextCursor);
+  }
+
+  /**
+   * Immutable holder for one keyset page's raw rows, {@code maxId} and next cursor.
+   */
+  private static final class KeysetScanResult {
+    private final List<SqlRow> _rows;
+    private final long _highWaterId;
+    private final RelationshipKeysetCursor _nextCursor;
+
+    KeysetScanResult(@Nonnull List<SqlRow> rows, long highWaterId,
+        @Nullable RelationshipKeysetCursor nextCursor) {
+      _rows = rows;
+      _highWaterId = highWaterId;
+      _nextCursor = nextCursor;
+    }
+
+    @Nonnull
+    List<SqlRow> getRows() {
+      return _rows;
+    }
+
+    long getHighWaterId() {
+      return _highWaterId;
+    }
+
+    @Nullable
+    RelationshipKeysetCursor getNextCursor() {
+      return _nextCursor;
+    }
+  }
+
+  /**
+   * Returns COALESCE(MAX(id), 0), the largest relationship row id ({@code maxId}), for the table.
+   */
+  private long fetchHighWaterId(@Nonnull final String relationshipTableName) {
+    final String sql = "SELECT COALESCE(MAX(id), 0) AS max_id FROM " + relationshipTableName;
+    final List<SqlRow> rows = _server.createSqlQuery(sql).findList();
+    return rows.isEmpty() ? 0L : rows.get(0).getLong("max_id");
+  }
+
   /**
    * Finds a list of relationships of a specific type (Urn) based on the given filters if applicable.
    *
@@ -862,6 +1032,89 @@ public class EbeanLocalRelationshipQueryDAO {
     if (includeNonCurrentRelationships) {
       sqlBuilder.append(") ranked_rows WHERE row_num = 1");
     }
+
+    return sqlBuilder.toString();
+  }
+
+  /**
+   * Keyset (seek) pagination counterpart of {@link #buildFindRelationshipSQL}: same join/filter
+   * construction plus keyset bounds ({@code rt.id > lastId AND rt.id <= maxId}, {@code maxId} being
+   * the largest relationship row id when paging starts), ascending id order and
+   * {@code LIMIT pageSize}. Kept separate to leave {@link #buildFindRelationshipSQL} untouched.
+   *
+   * <p>Always current-only ({@code deleted_ts IS NULL}); ranked/non-current pagination is
+   * unsupported because it could not bound the per-page DB work.</p>
+   *
+   * <p>Supported only for {@code NEW_SCHEMA_ONLY} and {@code DUAL_SCHEMA}; {@code OLD_SCHEMA_ONLY}
+   * throws {@link UnsupportedOperationException}.</p>
+   */
+  @Nonnull
+  @VisibleForTesting
+  public String buildFindRelationshipKeysetSQL(@Nonnull final String relationshipTableName,
+      @Nonnull LocalRelationshipFilter relationshipFilter, @Nullable final String sourceTableName,
+      @Nullable LocalRelationshipFilter sourceEntityFilter, @Nullable final String destTableName,
+      @Nullable LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId) {
+    if (pageSize < 1 || pageSize > MAX_KEYSET_PAGE_SIZE) {
+      throw new IllegalArgumentException(
+          "pageSize must be between 1 and " + MAX_KEYSET_PAGE_SIZE + " but was " + pageSize);
+    }
+    if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
+      throw new UnsupportedOperationException(
+          "Keyset pagination is not supported in OLD_SCHEMA_ONLY mode; use NEW_SCHEMA_ONLY or DUAL_SCHEMA.");
+    }
+
+    relationshipFilter = LogicalExpressionLocalRelationshipCriterionUtils.normalizeLocalRelationshipFilter(relationshipFilter);
+    sourceEntityFilter = LogicalExpressionLocalRelationshipCriterionUtils.normalizeLocalRelationshipFilter(sourceEntityFilter);
+    destinationEntityFilter = LogicalExpressionLocalRelationshipCriterionUtils.normalizeLocalRelationshipFilter(destinationEntityFilter);
+
+    // Cursor bounds are validated non-negative longs, so inlining them is safe and matches the
+    // existing flow that inlines filter values (including colon-bearing urns) without named params.
+    final String maxIdPredicate = "rt.id <= " + maxId;
+    final String lastIdPredicate = "rt.id > " + lastId;
+    final StringBuilder sqlBuilder = new StringBuilder();
+
+    sqlBuilder.append("SELECT rt.*");
+    sqlBuilder.append(" FROM ").append(relationshipTableName).append(" rt ");
+
+    final List<Triplet<LocalRelationshipFilter, String, String>> filters = new ArrayList<>();
+
+    if (_schemaConfig == EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY || _schemaConfig == EbeanLocalDAO.SchemaConfig.DUAL_SCHEMA) {
+      if (destTableName != null) {
+        sqlBuilder.append("INNER JOIN ").append(destTableName).append(" dt ON dt.urn=rt.destination ");
+
+        if (destinationEntityFilter != null) {
+          filters.add(new Triplet<>(destinationEntityFilter, "dt", destTableName));
+        }
+      } else if (destinationEntityFilter != null) {
+        validateEntityFilterOnlyOneUrn(destinationEntityFilter);
+        filters.add(new Triplet<>(destinationEntityFilter, "rt", relationshipTableName));
+      }
+
+      if (sourceTableName != null) {
+        sqlBuilder.append("INNER JOIN ").append(sourceTableName).append(" st ON st.urn=rt.source ");
+
+        if (sourceEntityFilter != null) {
+          filters.add(new Triplet<>(sourceEntityFilter, "st", sourceTableName));
+        }
+      }
+
+      filters.add(new Triplet<>(relationshipFilter, "rt", relationshipTableName));
+
+      final String whereClause = SQLStatementUtils.whereClause(SUPPORTED_CONDITIONS,
+          _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled(), _schemaValidatorUtil,
+          filters.toArray(new Triplet[filters.size()]));
+
+      sqlBuilder.append("WHERE rt.deleted_ts is NULL");
+      if (whereClause != null) {
+        sqlBuilder.append(" AND ").append(whereClause);
+      }
+      sqlBuilder.append(" AND ").append(lastIdPredicate).append(" AND ").append(maxIdPredicate);
+    } else {
+      // OLD_SCHEMA_ONLY is rejected above; only NEW_SCHEMA_ONLY and DUAL_SCHEMA are supported here.
+      throw new RuntimeException("The schema config must be set to DUAL_SCHEMA or NEW_SCHEMA_ONLY.");
+    }
+
+    sqlBuilder.append(" ORDER BY rt.id ASC LIMIT ").append(pageSize);
 
     return sqlBuilder.toString();
   }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
@@ -1,0 +1,48 @@
+package com.linkedin.metadata.dao;
+
+import lombok.Getter;
+
+
+/**
+ * Immutable position of a keyset (seek) pagination scan over a single relationship table, used by
+ * {@link EbeanLocalRelationshipQueryDAO#findRelationshipsByKeyset}.
+ *
+ * <p>{@code lastId} is the id of the last row returned; the next page starts strictly after it
+ * ({@code rt.id > lastId}) and is {@code 0} for the first page. {@code maxId} is the largest
+ * relationship row id when paging starts, captured on the first page
+ * ({@code COALESCE(MAX(id), 0)}); every page is bounded by {@code rt.id <= maxId}. Later inserts get
+ * larger ids and are excluded, which keeps the scan finite. The combined pages are not a
+ * point-in-time snapshot: existing rows updated or soft-deleted between page calls can change which
+ * rows a later page returns, so callers must not assume they see every row that was current when
+ * paging started. Both values are non-negative and {@code lastId <= maxId} always holds.</p>
+ */
+public final class RelationshipKeysetCursor {
+
+  @Getter
+  private final long lastId;
+  @Getter
+  private final long maxId;
+
+  /**
+   * Creates a cursor.
+   *
+   * @param lastId id of the last row already returned; the next page starts strictly after it.
+   *               Must be non-negative.
+   * @param maxId largest relationship row id when paging starts; bounds the scan. Must be
+   *              non-negative and {@code >= lastId}.
+   */
+  public RelationshipKeysetCursor(long lastId, long maxId) {
+    if (lastId < 0) {
+      throw new IllegalArgumentException("lastId must be non-negative but was " + lastId);
+    }
+    if (maxId < 0) {
+      throw new IllegalArgumentException("maxId must be non-negative but was " + maxId);
+    }
+    if (lastId > maxId) {
+      throw new IllegalArgumentException(
+          "lastId (" + lastId + ") must not be greater than maxId (" + maxId + ")");
+    }
+    this.lastId = lastId;
+    this.maxId = maxId;
+  }
+}

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetPage.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetPage.java
@@ -1,0 +1,59 @@
+package com.linkedin.metadata.dao;
+
+import com.linkedin.data.template.RecordTemplate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Getter;
+
+
+/**
+ * Immutable result of a single keyset (seek) pagination page returned by
+ * {@link EbeanLocalRelationshipQueryDAO#findRelationshipsByKeyset}.
+ *
+ * @param <R> the deserialized relationship record type
+ */
+public final class RelationshipKeysetPage<R extends RecordTemplate> {
+
+  @Getter
+  @Nonnull
+  private final List<R> relationships;
+  @Getter
+  private final long highWaterId;
+  @Getter
+  @Nullable
+  private final RelationshipKeysetCursor nextCursor;
+
+  /**
+   * Creates a page.
+   *
+   * @param relationships the relationships in this page, in ascending {@code id} order. Copied
+   *                      defensively and exposed as an unmodifiable list.
+   * @param highWaterId the largest relationship row {@code id} when paging started (the
+   *                    {@code maxId} captured on the first page), which bounds the scan. Must be
+   *                    non-negative.
+   * @param nextCursor cursor to fetch the next page, or {@code null} if this is the last page.
+   *                   When non-null it must preserve the same {@code maxId} as {@code highWaterId}.
+   */
+  public RelationshipKeysetPage(@Nonnull List<R> relationships, long highWaterId,
+      @Nullable RelationshipKeysetCursor nextCursor) {
+    if (relationships == null) {
+      throw new IllegalArgumentException("relationships must not be null");
+    }
+    if (highWaterId < 0) {
+      throw new IllegalArgumentException(
+          "highWaterId must be non-negative but was " + highWaterId);
+    }
+    if (nextCursor != null && nextCursor.getMaxId() != highWaterId) {
+      throw new IllegalArgumentException(
+          "nextCursor maxId (" + nextCursor.getMaxId() + ") must match highWaterId ("
+              + highWaterId + ")");
+    }
+    this.relationships =
+        Collections.unmodifiableList(new ArrayList<>(relationships));
+    this.highWaterId = highWaterId;
+    this.nextCursor = nextCursor;
+  }
+}

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -13,6 +13,8 @@ import com.linkedin.metadata.dao.EbeanLocalDAO;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipQueryDAO;
 import com.linkedin.metadata.dao.EbeanLocalRelationshipWriterDAO;
 import com.linkedin.metadata.dao.IEbeanLocalAccess;
+import com.linkedin.metadata.dao.RelationshipKeysetCursor;
+import com.linkedin.metadata.dao.RelationshipKeysetPage;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
 import com.linkedin.metadata.dao.utils.EmbeddedMariaInstance;
@@ -2190,4 +2192,414 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertEquals(results.size(), 1);
     assertEquals(results.get(0).getRelatedTo().getBelongsToV2().getDestination().getString(), problematicUrn);
   }
+
+  // -------------------------------------------------------------------------
+  // Keyset (seek) pagination: typed API, model and baseline SQL builder
+  // -------------------------------------------------------------------------
+
+  private LocalRelationshipFilter emptyFilter() {
+    return new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray());
+  }
+
+  private LocalRelationshipFilter outgoingEmptyFilter() {
+    return new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray())
+        .setDirection(RelationshipDirection.OUTGOING);
+  }
+
+  private List<FooUrn> addReportsToChain(int count, FooUrn destination) throws URISyntaxException {
+    List<FooUrn> sources = new ArrayList<>();
+    for (int i = 1; i <= count; i++) {
+      FooUrn source = new FooUrn(100 + i);
+      _localRelationshipWriterDAO.addRelationships(source, AspectFoo.class,
+          Collections.singletonList(new ReportsTo().setSource(source).setDestination(destination)), false);
+      sources.add(source);
+    }
+    return sources;
+  }
+
+  private RelationshipKeysetPage<ReportsTo> keysetPage(int pageSize, RelationshipKeysetCursor cursor) {
+    return _localRelationshipQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, outgoingEmptyFilter(), pageSize, cursor);
+  }
+
+  private List<ReportsTo> drainKeyset(int pageSize) {
+    List<ReportsTo> all = new ArrayList<>();
+    RelationshipKeysetCursor cursor = null;
+    do {
+      RelationshipKeysetPage<ReportsTo> page = keysetPage(pageSize, cursor);
+      all.addAll(page.getRelationships());
+      cursor = page.getNextCursor();
+    } while (cursor != null);
+    return all;
+  }
+
+  @Test
+  public void testBuildFindRelationshipKeysetSQL() {
+    // Unlike the existing offset builder, the keyset builder adds `id > lastId`, `id <= maxId`,
+    // `ORDER BY rt.id ASC` and a finite LIMIT.
+    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+        "source_table_name", null, "destination_table_name", null,
+        10, 5, 20);
+
+    assertEquals(sql,
+        "SELECT rt.* FROM relationship_table_name rt INNER JOIN destination_table_name dt ON dt.urn=rt.destination "
+            + "INNER JOIN source_table_name st ON st.urn=rt.source WHERE rt.deleted_ts is NULL "
+            + "AND rt.id > 5 AND rt.id <= 20 ORDER BY rt.id ASC LIMIT 10");
+  }
+
+  @Test
+  public void testBuildFindRelationshipKeysetSQLWithSource() {
+    LocalRelationshipCriterion filterCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create("Alice"),
+        Condition.EQUAL,
+        new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"));
+    LocalRelationshipFilter srcFilter = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterCriterion));
+
+    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+        "metadata_entity_foo", srcFilter, "destination_table_name", null,
+        10, 5, 20);
+
+    assertEquals(sql,
+        "SELECT rt.* FROM relationship_table_name rt INNER JOIN destination_table_name dt ON dt.urn=rt.destination "
+            + "INNER JOIN metadata_entity_foo st ON st.urn=rt.source WHERE rt.deleted_ts is NULL AND st.i_aspectfoo"
+            + (_eBeanDAOConfig.isNonDollarVirtualColumnsEnabled() ? "0" : "$") + "value='Alice' "
+            + "AND rt.id > 5 AND rt.id <= 20 ORDER BY rt.id ASC LIMIT 10");
+  }
+
+  @Test
+  public void testBuildFindRelationshipKeysetSQLRejectsInvalidPageSize() {
+    // Zero and negative are rejected.
+    expectThrows(IllegalArgumentException.class, () ->
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+            new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+            null, null, null, null, 0, 0, 20));
+    expectThrows(IllegalArgumentException.class, () ->
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+            new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+            null, null, null, null, -1, 0, 20));
+    // Above the hard upper bound of 1000 is rejected.
+    expectThrows(IllegalArgumentException.class, () ->
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+            new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+            null, null, null, null, 1001, 0, 20));
+  }
+
+  @Test
+  public void testKeysetPaginationRejectedInOldSchemaMode() throws URISyntaxException {
+    addReportsToChain(2, new FooUrn(1));
+    _localRelationshipQueryDAO.setSchemaConfig(EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY);
+
+    // Typed API rejects OLD_SCHEMA_ONLY before building/executing any SQL.
+    expectThrows(UnsupportedOperationException.class, () -> keysetPage(3, null));
+
+    // The public SQL builder rejects OLD_SCHEMA_ONLY as well.
+    expectThrows(UnsupportedOperationException.class, () ->
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+            new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+            null, null, null, null, 10, 5, 20));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetEmptyTable() {
+    RelationshipKeysetPage<ReportsTo> page = keysetPage(3, null);
+    assertTrue(page.getRelationships().isEmpty());
+    assertNull(page.getNextCursor());
+    assertEquals(page.getHighWaterId(), 0L);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetRejectsInvalidPageSize() {
+    expectThrows(IllegalArgumentException.class, () -> keysetPage(0, null));
+    expectThrows(IllegalArgumentException.class, () -> keysetPage(-1, null));
+    // Above the hard upper bound of 1000 is rejected.
+    expectThrows(IllegalArgumentException.class, () -> keysetPage(1001, null));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetFewerThanPageSize() throws URISyntaxException {
+    addReportsToChain(2, new FooUrn(1));
+    RelationshipKeysetPage<ReportsTo> page = keysetPage(5, null);
+    assertEquals(page.getRelationships().size(), 2);
+    assertNull(page.getNextCursor());
+    assertEquals(page.getHighWaterId(), 2L);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetExactlyPageSize() throws URISyntaxException {
+    addReportsToChain(3, new FooUrn(1));
+
+    // A full page whose last matching row equals maxId ends the scan: no next cursor.
+    RelationshipKeysetPage<ReportsTo> first = keysetPage(3, null);
+    assertEquals(first.getRelationships().size(), 3);
+    assertNull(first.getNextCursor());
+    assertEquals(first.getHighWaterId(), 3L);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetFullPageBelowMaxIdYieldsFinalEmptyQuery()
+      throws URISyntaxException {
+    FooUrn dest = new FooUrn(1);
+    // Insert 3 rows (ids 1..3), then soft-delete the last two by re-pointing their sources.
+    List<FooUrn> sources = addReportsToChain(3, dest);
+    // Re-adding source #2 and #3 soft-deletes ids 2 and 3 and inserts ids 4 and 5.
+    _localRelationshipWriterDAO.addRelationships(sources.get(1), AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(sources.get(1)).setDestination(new FooUrn(2))), false);
+    _localRelationshipWriterDAO.addRelationships(sources.get(2), AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(sources.get(2)).setDestination(new FooUrn(2))), false);
+
+    // Current rows toward dest #1: only id 1. High-water id is 5 because later nonmatching rows
+    // (ids 4/5 pointing elsewhere) set maxId. A page size of 1 fills fully with id 1 (below maxId
+    // 5), so a next cursor is produced; that continuation query is empty because ids 2 and 3 are
+    // soft-deleted and 4/5 point elsewhere, so one final empty page is needed to end the scan.
+    LocalRelationshipCriterion relCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create(dest.toString()), Condition.EQUAL, new UrnField().setName("destination"));
+    LocalRelationshipFilter relationshipFilter = new LocalRelationshipFilter()
+        .setCriteria(new LocalRelationshipCriterionArray(relCriterion))
+        .setDirection(RelationshipDirection.OUTGOING);
+
+    RelationshipKeysetPage<ReportsTo> first = _localRelationshipQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, relationshipFilter, 1, null);
+    assertEquals(first.getRelationships().size(), 1);
+    assertNotNull(first.getNextCursor());
+    assertEquals(first.getNextCursor().getMaxId(), 5L);
+
+    RelationshipKeysetPage<ReportsTo> second = _localRelationshipQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, relationshipFilter, 1, first.getNextCursor());
+    assertTrue(second.getRelationships().isEmpty());
+    assertNull(second.getNextCursor());
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetMultiPageOrderedComplete() throws URISyntaxException {
+    Set<FooUrn> expectedSources = new java.util.HashSet<>(addReportsToChain(7, new FooUrn(1)));
+
+    List<ReportsTo> drained = drainKeyset(2);
+
+    assertEquals(drained.size(), 7);
+    Set<FooUrn> actualSources = drained.stream()
+        .map(r -> makeFooUrn(r.getSource().toString()))
+        .collect(Collectors.toSet());
+    // No duplicates and all sources present.
+    assertEquals(actualSources.size(), 7);
+    assertEquals(actualSources, expectedSources);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetHighWaterExcludesLaterInsert() throws URISyntaxException {
+    addReportsToChain(5, new FooUrn(1));
+
+    // Capture the high-water id on the first page.
+    RelationshipKeysetCursor cursor = null;
+    List<ReportsTo> drained = new ArrayList<>();
+    RelationshipKeysetPage<ReportsTo> page = keysetPage(2, null);
+    drained.addAll(page.getRelationships());
+    cursor = page.getNextCursor();
+    assertEquals(page.getHighWaterId(), 5L);
+
+    // Insert more rows after the scan started; they must not be observed. These later inserts are
+    // deterministically excluded by the fixed maxId (best effort only covers updates/deletes of
+    // existing ids). Use distinct sources (200+) so no existing relationship is superseded.
+    for (int i = 1; i <= 3; i++) {
+      FooUrn src = new FooUrn(200 + i);
+      _localRelationshipWriterDAO.addRelationships(src, AspectFoo.class,
+          Collections.singletonList(new ReportsTo().setSource(src).setDestination(new FooUrn(2))), false);
+    }
+
+    while (cursor != null) {
+      page = keysetPage(2, cursor);
+      drained.addAll(page.getRelationships());
+      cursor = page.getNextCursor();
+    }
+
+    assertEquals(drained.size(), 5);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetSoftDeletedGaps() throws URISyntaxException {
+    FooUrn dest = new FooUrn(1);
+    FooUrn a = new FooUrn(101);
+    FooUrn b = new FooUrn(102);
+    FooUrn c = new FooUrn(103);
+    _localRelationshipWriterDAO.addRelationships(a, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(a).setDestination(dest)), false);
+    _localRelationshipWriterDAO.addRelationships(b, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(b).setDestination(dest)), false);
+    _localRelationshipWriterDAO.addRelationships(c, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(c).setDestination(dest)), false);
+
+    // Re-adding B soft-deletes its first row and inserts a new one, creating an id gap.
+    _localRelationshipWriterDAO.addRelationships(b, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(b).setDestination(dest)), false);
+
+    List<ReportsTo> drained = drainKeyset(2);
+
+    // Verifies a soft-deleted id sitting between live rows does not stop or skip the later live
+    // rows (distinct from the final-empty case: the gap is mid-scan, not a trailing empty page).
+    // Only the three current (non-deleted) relationships are returned, gap skipped.
+    assertEquals(drained.size(), 3);
+    Set<FooUrn> actual = drained.stream()
+        .map(r -> makeFooUrn(r.getSource().toString()))
+        .collect(Collectors.toSet());
+    assertEquals(actual, ImmutableSet.of(a, b, c));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetWithSourceFilter() throws URISyntaxException {
+    FooUrn alice = new FooUrn(1);
+    FooUrn bob = new FooUrn(2);
+    _fooUrnEBeanLocalAccess.add(alice, new AspectFoo().setValue("Alice"), AspectFoo.class, new AuditStamp(), null, false);
+    _fooUrnEBeanLocalAccess.add(bob, new AspectFoo().setValue("Bob"), AspectFoo.class, new AuditStamp(), null, false);
+
+    FooUrn boss = new FooUrn(9);
+    _localRelationshipWriterDAO.addRelationships(alice, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(alice).setDestination(boss)), false);
+    _localRelationshipWriterDAO.addRelationships(bob, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(bob).setDestination(boss)), false);
+
+    LocalRelationshipCriterion filterCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create("Alice"),
+        Condition.EQUAL,
+        new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"));
+    LocalRelationshipFilter srcFilter = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterCriterion));
+
+    RelationshipKeysetPage<ReportsTo> page = _localRelationshipQueryDAO.findRelationshipsByKeyset(
+        FooSnapshot.class, srcFilter, null, emptyFilter(), ReportsTo.class,
+        outgoingEmptyFilter(), 5, null);
+
+    assertEquals(page.getRelationships().size(), 1);
+    assertEquals(makeFooUrn(page.getRelationships().get(0).getSource().toString()), alice);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetWithDestinationFilter() throws URISyntaxException {
+    FooUrn worker = new FooUrn(1);
+    FooUrn alice = new FooUrn(2);
+    FooUrn bob = new FooUrn(3);
+    _fooUrnEBeanLocalAccess.add(alice, new AspectFoo().setValue("Alice"), AspectFoo.class, new AuditStamp(), null, false);
+    _fooUrnEBeanLocalAccess.add(bob, new AspectFoo().setValue("Bob"), AspectFoo.class, new AuditStamp(), null, false);
+
+    _localRelationshipWriterDAO.addRelationships(worker, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(worker).setDestination(alice)), false);
+    // A second source reporting to bob so the destination filter has something to exclude.
+    _localRelationshipWriterDAO.addRelationships(new FooUrn(4), AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(new FooUrn(4)).setDestination(bob)), false);
+
+    LocalRelationshipCriterion filterCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create("Alice"),
+        Condition.EQUAL,
+        new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"));
+    LocalRelationshipFilter destFilter = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterCriterion));
+
+    RelationshipKeysetPage<ReportsTo> page = _localRelationshipQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), FooSnapshot.class, destFilter, ReportsTo.class,
+        outgoingEmptyFilter(), 5, null);
+
+    assertEquals(page.getRelationships().size(), 1);
+    assertEquals(makeFooUrn(page.getRelationships().get(0).getDestination().toString()), alice);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetWithRelationshipFilter() throws URISyntaxException {
+    FooUrn worker = new FooUrn(1);
+    FooUrn alice = new FooUrn(2);
+    _fooUrnEBeanLocalAccess.add(worker, new AspectFoo().setValue("Worker"), AspectFoo.class, new AuditStamp(), null, false);
+    _fooUrnEBeanLocalAccess.add(alice, new AspectFoo().setValue("Alice"), AspectFoo.class, new AuditStamp(), null, false);
+
+    _localRelationshipWriterDAO.addRelationships(worker, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(worker).setDestination(alice)), false);
+    _localRelationshipWriterDAO.addRelationships(new FooUrn(3), AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(new FooUrn(3)).setDestination(new FooUrn(4))), false);
+
+    LocalRelationshipCriterion relCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create(alice.toString()), Condition.EQUAL, new UrnField().setName("destination"));
+    LocalRelationshipFilter relationshipFilter = new LocalRelationshipFilter()
+        .setCriteria(new LocalRelationshipCriterionArray(relCriterion))
+        .setDirection(RelationshipDirection.OUTGOING);
+
+    RelationshipKeysetPage<ReportsTo> page = _localRelationshipQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, relationshipFilter, 5, null);
+
+    assertEquals(page.getRelationships().size(), 1);
+    assertEquals(makeFooUrn(page.getRelationships().get(0).getDestination().toString()), alice);
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetBestEffortMembershipUnderConcurrentReplacement()
+      throws URISyntaxException {
+    FooUrn dest = new FooUrn(1);
+    FooUrn a = new FooUrn(101);
+    FooUrn b = new FooUrn(102);
+    FooUrn c = new FooUrn(103);
+    FooUrn d = new FooUrn(104);
+    // Ids 1..4, all current, all pointing at dest.
+    _localRelationshipWriterDAO.addRelationships(a, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(a).setDestination(dest)), false);
+    _localRelationshipWriterDAO.addRelationships(b, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(b).setDestination(dest)), false);
+    _localRelationshipWriterDAO.addRelationships(c, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(c).setDestination(dest)), false);
+    _localRelationshipWriterDAO.addRelationships(d, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(d).setDestination(dest)), false);
+
+    // Page 1 (size 2) captures the insertion high-water id maxId = 4 and returns ids 1,2 (a, b).
+    RelationshipKeysetPage<ReportsTo> first = keysetPage(2, null);
+    assertEquals(first.getHighWaterId(), 4L);
+    assertNotNull(first.getNextCursor());
+    List<ReportsTo> drained = new ArrayList<>(first.getRelationships());
+
+    // Between pages, "concurrently" replace c: this soft-deletes id 3 (which is <= maxId) and
+    // inserts a fresh current row id 5 (which is > maxId). The replacement row is excluded by the
+    // fixed maxId bound and the original id 3 is soft-deleted, so c may disappear from the scan even
+    // though it was current when the scan began. Because each page is a separate statement, maxId is
+    // only an insertion high-water mark, not a stable/complete snapshot: this is the documented
+    // best-effort membership behavior, chosen so the scan stays finite.
+    _localRelationshipWriterDAO.addRelationships(c, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(c).setDestination(dest)), false);
+
+    RelationshipKeysetCursor cursor = first.getNextCursor();
+    while (cursor != null) {
+      RelationshipKeysetPage<ReportsTo> page = keysetPage(2, cursor);
+      drained.addAll(page.getRelationships());
+      cursor = page.getNextCursor();
+    }
+
+    // c is missing: the scan reflects rows current when each page ran, not a snapshot of the
+    // rows that were current when the scan started.
+    Set<FooUrn> actual = drained.stream()
+        .map(r -> makeFooUrn(r.getSource().toString()))
+        .collect(Collectors.toSet());
+    assertEquals(actual, ImmutableSet.of(a, b, d));
+    assertFalse(actual.contains(c));
+  }
+
+  @Test
+  public void testRelationshipKeysetCursorValidationAndGetters() {
+    RelationshipKeysetCursor cursor = new RelationshipKeysetCursor(3, 10);
+    assertEquals(cursor.getLastId(), 3L);
+    assertEquals(cursor.getMaxId(), 10L);
+
+    expectThrows(IllegalArgumentException.class, () -> new RelationshipKeysetCursor(-1, 10));
+    expectThrows(IllegalArgumentException.class, () -> new RelationshipKeysetCursor(3, -1));
+    expectThrows(IllegalArgumentException.class, () -> new RelationshipKeysetCursor(11, 10));
+  }
+
+  @Test
+  public void testRelationshipKeysetPageDefensiveAndValidation() throws URISyntaxException {
+    List<ReportsTo> source = new ArrayList<>();
+    source.add(new ReportsTo().setSource(new FooUrn(1)).setDestination(new FooUrn(2)));
+    RelationshipKeysetPage<ReportsTo> page =
+        new RelationshipKeysetPage<>(source, 10, new RelationshipKeysetCursor(5, 10));
+
+    // Defensive copy: mutating the input list cannot alter the returned page contents.
+    source.clear();
+    assertEquals(page.getRelationships().size(), 1);
+    assertNotNull(page.getNextCursor());
+    expectThrows(UnsupportedOperationException.class, () -> page.getRelationships().add(null));
+
+    // next cursor maxId must match highWaterId.
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetPage<>(new ArrayList<ReportsTo>(), 10, new RelationshipKeysetCursor(5, 9)));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetPage<ReportsTo>(null, 10, null));
+  }
+
 }


### PR DESCRIPTION
## Summary

- Add typed keyset pagination for current relationship queries in `EbeanLocalRelationshipQueryDAO`.
- Bound each page by relationship ID using a fixed insertion high-water mark, stable ordering, and a positive page size.
- Enforce a maximum page size of 1,000 and support only new/dual schemas; old-schema callers fail explicitly.
- Preserve all existing offset-based APIs and centralize filters, schema naming, and index handling in the shared DAO.
- Document best-effort cross-page mutation consistency; rows inserted after page one are excluded, while concurrent updates or soft-deletes may affect later-page membership.

Related issue: [META-24159](https://linkedin.atlassian.net/browse/META-24159)

Follow-up changes are prepared separately:

1. V4 wrapper keyset pagination: `rgujar/add-v4-relationship-keyset-pagination`
2. Single-destination query optimization: `rgujar/optimize-single-destination-keyset`

## Testing Done

- `./gradlew :dao-impl:ebean-dao:test --tests com.linkedin.metadata.dao.localrelationship.EbeanLocalRelationshipQueryDAOTest`
- `./gradlew :dao-impl:ebean-dao:checkstyleMain`
- `./gradlew :dao-impl:ebean-dao:checkstyleTest`
- `./gradlew spotlessCheck`
- `EbeanLocalRelationshipQueryDAOTest`: 160 tests passed.
- Added TestNG coverage for empty/partial/exact/multi-page reads, insertion high-water behavior, concurrent replacement semantics, deleted-row gaps, typed entity and relationship filters, cursor validation, and defensive page behavior.

### Planned EI end-to-end validation

The production supernode from META-24159 does not exist in `ei-ltx1` or `ei4`, and no EI-origin equivalent was found. Its `DownstreamOf` degree is zero in EI.

After the V4 and GQS caller follow-ups are available, seed disposable data once in `ei-ltx1` using the synchronous metadata-store APIs:

1. Use timestamped EI-origin `external` dataset URNs:
   - `urn:li:dataset:(urn:li:dataPlatform:external,meta-24159.rgujar.<run-id>.hub,EI)`
   - `urn:li:dataset:(urn:li:dataPlatform:external,meta-24159.rgujar.<run-id>.child-0001,EI)`
2. Create the hub's default dataset-instance status with `DatasetInstances#setDatasetInstanceStatus(removed=false)`.
3. Create 1,001 children by calling `Datasets#setUpstreamLineage` once per child, with the hub as its single upstream dataset. This materializes 1,001 current `DownstreamOf` edges.
4. Write at no more than 5 requests/second with bounded concurrency and a persisted manifest of every test URN.
5. Query GQS with `stepMinDepth=1`, `stepMaxDepth=2`, `maxDepth=2`, and `maxNodes=1000`. Verify 1,000 unique results, bounded latency, two 500-row DAO pages, early termination, and no third page fetch.
6. Cleanup each child with `Datasets#overwriteUpstreamLineage(child, emptyLineage, false)`; a normal empty lineage write is not sufficient because actor-merge semantics can retain edges. Then mark child statuses removed and mark the hub removed last.
7. Verify the hub has zero active relationships through the DB-facing GQS API before completing cleanup.

This validates pagination and early-stop correctness, not 24.8M-edge production-scale performance.

### Rollout plan

This PR is additive: it introduces a new API and does not change any existing caller or offset-based query.

- V4 wrapper support and the single-destination query-plan optimization are separate follow-up changes.
- GQS does not currently have a keyset-path gate. Its caller PR must add a default-off CFG2 boolean that chooses exactly one path per request; do not shadow both paths because that would duplicate the expensive read.
- Add `pagesFetched`, `rowsFetched`, `pageSize`, and `stoppedEarly` logs/metrics in the GQS caller before EI validation.
- Validate QuickDeploy/D2 routing for the candidate build first, then run the synthetic EI test.
- Compare old and keyset paths through separate EI invocations on synthetic and known-low-degree queries, checking result sets and latency.
- Ramp the CFG2 gate to EI, then one production fabric/ring, while retaining the old path for immediate rollback.
- Ranked/non-current relationship queries continue using the existing API because their ranking semantics cannot be safely keyset-paged.
- Metadata-store adopts the typed API independently after the shared dependency is released.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
