### PR TITLE
feat(ebean-dao): add V4 relationship keyset pagination

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -297,8 +297,8 @@ public class EbeanLocalRelationshipQueryDAO {
    * rows updated or soft-deleted between page calls can change which rows a later page returns (see
    * {@link RelationshipKeysetCursor}).</p>
    *
-   * <p>Supported only when {@code SchemaConfig} is {@code NEW_SCHEMA_ONLY} or {@code DUAL_SCHEMA};
-   * {@code OLD_SCHEMA_ONLY} throws {@link UnsupportedOperationException}.</p>
+   * <p>Supported only when {@code SchemaConfig} is {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY}
+   * and {@code DUAL_SCHEMA} (deprecated) throw {@link UnsupportedOperationException}.</p>
    *
    * @param sourceEntityClass the source entity class to query
    * @param sourceEntityFilter the filter to apply to the source entity when querying
@@ -310,7 +310,7 @@ public class EbeanLocalRelationshipQueryDAO {
    *                 1000 inclusive.
    * @param cursor the cursor from the previous page, or {@code null} for the first page.
    * @return a page of relationship records plus a next cursor (null when the scan is exhausted).
-   * @throws UnsupportedOperationException when the DAO is in {@code OLD_SCHEMA_ONLY} mode.
+   * @throws UnsupportedOperationException when the DAO is not in {@code NEW_SCHEMA_ONLY} mode.
    */
   @Nonnull
   public <SRC_SNAPSHOT extends RecordTemplate, DEST_SNAPSHOT extends RecordTemplate, RELATIONSHIP extends RecordTemplate>
@@ -347,12 +347,77 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Shared row-level keyset core for {@link #findRelationshipsByKeyset}: captures the first-page
-   * {@code maxId} (largest row id when paging starts), runs the current-only keyset SQL, validates
-   * strictly increasing id progress and computes the next cursor. Callers resolve their own table
-   * names/filters and map the returned rows. Supported only for {@code NEW_SCHEMA_ONLY} and
-   * {@code DUAL_SCHEMA}; {@code OLD_SCHEMA_ONLY} throws {@link UnsupportedOperationException} before
-   * any SQL is built or executed.
+   * Keyset (seek) paginated, current-only ({@code deleted_ts IS NULL}) variant of
+   * {@link #findRelationshipsV4(String, LocalRelationshipFilter, String, LocalRelationshipFilter,
+   * Class, LocalRelationshipFilter, Class, Map, int, int, RelationshipLookUpContext)} that walks the
+   * matching set in bounded pages and returns the same wrapped {@code ASSET_RELATIONSHIP} records.
+   * Validates V4 logical-expression filters and the {@code wrapOptions} contract. Ranked/non-current
+   * pagination is unsupported because it could not bound the per-page DB work.
+   *
+   * <p>First page: pass {@code cursor = null}; the DAO captures {@code maxId}, the largest
+   * relationship row id when paging starts ({@code COALESCE(MAX(id), 0)}), and returns rows with
+   * {@code 0 < rt.id <= maxId} ordered by id, up to {@code pageSize}. Continuation: pass the next
+   * cursor from the previous {@link RelationshipKeysetPage}. Later inserts get larger ids and are
+   * excluded, keeping the scan finite. The combined pages are not a point-in-time snapshot: existing
+   * rows updated or soft-deleted between page calls can change which rows a later page returns (see
+   * {@link RelationshipKeysetCursor}).</p>
+   *
+   * <p>Supported only when {@code SchemaConfig} is {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY}
+   * and {@code DUAL_SCHEMA} (deprecated) throw {@link UnsupportedOperationException}.</p>
+   *
+   * @param sourceEntityType type of source entity to query (e.g. "dataset")
+   * @param sourceEntityFilter filter on the source entity (not applicable to non-MG entities); criteria must be null, use logicalExpressionCriteria
+   * @param destinationEntityType type of destination entity to query (e.g. "dataset")
+   * @param destinationEntityFilter filter on the destination entity (not applicable to non-MG entities); criteria must be null, use logicalExpressionCriteria
+   * @param relationshipType the type of relationship to query
+   * @param relationshipFilter filter on the relationship; criteria must be null, use logicalExpressionCriteria
+   * @param assetRelationshipClass the wrapper class for the relationship type
+   * @param wrapOptions options to wrap the relationship. Must carry the AssetRelationship return type marker.
+   * @param pageSize the maximum number of relationships to return per page. Must be between 1 and
+   *                 1000 inclusive.
+   * @param cursor the cursor from the previous page, or {@code null} for the first page.
+   * @return a page of wrapped relationship records plus a next cursor (null when the scan is exhausted).
+   * @throws IllegalArgumentException when {@code wrapOptions} does not carry {@code RELATIONSHIP_RETURN_TYPE}
+   *         set to {@code MG_INTERNAL_ASSET_RELATIONSHIP_TYPE}.
+   * @throws UnsupportedOperationException when the DAO is not in {@code NEW_SCHEMA_ONLY} mode.
+   */
+  @Nonnull
+  public <ASSET_RELATIONSHIP extends RecordTemplate, RELATIONSHIP extends RecordTemplate>
+      RelationshipKeysetPage<ASSET_RELATIONSHIP> findRelationshipsV4ByKeyset(
+      @Nullable String sourceEntityType, @Nullable LocalRelationshipFilter sourceEntityFilter,
+      @Nullable String destinationEntityType, @Nullable LocalRelationshipFilter destinationEntityFilter,
+      @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
+      @Nonnull Class<ASSET_RELATIONSHIP> assetRelationshipClass, @Nullable Map<String, Object> wrapOptions,
+      int pageSize, @Nullable RelationshipKeysetCursor cursor) {
+    validateAssetRelationshipWrapOptions(wrapOptions, "findRelationshipsV4ByKeyset");
+
+    validateEntityTypeAndFilter(sourceEntityFilter, sourceEntityType, true);
+    validateEntityTypeAndFilter(destinationEntityFilter, destinationEntityType, true);
+    validateRelationshipFilter(relationshipFilter, true);
+
+    final String sourceTableName = getMgEntityTableName(sourceEntityType);
+    final String destTableName = getMgEntityTableName(destinationEntityType);
+    final String relationshipTableName = SQLSchemaUtils.getRelationshipTableName(relationshipType);
+
+    final KeysetScanResult scan = findRelationshipsByKeysetCore(relationshipTableName, sourceTableName,
+        sourceEntityFilter, destTableName, destinationEntityFilter, relationshipFilter, pageSize, cursor);
+
+    final List<ASSET_RELATIONSHIP> relationships = new ArrayList<>(scan.getRows().size());
+    for (SqlRow row : scan.getRows()) {
+      relationships.add(createAssetRelationshipWrapperForRelationship(
+          relationshipType, assetRelationshipClass, row.getString(METADATA), row.getString(SOURCE), wrapOptions));
+    }
+
+    return new RelationshipKeysetPage<>(relationships, scan.getHighWaterId(), scan.getNextCursor());
+  }
+
+  /**
+   * Shared row-level keyset core for {@link #findRelationshipsByKeyset} and
+   * {@link #findRelationshipsV4ByKeyset}: captures the first-page {@code maxId} (largest row id when
+   * paging starts), runs the current-only keyset SQL, validates strictly increasing id progress and
+   * computes the next cursor. Callers resolve their own table names/filters and map the returned
+   * rows. Supported only for {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY} and {@code DUAL_SCHEMA}
+   * (deprecated) throw {@link UnsupportedOperationException} before any SQL is built or executed.
    */
   @Nonnull
   private KeysetScanResult findRelationshipsByKeysetCore(@Nonnull final String relationshipTableName,
@@ -364,11 +429,11 @@ public class EbeanLocalRelationshipQueryDAO {
       throw new IllegalArgumentException(
           "pageSize must be between 1 and " + MAX_KEYSET_PAGE_SIZE + " but was " + pageSize);
     }
-    if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
+    if (_schemaConfig != EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY) {
       throw new UnsupportedOperationException(
-          "Keyset pagination is not supported in OLD_SCHEMA_ONLY mode; use NEW_SCHEMA_ONLY or DUAL_SCHEMA.");
+          "Keyset pagination is only supported in NEW_SCHEMA_ONLY mode; OLD_SCHEMA_ONLY and DUAL_SCHEMA "
+              + "(deprecated) are rejected.");
     }
-
     final long lastId;
     final long maxId;
     if (cursor == null) {
@@ -540,10 +605,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
       @Nonnull Class<ASSET_RELATIONSHIP> assetRelationshipClass, @Nullable Map<String, Object> wrapOptions,
       int offset, int count, RelationshipLookUpContext relationshipLookUpContext) {
-    if (wrapOptions == null || !wrapOptions.containsKey(RELATIONSHIP_RETURN_TYPE)
-        || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(RELATIONSHIP_RETURN_TYPE))) {
-      throw new IllegalArgumentException("Please check your use of the findRelationshipsV3 method.");
-    }
+    validateAssetRelationshipWrapOptions(wrapOptions, "findRelationshipsV3");
 
     List<SqlRow> sqlRows = findRelationshipsV2V3V4Core(
         sourceEntityType, sourceEntityFilter, destinationEntityType, destinationEntityFilter,
@@ -582,10 +644,7 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull LocalRelationshipFilter relationshipFilter,
       @Nonnull Class<ASSET_RELATIONSHIP> assetRelationshipClass, @Nullable Map<String, Object> wrapOptions,
       int offset, int count, RelationshipLookUpContext relationshipLookUpContext) {
-    if (wrapOptions == null || !wrapOptions.containsKey(RELATIONSHIP_RETURN_TYPE)
-        || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(RELATIONSHIP_RETURN_TYPE))) {
-      throw new IllegalArgumentException("Please check your use of the findRelationshipsV3 method.");
-    }
+    validateAssetRelationshipWrapOptions(wrapOptions, "findRelationshipsV4");
 
     List<SqlRow> sqlRows = findRelationshipsV2V3V4Core(
         sourceEntityType, sourceEntityFilter, destinationEntityType, destinationEntityFilter,
@@ -595,6 +654,25 @@ public class EbeanLocalRelationshipQueryDAO {
         .map(row -> createAssetRelationshipWrapperForRelationship(
             relationshipType, assetRelationshipClass, row.getString(METADATA), row.getString(SOURCE), wrapOptions))
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Validates that {@code wrapOptions} carries the AssetRelationship return-type marker required by
+   * the V3/V4 asset-relationship APIs. Shared by {@link #findRelationshipsV3}, {@link #findRelationshipsV4}
+   * and {@link #findRelationshipsV4ByKeyset} to avoid duplicating the contract check.
+   *
+   * @param wrapOptions the wrap options supplied by the caller
+   * @param methodName the calling method name, surfaced in the error message
+   * @throws IllegalArgumentException when {@code wrapOptions} is null or does not carry
+   *         {@code RELATIONSHIP_RETURN_TYPE} set to {@code MG_INTERNAL_ASSET_RELATIONSHIP_TYPE}.
+   */
+  private static void validateAssetRelationshipWrapOptions(@Nullable Map<String, Object> wrapOptions,
+      @Nonnull String methodName) {
+    if (wrapOptions == null || !wrapOptions.containsKey(RELATIONSHIP_RETURN_TYPE)
+        || !MG_INTERNAL_ASSET_RELATIONSHIP_TYPE.equals(wrapOptions.get(RELATIONSHIP_RETURN_TYPE))) {
+      throw new IllegalArgumentException(methodName + " requires wrapOptions to carry key '"
+          + RELATIONSHIP_RETURN_TYPE + "' set to '" + MG_INTERNAL_ASSET_RELATIONSHIP_TYPE + "'.");
+    }
   }
 
   /**
@@ -1045,8 +1123,8 @@ public class EbeanLocalRelationshipQueryDAO {
    * <p>Always current-only ({@code deleted_ts IS NULL}); ranked/non-current pagination is
    * unsupported because it could not bound the per-page DB work.</p>
    *
-   * <p>Supported only for {@code NEW_SCHEMA_ONLY} and {@code DUAL_SCHEMA}; {@code OLD_SCHEMA_ONLY}
-   * throws {@link UnsupportedOperationException}.</p>
+   * <p>Supported only for {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY} and {@code DUAL_SCHEMA}
+   * (deprecated) throw {@link UnsupportedOperationException} before any SQL is built.</p>
    */
   @Nonnull
   @VisibleForTesting
@@ -1058,9 +1136,10 @@ public class EbeanLocalRelationshipQueryDAO {
       throw new IllegalArgumentException(
           "pageSize must be between 1 and " + MAX_KEYSET_PAGE_SIZE + " but was " + pageSize);
     }
-    if (_schemaConfig == EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY) {
+    if (_schemaConfig != EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY) {
       throw new UnsupportedOperationException(
-          "Keyset pagination is not supported in OLD_SCHEMA_ONLY mode; use NEW_SCHEMA_ONLY or DUAL_SCHEMA.");
+          "Keyset pagination is only supported in NEW_SCHEMA_ONLY mode; OLD_SCHEMA_ONLY and DUAL_SCHEMA "
+              + "(deprecated) are rejected.");
     }
 
     relationshipFilter = LogicalExpressionLocalRelationshipCriterionUtils.normalizeLocalRelationshipFilter(relationshipFilter);
@@ -1078,7 +1157,7 @@ public class EbeanLocalRelationshipQueryDAO {
 
     final List<Triplet<LocalRelationshipFilter, String, String>> filters = new ArrayList<>();
 
-    if (_schemaConfig == EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY || _schemaConfig == EbeanLocalDAO.SchemaConfig.DUAL_SCHEMA) {
+    if (_schemaConfig == EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY) {
       if (destTableName != null) {
         sqlBuilder.append("INNER JOIN ").append(destTableName).append(" dt ON dt.urn=rt.destination ");
 
@@ -1110,8 +1189,8 @@ public class EbeanLocalRelationshipQueryDAO {
       }
       sqlBuilder.append(" AND ").append(lastIdPredicate).append(" AND ").append(maxIdPredicate);
     } else {
-      // OLD_SCHEMA_ONLY is rejected above; only NEW_SCHEMA_ONLY and DUAL_SCHEMA are supported here.
-      throw new RuntimeException("The schema config must be set to DUAL_SCHEMA or NEW_SCHEMA_ONLY.");
+      // OLD_SCHEMA_ONLY and DUAL_SCHEMA are rejected above; only NEW_SCHEMA_ONLY is supported here.
+      throw new RuntimeException("The schema config must be set to NEW_SCHEMA_ONLY.");
     }
 
     sqlBuilder.append(" ORDER BY rt.id ASC LIMIT ").append(pageSize);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -2286,18 +2286,28 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
-  public void testKeysetPaginationRejectedInOldSchemaMode() throws URISyntaxException {
+  public void testKeysetPaginationRejectedInNonNewSchemaModes() throws URISyntaxException {
     addReportsToChain(2, new FooUrn(1));
-    _localRelationshipQueryDAO.setSchemaConfig(EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY);
 
-    // Typed API rejects OLD_SCHEMA_ONLY before building/executing any SQL.
-    expectThrows(UnsupportedOperationException.class, () -> keysetPage(3, null));
+    // Keyset pagination is supported only in NEW_SCHEMA_ONLY. Both OLD_SCHEMA_ONLY and the
+    // deprecated DUAL_SCHEMA must be rejected before building/executing any SQL, on the typed API
+    // and the public SQL builder alike. Restore NEW_SCHEMA_ONLY after each assertion so the mode
+    // cannot leak into subsequent assertions or tests.
+    for (EbeanLocalDAO.SchemaConfig rejectedConfig : new EbeanLocalDAO.SchemaConfig[]{
+        EbeanLocalDAO.SchemaConfig.OLD_SCHEMA_ONLY, EbeanLocalDAO.SchemaConfig.DUAL_SCHEMA}) {
+      _localRelationshipQueryDAO.setSchemaConfig(rejectedConfig);
 
-    // The public SQL builder rejects OLD_SCHEMA_ONLY as well.
-    expectThrows(UnsupportedOperationException.class, () ->
-        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
-            new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
-            null, null, null, null, 10, 5, 20));
+      // Typed API rejects the mode before building/executing any SQL.
+      expectThrows(UnsupportedOperationException.class, () -> keysetPage(3, null));
+
+      // The public SQL builder rejects the mode as well.
+      expectThrows(UnsupportedOperationException.class, () ->
+          _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+              new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+              null, null, null, null, 10, 5, 20));
+
+      _localRelationshipQueryDAO.setSchemaConfig(EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY);
+    }
   }
 
   @Test
@@ -2600,6 +2610,172 @@ public class EbeanLocalRelationshipQueryDAOTest {
         new RelationshipKeysetPage<>(new ArrayList<ReportsTo>(), 10, new RelationshipKeysetCursor(5, 9)));
     expectThrows(IllegalArgumentException.class, () ->
         new RelationshipKeysetPage<ReportsTo>(null, 10, null));
+  }
+
+  // -------------------------------------------------------------------------
+  // V4 keyset (seek) pagination: behavioral tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testFindRelationshipsV4ByKeysetMultiPageWrappedRecordsWithLogicalFilters()
+      throws URISyntaxException {
+    FooUrn owner = new FooUrn(1000);
+    _fooUrnEBeanLocalAccess.add(owner, new AspectFoo().setValue("Owner"), AspectFoo.class, new AuditStamp(), null, false);
+
+    // Five cars, each with aspect value "Car", each belongs-to the same owner.
+    List<FooUrn> cars = new ArrayList<>();
+    for (int i = 1; i <= 5; i++) {
+      FooUrn car = new FooUrn(i);
+      _fooUrnEBeanLocalAccess.add(car, new AspectFoo().setValue("Car"), AspectFoo.class, new AuditStamp(), null, false);
+      BelongsToV2 belongsTo = new BelongsToV2();
+      belongsTo.setDestination(BelongsToV2.Destination.create(owner.toString()));
+      _localRelationshipWriterDAO.addRelationships(car, AspectFoo.class, Collections.singletonList(belongsTo), false);
+      cars.add(car);
+    }
+
+    // Source nonmatch: a "Truck" belongs-to the owner; excluded by the source aspect filter.
+    FooUrn truck = new FooUrn(2000);
+    _fooUrnEBeanLocalAccess.add(truck, new AspectFoo().setValue("Truck"), AspectFoo.class, new AuditStamp(), null, false);
+    BelongsToV2 truckBelongsTo = new BelongsToV2();
+    truckBelongsTo.setDestination(BelongsToV2.Destination.create(owner.toString()));
+    _localRelationshipWriterDAO.addRelationships(truck, AspectFoo.class, Collections.singletonList(truckBelongsTo), false);
+
+    // Destination nonmatch: a "Car" belongs-to a "Stranger"; excluded solely by the destination
+    // aspect filter (destination value != "Owner"). The relationship filter is intentionally an
+    // empty logical OUTGOING filter here, so this row is excluded by the destination filter alone;
+    // relationship-filter behavior is covered independently by the non-MG destination test.
+    FooUrn stranger = new FooUrn(3000);
+    _fooUrnEBeanLocalAccess.add(stranger, new AspectFoo().setValue("Stranger"), AspectFoo.class, new AuditStamp(), null, false);
+    FooUrn strayCar = new FooUrn(6);
+    _fooUrnEBeanLocalAccess.add(strayCar, new AspectFoo().setValue("Car"), AspectFoo.class, new AuditStamp(), null, false);
+    BelongsToV2 strayBelongsTo = new BelongsToV2();
+    strayBelongsTo.setDestination(BelongsToV2.Destination.create(stranger.toString()));
+    _localRelationshipWriterDAO.addRelationships(strayCar, AspectFoo.class, Collections.singletonList(strayBelongsTo), false);
+
+    // Logical source filter: source foo aspect value == "Car".
+    LocalRelationshipFilter srcFilter = new LocalRelationshipFilter().setLogicalExpressionCriteria(
+        wrapCriterionAsLogicalExpression(EBeanDAOUtils.buildRelationshipFieldCriterion(
+            LocalRelationshipValue.create("Car"), Condition.EQUAL,
+            new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"))));
+
+    // Logical destination filter: destination foo aspect value == "Owner".
+    LocalRelationshipFilter destFilter = new LocalRelationshipFilter().setLogicalExpressionCriteria(
+        wrapCriterionAsLogicalExpression(EBeanDAOUtils.buildRelationshipFieldCriterion(
+            LocalRelationshipValue.create("Owner"), Condition.EQUAL,
+            new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"))));
+
+    // Empty logical OUTGOING relationship filter: matches every belongs-to row, so each row is
+    // included or excluded purely by the source and destination entity filters. This keeps the
+    // multi-page test focused on the entity filters; relationship-filter behavior is exercised
+    // independently by the non-MG destination test.
+    LocalRelationshipFilter relationshipFilter = new LocalRelationshipFilter()
+        .setLogicalExpressionCriteria(new LogicalExpressionLocalRelationshipCriterion())
+        .setDirection(RelationshipDirection.OUTGOING);
+
+    Map<String, Object> wrapOptions = new HashMap<>();
+    wrapOptions.put(RELATIONSHIP_RETURN_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+
+    List<AssetRelationship> drained = new ArrayList<>();
+    int pages = 0;
+    RelationshipKeysetCursor cursor = null;
+    do {
+      RelationshipKeysetPage<AssetRelationship> page = _localRelationshipQueryDAO.findRelationshipsV4ByKeyset(
+          "foo", srcFilter, "foo", destFilter, BelongsToV2.class, relationshipFilter,
+          AssetRelationship.class, wrapOptions, 2, cursor);
+      assertEquals(page.getHighWaterId(), 7L);
+      drained.addAll(page.getRelationships());
+      cursor = page.getNextCursor();
+      pages++;
+    } while (cursor != null);
+
+    // 5 matching rows (nonmatching source/destination rows excluded) over pages of size 2
+    // => 3 pages, no duplicates, all wrapped. maxId spans the two nonmatching rows too.
+    assertEquals(pages, 3);
+    assertEquals(drained.size(), 5);
+    Set<String> actualSources = new java.util.HashSet<>();
+    for (AssetRelationship rel : drained) {
+      actualSources.add(rel.getSource());
+      assertEquals(rel.getRelatedTo().getBelongsToV2().getDestination().getString(), owner.toString());
+    }
+    Set<String> expectedSources = cars.stream().map(FooUrn::toString).collect(Collectors.toSet());
+    assertEquals(actualSources, expectedSources);
+  }
+
+  @Test
+  public void testFindRelationshipsV4ByKeysetNonMgDestinationTypeResolvesNoTable() throws URISyntaxException {
+    // GQS non-MG destination usage: GQS passes the literal destination entity type "NON_MG_ASSET"
+    // with a null destination filter. "NON_MG_ASSET" is not a registered MG entity type, so
+    // getMgEntityTableName returns null and no destination entity table is joined. Guards against
+    // accidentally requiring a destination entity table for the V4 keyset wrapper.
+    FooUrn source = new FooUrn(1);
+    _fooUrnEBeanLocalAccess.add(source, new AspectFoo().setValue("Car"), AspectFoo.class, new AuditStamp(), null, false);
+
+    // Non-MG destination: an external dataset urn with no metadata_entity table.
+    String nonMgDestination = "urn:li:dataset:(urn:li:dataPlatform:hdfs,/data/tracking/events,PROD)";
+    BelongsToV2 belongsTo = new BelongsToV2();
+    belongsTo.setDestination(BelongsToV2.Destination.create(nonMgDestination));
+    _localRelationshipWriterDAO.addRelationships(source, AspectFoo.class, Collections.singletonList(belongsTo), false);
+
+    // Source aspect filter still applies; the relationship filter pins the non-MG destination urn.
+    LocalRelationshipFilter srcFilter = new LocalRelationshipFilter().setLogicalExpressionCriteria(
+        wrapCriterionAsLogicalExpression(EBeanDAOUtils.buildRelationshipFieldCriterion(
+            LocalRelationshipValue.create("Car"), Condition.EQUAL,
+            new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"))));
+    LocalRelationshipFilter relationshipFilter = new LocalRelationshipFilter()
+        .setLogicalExpressionCriteria(wrapCriterionAsLogicalExpression(
+            EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create(nonMgDestination),
+                Condition.EQUAL, new UrnField().setName("destination"))))
+        .setDirection(RelationshipDirection.OUTGOING);
+
+    Map<String, Object> wrapOptions = new HashMap<>();
+    wrapOptions.put(RELATIONSHIP_RETURN_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+
+    // Non-MG destination type "NON_MG_ASSET" (as GQS passes) with a null destination filter.
+    RelationshipKeysetPage<AssetRelationship> page = _localRelationshipQueryDAO.findRelationshipsV4ByKeyset(
+        "foo", srcFilter, "NON_MG_ASSET", null, BelongsToV2.class, relationshipFilter,
+        AssetRelationship.class, wrapOptions, 10, null);
+
+    assertEquals(page.getHighWaterId(), 1L);
+    assertNull(page.getNextCursor());
+    assertEquals(page.getRelationships().size(), 1);
+    AssetRelationship wrapped = page.getRelationships().get(0);
+    assertEquals(wrapped.getSource(), source.toString());
+    assertEquals(wrapped.getRelatedTo().getBelongsToV2().getDestination().getString(), nonMgDestination);
+  }
+
+  @Test
+  public void testFindRelationshipsV4ByKeysetRejectsInvalidWrapOptions() {
+    LocalRelationshipFilter emptyLogical = new LocalRelationshipFilter()
+        .setLogicalExpressionCriteria(new LogicalExpressionLocalRelationshipCriterion())
+        .setDirection(RelationshipDirection.OUTGOING);
+
+    // null wrapOptions.
+    expectThrows(IllegalArgumentException.class, () ->
+        _localRelationshipQueryDAO.findRelationshipsV4ByKeyset(
+            null, null, null, null, ReportsTo.class, emptyLogical, AssetRelationship.class, null, 2, null));
+
+    // wrapOptions missing the AssetRelationship return-type marker.
+    Map<String, Object> badWrapOptions = new HashMap<>();
+    badWrapOptions.put(RELATIONSHIP_RETURN_TYPE, "SomethingElse");
+    expectThrows(IllegalArgumentException.class, () ->
+        _localRelationshipQueryDAO.findRelationshipsV4ByKeyset(
+            null, null, null, null, ReportsTo.class, emptyLogical, AssetRelationship.class, badWrapOptions, 2, null));
+  }
+
+  @Test
+  public void testFindRelationshipsV4ByKeysetRejectsCriteriaField() {
+    Map<String, Object> wrapOptions = new HashMap<>();
+    wrapOptions.put(RELATIONSHIP_RETURN_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+
+    // V4 requires logical-expression filters; the legacy criteria field must be rejected.
+    LocalRelationshipFilter criteriaRelationshipFilter = new LocalRelationshipFilter()
+        .setCriteria(new LocalRelationshipCriterionArray())
+        .setDirection(RelationshipDirection.OUTGOING);
+
+    expectThrows(IllegalArgumentException.class, () ->
+        _localRelationshipQueryDAO.findRelationshipsV4ByKeyset(
+            null, null, null, null, ReportsTo.class, criteriaRelationshipFilter,
+            AssetRelationship.class, wrapOptions, 2, null));
   }
 
 }


### PR DESCRIPTION
## Summary

- Add `findRelationshipsV4ByKeyset`, the wrapped-record counterpart of the typed keyset API added in PR #632.
- Preserve V4 logical-expression validation and `AssetRelationship` wrapping while delegating paging to the shared keyset core.
- Support current relationships on `NEW_SCHEMA_ONLY`; ranked/non-current and deprecated schema modes continue using the existing V4 API.

GQS queries different relationship types through one generic path and expects each result as an `AssetRelationship` wrapper containing the source URN and a typed `relatedTo` union. The typed API from PR #632 returns the relationship record directly, so GQS needs this wrapped variant to adopt keyset pagination without changing its response model.

Related issue: [META-24159](https://linkedin.atlassian.net/browse/META-24159)

## Testing Done

- `./gradlew :dao-impl:ebean-dao:test --tests com.linkedin.metadata.dao.localrelationship.EbeanLocalRelationshipQueryDAOTest`
- `./gradlew :dao-impl:ebean-dao:javadoc`
- `./gradlew :dao-impl:ebean-dao:checkstyleMain`
- `./gradlew :dao-impl:ebean-dao:checkstyleTest`
- `./gradlew spotlessCheck`
- Added focused coverage for:
  - multi-page wrapped records with independent source and destination logical-filter exclusions;
  - relationship filtering on the GQS `NON_MG_ASSET` destination path;
  - invalid wrap options and legacy criteria filters.

This PR is additive and changes no production caller. The GQS caller implementation is in draft [metadata-graph-query PR #671](https://github.com/linkedin-multiproduct/metadata-graph-query/pull/671); rollout gating, observability, and EI validation remain planned follow-up work there.

The existing offset-based V3/V4 methods remain available and unchanged for current callers, including ranked/non-current queries and callers using deprecated schema modes. Keyset APIs are opt-in and intended for current-relationship callers that need bounded database pages.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
