### PR TITLE
fix(dao): reconstruct canonical URN as entity-specific type to prevent ClassCastException

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -127,15 +127,18 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     }
   }
 
+  // Note: intentionally NOT static so it can reference the outer class's URN type parameter directly,
+  // ensuring canonicalUrn stays entity-specific (e.g. DatasetInstanceUrn) instead of the base Urn.
   @Getter
   @AllArgsConstructor
-  static class AddResult<ASPECT extends RecordTemplate> {
+  class AddResult<ASPECT extends RecordTemplate> {
     ASPECT oldValue;
     ASPECT newValue;
     Class<ASPECT> klass;
-    // The canonical URN as stored in the DB (may differ in case from the incoming MCE URN).
-    // For new entities with no existing DB row, this is set to the incoming MCE URN.
-    @Nonnull Urn canonicalUrn;
+    // The canonical URN as stored in the DB (may differ in case from the incoming MCE URN), reconstructed
+    // as the entity-specific URN type (not the base Urn) so hooks/producers expecting URN don't get a
+    // ClassCastException. For new entities with no existing DB row, this is set to the incoming MCE URN.
+    @Nonnull URN canonicalUrn;
   }
 
   @Value
@@ -556,7 +559,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
     // arrive with different-case URNs (e.g. lixTrackingArchive vs LixTrackingArchive).
     // Extracted before shouldUpdateAspect so both the early-return (no-op) and update paths
     // carry the canonical URN — needed when alwaysEmitAuditEvent=true emits MAE even for no-ops.
-    final Urn canonicalUrn = latest.getExtraInfo() != null ? latest.getExtraInfo().getUrn() : urn;
+    // Reconstructed as the entity-specific URN type (not ExtraInfo's base Urn) via reflection so
+    // downstream hooks/producers typed on URN (e.g. DatasetInstanceUrn) don't get a ClassCastException.
+    final URN canonicalUrn = latest.getExtraInfo() != null
+        ? ModelUtils.getUrnFromString(latest.getExtraInfo().getUrn().toString(), _urnClass)
+        : urn;
 
     // Unified logic determines whether an update to aspect should be persisted (includes backfill, equality, version, mode checks)
     if (!shouldUpdateAspect(ingestionParams.getIngestionMode(), urn, oldValue, newValue, aspectClass, auditStamp, equalityTester,
@@ -847,8 +854,11 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
           ingestionParams, aspectClass, urn);
 
       // Extract canonical URN before shouldUpdateAspect — no-op path also needs it
-      // (alwaysEmitAuditEvent=true emits MAE even when old == new)
-      final Urn batchCanonicalUrn = oldExtraInfo != null ? oldExtraInfo.getUrn() : urn;
+      // (alwaysEmitAuditEvent=true emits MAE even when old == new). Reconstructed as the
+      // entity-specific URN type — see addCommon() for why this must not be the base Urn.
+      final URN batchCanonicalUrn = oldExtraInfo != null
+          ? ModelUtils.getUrnFromString(oldExtraInfo.getUrn().toString(), _urnClass)
+          : urn;
 
       if (!shouldUpdateAspect(ingestionParams.getIngestionMode(), urn, oldAspect, newValue,
                               aspectClass, auditStamp, equalityTester, oldAuditStamp, eTagAuditStamp,
@@ -1062,8 +1072,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
         || (oldValue != null && newValue != null && equalityTester.equals(oldValue, newValue));
 
     // Use the canonical URN stored in AddResult (DB-stored URN if available, otherwise the incoming URN).
-    @SuppressWarnings("unchecked")
-    final URN maeUrn = (URN) result.getCanonicalUrn();
+    // Already the correctly-typed URN (see addCommon()/addManyBatchInternal()) — no cast needed.
+    final URN maeUrn = result.getCanonicalUrn();
 
     // Invoke post-update hooks if there's any
     // Note that we do NOT support post-update (or pre-update) hooks for deletion operations (yet). However, since

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -668,6 +668,63 @@ public class BaseLocalDAOTest {
     verifyNoMoreInteractions(_mockEventProducer);
   }
 
+  /**
+   * Concrete (non-mock) BiConsumer implementation typed on BurgerUrn. A Mockito mock would not
+   * reproduce the original bug: the compiler-generated bridge method (accept(Object, Object) ->
+   * accept(BurgerUrn, ASPECT)) that performs the unchecked cast only exists on real generated
+   * classes, not on mock proxies. This class is required to genuinely exercise that cast.
+   */
+  static class RecordingBurgerPostUpdateHook<ASPECT extends RecordTemplate> implements BiConsumer<BurgerUrn, ASPECT> {
+    final List<BurgerUrn> urnsSeen = new ArrayList<>();
+    final List<ASPECT> aspectsSeen = new ArrayList<>();
+
+    @Override
+    public void accept(BurgerUrn urn, ASPECT aspect) {
+      urnsSeen.add(urn);
+      aspectsSeen.add(aspect);
+    }
+  }
+
+  /**
+   * Regression test for a ClassCastException that occurred when a post-update hook typed on a
+   * concrete URN subclass (e.g. BurgerUrn) was invoked with the canonical URN. Before the fix,
+   * canonicalUrn was the loosely-typed base Urn from ExtraInfo.getUrn(), unchecked-cast to URN
+   * in unwrapAddResult() — this only failed on the second write to an entity, since the first
+   * write has no ExtraInfo and falls back to the correctly-typed incoming urn.
+   *
+   * <p>The fix reconstructs canonicalUrn as the entity-specific URN type via
+   * ModelUtils.getUrnFromString(str, _urnClass), so the hook always receives a properly-typed
+   * BurgerUrn and no ClassCastException is thrown.
+   */
+  @Test
+  public void testPostUpdateHookReceivesTypedUrnOnSecondWrite() {
+    BurgerUrn urn = new BurgerUrn("burgerKing");
+    AspectFoo firstFoo = new AspectFoo().setValue("first");
+    AspectFoo secondFoo = new AspectFoo().setValue("second");
+
+    BiFunction<BurgerUrn, Class<? extends RecordTemplate>, BaseLocalDAO.AspectEntry> burgerGetLatest = mock(BiFunction.class);
+    DummyBurgerLocalDAO<EntityAspectUnion> burgerDAO = new DummyBurgerLocalDAO<>(
+        EntityAspectUnion.class, burgerGetLatest, _mockEventProducer, _mockTransactionRunner);
+
+    RecordingBurgerPostUpdateHook<AspectFoo> postUpdateHook = new RecordingBurgerPostUpdateHook<>();
+    burgerDAO.addPostUpdateHook(AspectFoo.class, postUpdateHook);
+
+    // First call: no DB row yet → ExtraInfo is null → falls back to incoming urn.
+    when(burgerGetLatest.apply(urn, AspectFoo.class))
+        .thenReturn(new BaseLocalDAO.AspectEntry<>(null, null));
+    burgerDAO.add(urn, firstFoo, _dummyAuditStamp);
+
+    // Second call: DB row exists → ExtraInfo.urn is set → canonicalUrn must be reconstructed as
+    // a BurgerUrn (not the loosely-typed base Urn) so the hook below doesn't throw a CCE.
+    ExtraInfo extraInfoWithCanonical = new ExtraInfo().setAudit(_dummyAuditStamp).setUrn(urn);
+    when(burgerGetLatest.apply(urn, AspectFoo.class))
+        .thenReturn(new BaseLocalDAO.AspectEntry<>(firstFoo, extraInfoWithCanonical));
+    burgerDAO.add(urn, secondFoo, _dummyAuditStamp);
+
+    assertEquals(postUpdateHook.urnsSeen, Arrays.asList(urn, urn));
+    assertEquals(postUpdateHook.aspectsSeen, Arrays.asList(firstFoo, secondFoo));
+  }
+
   @Test
   public void testMAEv5WithTracking() throws URISyntaxException {
     FooUrn urn = new FooUrn(1);


### PR DESCRIPTION
## Summary

`AddResult.canonicalUrn` (and its batch counterpart, `batchCanonicalUrn`) were sourced directly from `ExtraInfo.getUrn()`, which returns the loosely-typed base `com.linkedin.common.urn.Urn`. This value was later unchecked-cast to the DAO's entity-specific `URN` type parameter (e.g. `DatasetInstanceUrn`) when invoking post-update hooks in `unwrapAddResult()`, causing:

```
java.lang.ClassCastException: class com.linkedin.common.urn.Urn
cannot be cast to class com.linkedin.common.urn.DatasetInstanceUrn
```

This only manifests on the **second** write to a given URN — the first write has no `ExtraInfo` (falls back to the correctly-typed incoming `urn` param), so the bug can easily slip past quick smoke tests. It surfaced as recurring HTTP 500s from `Datasets.updateStatus` in `annotations-gms` integration tests.

### Fix

- Changed `AddResult.canonicalUrn` from `Urn` to `URN` (the DAO's own type parameter), and made `AddResult` a non-static inner class so it can reference the outer class's `URN` type directly.
- In `addCommon()` and `addManyBatchInternal()`, when `ExtraInfo` is present, reconstruct the canonical URN via `ModelUtils.getUrnFromString(str, _urnClass)` instead of using `ExtraInfo.getUrn()` directly, guaranteeing the entity-specific type.
- Removed the now-unnecessary unchecked cast in `unwrapAddResult()`.

## Testing Done

- [x] Local code review completed

### End-to-end reproduction & verification via metadata-graph-assets (MGA)

Since the bug only manifests on the *second* write to the same URN (the first write has no `ExtraInfo`, so it falls back to the correctly-typed incoming `urn`), we needed a live service with a post-update hook typed on a concrete `URN` subtype to reproduce it — `metadata-graph-assets`' `DatasetDerivedStatusHook` (typed `BiConsumer<DatasetInstanceUrn, Status>`) was used for this.

**1) Reproduced the original bug (pre-fix `datahub-gma:0.6.193`):**
- Deployed MGA locally (QEI, `mint debug`) with its existing `product-spec.json` pin (`metadata-models:278.0.19` → `datahub-gma:0.6.193`, i.e. pre-fix).
- Called `DatasetInstanceAssetService/update` (which internally calls `Datasets.updateStatus`-equivalent DAO logic) **twice** on the same URN via grpcurli:
  ```
  grpcurli --dv-auth SELF localhost:25403 proto.com.linkedin.mg.assets.service.DatasetInstanceAssetService/update \
    -d '{"value":{"urn":{"dataset":{"platform":{"platformName":"hdfs"},"datasetName":"temp_mridul","origin":"FabricType_EI"},"name":"default"},"status":{"removed":false}}}'
  ```
- The **second** call failed with the exact reported `ClassCastException`, confirming the bug reproduces outside of `annotations-gms` too, with the same root cause:
  ```
  io.grpc.StatusRuntimeException: INTERNAL: class com.linkedin.common.urn.Urn cannot be cast to
  class com.linkedin.common.urn.DatasetInstanceUrn (com.linkedin.common.urn.Urn and
  com.linkedin.common.urn.DatasetInstanceUrn are in unnamed module of loader 'app')
  Caused by: java.lang.ClassCastException: class com.linkedin.common.urn.Urn cannot be cast to
  class com.linkedin.common.urn.DatasetInstanceUrn (...)
          at com.linkedin.metadata.dao.EbeanLocalDAO.runInTransactionWithRetry(EbeanLocalDAO.java:612)
              ~[com.linkedin.datahub-gma.ebean-dao-0.6.193.jar:?]
          at com.linkedin.metadata.dao.BaseLocalDAO.batchUpsert(BaseLocalDAO.java:758)
              ~[com.linkedin.datahub-gma.dao-api-0.6.193.jar:?]
          at com.linkedin.mg.assets.service.impl.BaseAssetServiceImpl.ingestInternal(BaseAssetServiceImpl.java:979)
              ~[metadata-graph-assets-impl-9.0.370.jar:?]
          at com.linkedin.mg.assets.service.impl.BaseAssetServiceImpl.update(BaseAssetServiceImpl.java:387)
              ~[metadata-graph-assets-impl-9.0.370.jar:?]
          at com.linkedin.mg.assets.service.impl.generated.DatasetInstanceAssetServiceImpl.update(DatasetInstanceAssetServiceImpl.java:197)
              ~[metadata-graph-assets-impl-9.0.370.jar:?]
  ```
  This confirmed: the crash happens **inside `BaseLocalDAO.batchUpsert`**, before ever reaching `DatasetDerivedStatusHook` — i.e. without this fix, the request fails on the URN cast and the post-update hook is **never invoked**.

**2) Verified the fix (patched `datahub-gma:0.6.197`):**
- Republished `datahub-gma` locally with this fix as `0.6.197`, consumed transitively by a `metadata-models:278.0.25-SNAPSHOT` snapshot, and pointed MGA's `product-spec.json` at that snapshot.
- Redeployed MGA locally with the patched chain and re-ran the **identical** grpcurli request twice against the same URN.
- Result: **no `ClassCastException`** — the request now proceeds past `BaseLocalDAO.batchUpsert` and successfully **reaches `DatasetDerivedStatusHook`** (confirmed via logs showing execution inside the hook), i.e. the post-update hook invocation path that previously crashed now runs correctly with the properly-typed `DatasetInstanceUrn`.
- The call then failed only on an unrelated, transient local MySQL connectivity error while inside the hook's DB call (`Communications link failure`, explicitly returned as `Code: Unavailable, Message: Transient database error, safe to retry`) — this is a local network/DB blip (staging DB reachability from a laptop), not related to the fix, and confirms the fix resolved the actual `ClassCastException` defect: execution now gets meaningfully further than before, all the way into the hook logic.

### Automated regression test

Added `testPostUpdateHookReceivesTypedUrnOnSecondWrite` to `BaseLocalDAOTest`, which registers a
post-update hook typed on `BurgerUrn` via a **concrete** `BiConsumer` implementation (not a Mockito
mock — a mock proxy does not exercise the compiler-generated bridge method that performs the
unchecked cast, so it would not have caught this bug). The test performs two writes to the same
URN (mirroring the real-world "first write vs. second write" distinction) and asserts the hook
receives the correctly-typed `BurgerUrn` both times.

- Verified this test **fails with the exact `ClassCastException`** when the fix in `BaseLocalDAO`
  is reverted (confirming it's a real regression test, not a tautology).
- Verified it **passes** with the fix applied.

**Summary of before/after:**

| | Pre-fix (`datahub-gma:0.6.193`) | Post-fix (`datahub-gma:0.6.197`) |
|---|---|---|
| 1st write to URN | Succeeds | Succeeds |
| 2nd write to same URN | `ClassCastException` in `BaseLocalDAO.batchUpsert`, before hook runs | No cast error; reaches `DatasetDerivedStatusHook` successfully |

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
