### PR TITLE
fix(ebean-dao): harden usage emission against throwing emitters

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -24,6 +24,7 @@ import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
 import com.linkedin.metadata.dao.tracking.DaoReadContext;
 import com.linkedin.metadata.dao.tracking.DaoUsageBuffer;
+import com.linkedin.metadata.dao.tracking.NoOpDaoUsageEmitter;
 import com.linkedin.metadata.dao.urnpath.EmptyPathExtractor;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.utils.EBeanDAOUtils;
@@ -606,9 +607,19 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    * emitter is fire-and-forget (never throws into the call path). Composes with
    * {@link #setBenchmarkMetrics} -- both decorate {@code _localAccess}, in either order.
    *
+   * <p>Single-shot per DAO: a repeat call is ignored, because stacking a second decorator would
+   * emit every event twice. Passing a {@link NoOpDaoUsageEmitter} is treated as "not configured"
+   * and installs nothing -- otherwise it would consume the one-shot and silently block a real
+   * emitter wired later, which is a live risk under non-deterministic dependency-injection order.
+   *
    * @param usageEmitter the usage emitter implementation to use
    */
   public void setUsageEmitter(@Nonnull BaseDaoUsageEmitter usageEmitter) {
+    if (usageEmitter instanceof NoOpDaoUsageEmitter) {
+      // "No emitter configured" is already expressed by leaving _localAccess undecorated, which is
+      // strictly cheaper. Returning early also leaves the one-shot open for a real emitter.
+      return;
+    }
     if (_usageTrackingInstalled) {
       // Stacking a second decorator would emit every event twice.
       log.warn("Usage emitter is already set on this DAO; ignoring the repeat call.");
@@ -670,8 +681,14 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
 
     // Flush outside the transaction: emission must not be able to affect it, or vice versa.
+    // Guarded per emission so one bad emission can neither fail a caller whose write is already
+    // durable nor silently drop the emissions queued behind it.
     for (Runnable emission : pendingUsage) {
-      emission.run();
+      try {
+        emission.run();
+      } catch (Throwable t) {
+        log.warn("Failed to flush buffered usage emission after commit.", t);
+      }
     }
 
     return result;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccess.java
@@ -153,7 +153,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean includeSoftDeleted, boolean isTestMode) {
     final List<EbeanMetadataAspect> result =
         _delegate.batchGetUnion(keys, keysCount, position, includeSoftDeleted, isTestMode);
-    if (_usageEmitter.isEnabled() && !isTestMode && !DaoReadContext.isInternalRead()) {
+    if (emissionEnabled() && !isTestMode && !DaoReadContext.isInternalRead()) {
       emitRead("batchGetUnion", () -> entityTypeFromKeys(keys, keysCount, position),
           () -> targetsFromKeys(keys, keysCount, position));
     }
@@ -165,7 +165,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
   public <ASPECT extends RecordTemplate> ListResult<ASPECT> list(@Nonnull Class<ASPECT> aspectClass,
       @Nonnull URN urn, int start, int pageSize) {
     final ListResult<ASPECT> result = _delegate.list(aspectClass, urn, start, pageSize);
-    if (_usageEmitter.isEnabled() && !DaoReadContext.isInternalRead()) {
+    if (emissionEnabled() && !DaoReadContext.isInternalRead()) {
       emitRead("list", urn::getEntityType,
           () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
@@ -182,7 +182,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       @Nullable IngestionTrackingContext ingestionTrackingContext, boolean isTestMode) {
     final int result =
         _delegate.add(urn, newValue, aspectClass, auditStamp, ingestionTrackingContext, isTestMode);
-    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+    if (result > 0 && emissionEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
       emitWriteOnCommit(newValue != null ? OP_WRITE : OP_DELETE, "add", auditStamp,
           urn::getEntityType, () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
@@ -196,7 +196,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean isTestMode, boolean softDeleteOverwrite) {
     final int result = _delegate.addWithOptimisticLocking(urn, newValue, aspectClass, auditStamp,
         oldTimestamp, ingestionTrackingContext, isTestMode, softDeleteOverwrite);
-    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+    if (result > 0 && emissionEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
       emitWriteOnCommit(newValue != null ? OP_WRITE : OP_DELETE, "addWithOptimisticLocking",
           auditStamp, urn::getEntityType, () -> singleTarget(urn, aspectClass.getSimpleName()));
     }
@@ -211,7 +211,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean isTestMode) {
     final int result = _delegate.create(urn, aspectValues, aspectCreateLambdas, auditStamp,
         ingestionTrackingContext, isTestMode);
-    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+    if (result > 0 && emissionEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
       emitWriteOnCommit(OP_WRITE, "create", auditStamp, urn::getEntityType,
           () -> singleTarget(urn, aspectSimpleNames(aspectValues)));
     }
@@ -225,7 +225,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       boolean isTestMode) {
     final int result =
         _delegate.batchUpsert(urn, updateContexts, auditStamp, ingestionTrackingContext, isTestMode);
-    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
+    if (result > 0 && emissionEnabled() && !isTestMode && !isBackfill(ingestionTrackingContext)) {
       emitWriteOnCommit(OP_WRITE, "batchUpsert", auditStamp, urn::getEntityType,
           () -> singleTarget(urn, aspectNamesFromContexts(updateContexts)));
     }
@@ -235,7 +235,7 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
   @Override
   public int softDeleteAsset(@Nonnull URN urn, boolean isTestMode) {
     final int result = _delegate.softDeleteAsset(urn, isTestMode);
-    if (result > 0 && _usageEmitter.isEnabled() && !isTestMode) {
+    if (result > 0 && emissionEnabled() && !isTestMode) {
       // Whole-entity delete: no audit stamp on this path (actor null), empty aspect list.
       emitWriteOnCommit(OP_DELETE_ALL, "softDeleteAsset", null, urn::getEntityType,
           () -> Collections.singletonList(
@@ -247,6 +247,25 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
   // ---------------------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------------------
+
+  /**
+   * Whether emission is on. {@link BaseDaoUsageEmitter} is a public extension point, so this call
+   * lands in third-party code; it is guarded because it is evaluated on the DAO call path, for
+   * writes inside the open transaction of {@code runInTransactionWithRetry}. An escaping throwable
+   * there is not one of the retryable types, so it would abort the retry loop before
+   * {@code commit()} and roll back a write that had already succeeded. Failing closed keeps usage
+   * capture fail-open.
+   *
+   * @return true when the emitter reports enabled, false on any throwable
+   */
+  private boolean emissionEnabled() {
+    try {
+      return _usageEmitter.isEnabled();
+    } catch (Throwable t) {
+      log.warn("Usage emitter isEnabled() threw; treating usage emission as disabled.", t);
+      return false;
+    }
+  }
 
   /**
    * Builds the targets and emits, swallowing any exception so usage capture can never affect
@@ -280,9 +299,12 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
       } else {
         emission.run();
       }
-    } catch (Exception e) {
-      // Fire-and-forget: never propagate an emission failure to the caller.
-      log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, e);
+    } catch (Throwable t) {
+      // Fire-and-forget: never propagate an emission failure to the caller. Throwable, not
+      // Exception: a caller-supplied emitter can fail to link rather than throw -- for example
+      // when its serialization library resolves to a conflicting version -- and the resulting
+      // Error would otherwise fail the caller's read or write.
+      log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, t);
     }
   }
 
@@ -315,11 +337,13 @@ public class UsageTrackingEbeanLocalAccess<URN extends Urn> implements IEbeanLoc
     try {
       _usageEmitter.emit(operationType, entityType, sourceOperation, actorUrn, impersonatorUrn,
           targets);
-    } catch (Exception e) {
-      log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, e);
+    } catch (Throwable t) {
+      // Throwable, not Exception: a LinkageError raised while linking the emit call site is thrown
+      // at the invocation, so the implementation's own internal guard never sees it. This runs at
+      // transaction-commit time for writes, where an escaping error would fail a durable write.
+      log.warn("Failed to emit usage event for {} {}", operationType, sourceOperation, t);
     }
   }
-
   /**
    * Entity type for a read, taken from the first key in the window the delegate actually read.
    * Returns {@code null} when the window is empty, in which case there is nothing to report.

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -33,6 +33,7 @@ import com.linkedin.metadata.dao.storage.LocalDAOStorageConfig;
 import com.linkedin.metadata.dao.tracking.BaseDaoBenchmarkMetrics;
 import com.linkedin.metadata.dao.tracking.BaseDaoUsageEmitter;
 import com.linkedin.metadata.dao.tracking.BaseTrackingManager;
+import com.linkedin.metadata.dao.tracking.NoOpDaoUsageEmitter;
 import com.linkedin.metadata.dao.urnpath.UrnPathExtractor;
 import com.linkedin.metadata.dao.utils.BarUrnPathExtractor;
 import com.linkedin.metadata.dao.utils.EbeanServerUtils;
@@ -346,6 +347,27 @@ public class EbeanLocalDAOTest {
     // check on the outermost layer would miss it and stack a second usage decorator.
     dao.setUsageEmitter(mockEmitter);
     dao.setBenchmarkMetrics(mockMetrics);
+    dao.setUsageEmitter(mockEmitter);
+
+    dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
+
+    verify(mockEmitter, times(1)).emit(eq("WRITE"), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  public void testSetUsageEmitterIgnoresNoOpAndStaysOpenForARealEmitter() throws Exception {
+    if (_schemaConfig != SchemaConfig.NEW_SCHEMA_ONLY) {
+      // Only the new-schema path routes writes through _localAccess, where the decorator lives.
+      return;
+    }
+    EbeanLocalDAO<EntityAspectUnion, FooUrn> dao = createDao(FooUrn.class);
+    BaseDaoUsageEmitter mockEmitter = mock(BaseDaoUsageEmitter.class);
+    when(mockEmitter.isEnabled()).thenReturn(true);
+
+    // A no-op emitter means "not configured". If it consumed the single-shot install, a real
+    // emitter wired afterwards -- which happens under non-deterministic injection order -- would
+    // be silently dropped and the service would emit nothing.
+    dao.setUsageEmitter(new NoOpDaoUsageEmitter());
     dao.setUsageEmitter(mockEmitter);
 
     dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/UsageTrackingEbeanLocalAccessTest.java
@@ -524,6 +524,47 @@ public class UsageTrackingEbeanLocalAccessTest {
   }
 
   @Test
+  public void testIsEnabledThrowingDoesNotPropagateOnWrite() {
+    // isEnabled() lands in third-party code and is evaluated inside the open transaction of
+    // runInTransactionWithRetry. A throwable escaping here is not a retryable type, so it would
+    // abort the retry loop before commit() and roll back a write that had already succeeded.
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(3);
+    when(_mockEmitter.isEnabled()).thenThrow(new RuntimeException("gate blew up"));
+
+    int result = _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null, false);
+
+    assertEquals(result, 3);
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  public void testIsEnabledThrowingDoesNotPropagateOnRead() {
+    when(_mockDelegate.batchGetUnion(any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
+    when(_mockEmitter.isEnabled()).thenThrow(new RuntimeException("gate blew up"));
+
+    // A served read must not be turned into a failure by the usage gate.
+    _usage.batchGetUnion(Collections.emptyList(), 0, 0, false, false);
+
+    verify(_mockEmitter, never()).emit(anyString(), anyString(), anyString(), any(), any(), any());
+  }
+
+  @Test
+  public void testEmitterLinkageErrorDoesNotPropagate() {
+    // A caller-supplied emitter can fail to link rather than throw -- e.g. when its serialization
+    // library resolves to a conflicting version. A LinkageError raised while linking the emit call
+    // site is thrown at the invocation, so the implementation's own internal guard never sees it
+    // and the decorator has to absorb it.
+    when(_mockDelegate.add(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(3);
+    doThrow(new NoClassDefFoundError("com/example/usage/UsageEventRecord"))
+        .when(_mockEmitter).emit(anyString(), anyString(), anyString(), any(), any(), any());
+
+    int result = _usage.add(_urn1, new AspectFoo(), AspectFoo.class, _auditStamp, null, false);
+
+    assertEquals(result, 3);
+  }
+
+  @Test
   public void testPartialAuditStampDoesNotPropagate() {
     // actor is a required field: AuditStamp#getActor() uses GetMode.STRICT and throws on a
     // partial record. Deriving the caller must stay inside the emitter's failure boundary so a

--- a/docs/rfc/active/dao-usage-event-instrumentation.md
+++ b/docs/rfc/active/dao-usage-event-instrumentation.md
@@ -32,8 +32,13 @@ not infer the operation kind from an empty `aspects` list; `operationType` is th
 
 ### `NoOpDaoUsageEmitter`
 
-Located in `dao-api/.../tracking/NoOpDaoUsageEmitter.java`. All methods no-op; `isEnabled()` returns `false`. The
-default when no emitter is configured. Follows the `NoOpDaoBenchmarkMetrics` pattern.
+Located in `dao-api/.../tracking/NoOpDaoUsageEmitter.java`. All methods no-op; `isEnabled()` returns `false`. Follows
+the `NoOpDaoBenchmarkMetrics` pattern.
+
+Note that this is _not_ the mechanism by which tracking is off by default — a DAO that never has `setUsageEmitter`
+called simply leaves `_localAccess` undecorated, which is strictly cheaper than routing through a no-op. Passing a
+`NoOpDaoUsageEmitter` to `setUsageEmitter` is therefore treated as "not configured" and installs nothing, so it cannot
+consume the single-shot install and silently block a real emitter wired later.
 
 ### `UsageTrackingEbeanLocalAccess` decorator
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #631. `BaseDaoUsageEmitter` is a public extension point,
so a caller-supplied emitter must never break the DAO operation it is only meant
to observe. Three gaps allowed exactly that:

1. **A throwing `isEnabled()` could roll back a successful write.** The gate was
   called outside the fail-open guard, and on writes it runs inside an open
   transaction, so the exception escaped the retry loop before `commit()`. Now
   routed through `emissionEnabled()`, which returns `false` instead of throwing.

2. **`Error`s slipped past the guards,** which caught only `Exception`. With more
   than one Avro version on the classpath, a `LinkageError` is thrown at the
   `emit` call site itself, before the emitter's own guard runs. Guards widened to
   `Throwable`, and the post-commit flush now guards each emission individually so
   one failure cannot fail an already-committed write or drop the ones behind it.

3. **A no-op emitter silently disabled tracking for good.** `setUsageEmitter`
   accepted `NoOpDaoUsageEmitter` as real, consuming the one-time install so a
   real emitter wired later was ignored with only a warning. It now installs
   nothing, leaving the slot open.

## Testing Done

- [x] Local code review completed
- [x] Unit tests added/updated
- [ ] Integration tests pass — see caveat below
- [ ] Manual testing performed — n/a

Added four regression tests. The three fail-open tests were confirmed to **fail
against the pre-fix code and pass after**, so they cover the gap rather than the fix:

- `testIsEnabledThrowingDoesNotPropagateOnWrite` / `…OnRead`
- `testEmitterLinkageErrorDoesNotPropagate`
- `testSetUsageEmitterIgnoresNoOpAndStaysOpenForARealEmitter`

`:dao-api:test` (24 tracking tests) and `UsageTrackingEbeanLocalAccessTest` (30/30)
pass; `checkstyleMain` and `checkstyleTest` are clean.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable) — follow-up to #631
- [x] Docs related to the changes have been added/updated (if applicable) — RFC corrected