### PR TITLE
fix(ebean-dao): stop relationship keyset scans dropping rewritten rows

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -349,7 +349,7 @@ public class EbeanLocalRelationshipQueryDAO {
       relationships.add(RecordUtils.toRecordTemplate(relationshipType, row.getString(METADATA)));
     }
 
-    return new RelationshipKeysetPage<>(relationships, scan.getHighWaterId(), scan.getNextCursor());
+    return new RelationshipKeysetPage<>(relationships, scan.getMaxId(), scan.getNextCursor());
   }
 
   /**
@@ -414,7 +414,7 @@ public class EbeanLocalRelationshipQueryDAO {
           relationshipType, assetRelationshipClass, row.getString(METADATA), row.getString(SOURCE), wrapOptions));
     }
 
-    return new RelationshipKeysetPage<>(relationships, scan.getHighWaterId(), scan.getNextCursor());
+    return new RelationshipKeysetPage<>(relationships, scan.getMaxId(), scan.getNextCursor());
   }
 
   /**
@@ -446,9 +446,9 @@ public class EbeanLocalRelationshipQueryDAO {
     final Timestamp scanStartTime;
     if (cursor == null) {
       lastId = 0L;
-      final KeysetHighWaterMark highWaterMark = fetchHighWaterMark(relationshipTableName);
-      maxId = highWaterMark.getMaxId();
-      scanStartTime = highWaterMark.getScanStartTime();
+      final KeysetScanStart scanStart = fetchScanStart(relationshipTableName);
+      maxId = scanStart.getMaxId();
+      scanStartTime = scanStart.getScanStartTime();
     } else {
       validateKeysetCursorTable(cursor, relationshipTableName);
       lastId = cursor.getLastId();
@@ -543,13 +543,13 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Immutable holder for one keyset scan's insertion high-water id and database start time.
+   * Immutable holder for one keyset scan's largest row id and database start time.
    */
-  private static final class KeysetHighWaterMark {
+  private static final class KeysetScanStart {
     private final long _maxId;
     private final Timestamp _scanStartTime;
 
-    KeysetHighWaterMark(long maxId, @Nonnull Timestamp scanStartTime) {
+    KeysetScanStart(long maxId, @Nonnull Timestamp scanStartTime) {
       _maxId = maxId;
       _scanStartTime = copyTimestamp(scanStartTime);
     }
@@ -569,13 +569,13 @@ public class EbeanLocalRelationshipQueryDAO {
    */
   private static final class KeysetScanResult {
     private final List<SqlRow> _rows;
-    private final long _highWaterId;
+    private final long _maxId;
     private final RelationshipKeysetCursor _nextCursor;
 
-    KeysetScanResult(@Nonnull List<SqlRow> rows, long highWaterId,
+    KeysetScanResult(@Nonnull List<SqlRow> rows, long maxId,
         @Nullable RelationshipKeysetCursor nextCursor) {
       _rows = rows;
-      _highWaterId = highWaterId;
+      _maxId = maxId;
       _nextCursor = nextCursor;
     }
 
@@ -584,8 +584,8 @@ public class EbeanLocalRelationshipQueryDAO {
       return _rows;
     }
 
-    long getHighWaterId() {
-      return _highWaterId;
+    long getMaxId() {
+      return _maxId;
     }
 
     @Nullable
@@ -596,18 +596,18 @@ public class EbeanLocalRelationshipQueryDAO {
 
   /**
    * Returns the largest relationship row id ({@code maxId}) and the database timestamp for the
-   * start of the scan. Both values come from one statement so the timestamp and high-water id are
+   * start of the scan. Both values come from one statement so the timestamp and max id are
    * captured against the same DB clock.
    */
-  private KeysetHighWaterMark fetchHighWaterMark(@Nonnull final String relationshipTableName) {
+  private KeysetScanStart fetchScanStart(@Nonnull final String relationshipTableName) {
     final String sql =
         "SELECT COALESCE(MAX(id), 0) AS max_id, DATE_FORMAT(NOW(6), '%Y-%m-%d %H:%i:%s.%f') AS scan_start_time FROM "
             + relationshipTableName;
     final List<SqlRow> rows = _server.createSqlQuery(sql).findList();
     if (rows.isEmpty()) {
-      throw new IllegalStateException("High-water query returned no rows for table " + relationshipTableName);
+      throw new IllegalStateException("Scan-start query returned no rows for table " + relationshipTableName);
     }
-    return new KeysetHighWaterMark(rows.get(0).getLong("max_id"),
+    return new KeysetScanStart(rows.get(0).getLong("max_id"),
         Timestamp.valueOf(rows.get(0).getString("scan_start_time")));
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -25,8 +25,6 @@ import io.ebean.EbeanServer;
 import io.ebean.SqlQuery;
 import io.ebean.SqlRow;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,8 +62,6 @@ public class EbeanLocalRelationshipQueryDAO {
   private static final String IDX_DESTINATION_DELETED_TS = "idx_destination_deleted_ts";
   private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_destination_deleted_ts) ";
   private static final String DESTINATION_FIELD =  "destination";
-  private static final DateTimeFormatter MYSQL_TIMESTAMP_6_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -443,7 +439,7 @@ public class EbeanLocalRelationshipQueryDAO {
     }
     final long lastId;
     final long maxId;
-    final Timestamp scanStartTime;
+    final String scanStartTime;
     if (cursor == null) {
       lastId = 0L;
       final KeysetScanStart scanStart = fetchScanStart(relationshipTableName);
@@ -467,6 +463,7 @@ public class EbeanLocalRelationshipQueryDAO {
     // Query current rows first. If a row is soft-deleted between the two reads, Query B may also see
     // the same id; mergeKeysetRows dedups that id. Running B first could turn the race into a drop.
     final List<SqlRow> currentRows = executeSqlWithIndexCheck(currentSql, relationshipTableName);
+    // No-op seam that tests override to inject a soft-delete between Query A and Query B.
     afterKeysetCurrentRowsFetched(relationshipTableName, currentRows);
     final long deletedUpperId = currentRows.size() == pageSize ? currentRows.get(currentRows.size() - 1).getLong("id")
         : maxId;
@@ -547,11 +544,14 @@ public class EbeanLocalRelationshipQueryDAO {
    */
   private static final class KeysetScanStart {
     private final long _maxId;
-    private final Timestamp _scanStartTime;
+    private final String _scanStartTime;
 
-    KeysetScanStart(long maxId, @Nonnull Timestamp scanStartTime) {
+    KeysetScanStart(long maxId, @Nonnull String scanStartTime) {
       _maxId = maxId;
-      _scanStartTime = copyTimestamp(scanStartTime);
+      if (StringUtils.isBlank(scanStartTime)) {
+        throw new IllegalArgumentException("scanStartTime must not be null or empty");
+      }
+      _scanStartTime = scanStartTime;
     }
 
     long getMaxId() {
@@ -559,8 +559,8 @@ public class EbeanLocalRelationshipQueryDAO {
     }
 
     @Nonnull
-    Timestamp getScanStartTime() {
-      return copyTimestamp(_scanStartTime);
+    String getScanStartTime() {
+      return _scanStartTime;
     }
   }
 
@@ -603,12 +603,11 @@ public class EbeanLocalRelationshipQueryDAO {
     final String sql =
         "SELECT COALESCE(MAX(id), 0) AS max_id, DATE_FORMAT(NOW(6), '%Y-%m-%d %H:%i:%s.%f') AS scan_start_time FROM "
             + relationshipTableName;
-    final List<SqlRow> rows = _server.createSqlQuery(sql).findList();
-    if (rows.isEmpty()) {
+    final SqlRow row = _server.createSqlQuery(sql).findOne();
+    if (row == null) {
       throw new IllegalStateException("Scan-start query returned no rows for table " + relationshipTableName);
     }
-    return new KeysetScanStart(rows.get(0).getLong("max_id"),
-        Timestamp.valueOf(rows.get(0).getString("scan_start_time")));
+    return new KeysetScanStart(row.getLong("max_id"), row.getString("scan_start_time"));
   }
 
   /**
@@ -1243,9 +1242,9 @@ public class EbeanLocalRelationshipQueryDAO {
       @Nonnull LocalRelationshipFilter relationshipFilter, @Nullable final String sourceTableName,
       @Nullable LocalRelationshipFilter sourceEntityFilter, @Nullable final String destTableName,
       @Nullable LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId,
-      @Nonnull Timestamp scanStartTime) {
-    if (scanStartTime == null) {
-      throw new IllegalArgumentException("scanStartTime must not be null");
+      @Nonnull String scanStartTime) {
+    if (StringUtils.isBlank(scanStartTime)) {
+      throw new IllegalArgumentException("scanStartTime must not be null or empty");
     }
     return buildFindRelationshipKeysetSQL(relationshipTableName, relationshipFilter, sourceTableName, sourceEntityFilter,
         destTableName, destinationEntityFilter, pageSize, lastId, maxId,
@@ -1346,24 +1345,24 @@ public class EbeanLocalRelationshipQueryDAO {
     try {
       return _server.createSqlQuery(sql).findList();
     } catch (PersistenceException e) {
-      handleSqlExecutionException(e, relationshipTableName);
+      throwIfMissingIndex(e, relationshipTableName);
       throw new RuntimeException("Failed to execute SQL query for relationships", e);
     }
   }
 
   private List<SqlRow> executeSqlWithIndexCheck(String sql, String relationshipTableName,
-      @Nonnull Timestamp scanStartTime) {
+      @Nonnull String scanStartTime) {
     try {
       SqlQuery query = _server.createSqlQuery(sql);
-      query.setParameter("scanStartTime", formatTimestamp6(scanStartTime));
+      query.setParameter("scanStartTime", scanStartTime);
       return query.findList();
     } catch (PersistenceException e) {
-      handleSqlExecutionException(e, relationshipTableName);
+      throwIfMissingIndex(e, relationshipTableName);
       throw new RuntimeException("Failed to execute SQL query for relationships", e);
     }
   }
 
-  private void handleSqlExecutionException(PersistenceException e, String relationshipTableName) {
+  private void throwIfMissingIndex(PersistenceException e, String relationshipTableName) {
     Throwable cause = e.getCause();
     if (cause instanceof SQLException && cause.getMessage() != null
         && cause.getMessage().contains("doesn't exist in table")) {
@@ -1374,18 +1373,6 @@ public class EbeanLocalRelationshipQueryDAO {
       log.error(errorMsg);
       throw new IllegalStateException(errorMsg, e);
     }
-  }
-
-  @Nonnull
-  private static Timestamp copyTimestamp(@Nonnull Timestamp timestamp) {
-    Timestamp copy = new Timestamp(timestamp.getTime());
-    copy.setNanos(timestamp.getNanos());
-    return copy;
-  }
-
-  @Nonnull
-  private static String formatTimestamp6(@Nonnull Timestamp timestamp) {
-    return timestamp.toLocalDateTime().format(MYSQL_TIMESTAMP_6_FORMATTER);
   }
 
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -465,6 +465,9 @@ public class EbeanLocalRelationshipQueryDAO {
     final List<SqlRow> currentRows = executeSqlWithIndexCheck(currentSql, relationshipTableName);
     // No-op seam that tests override to inject a soft-delete between Query A and Query B.
     afterKeysetCurrentRowsFetched(relationshipTableName, currentRows);
+    // Cap Query B at Query A's frontier when A filled the page. Query B is itself
+    // ORDER BY id LIMIT pageSize, so this bounds per-page work rather than changing which rows the
+    // merge selects: ids above A's last id would lose to lower ids in the merge regardless.
     final long deletedUpperId = currentRows.size() == pageSize ? currentRows.get(currentRows.size() - 1).getLong("id")
         : maxId;
     final String deletedSinceScanStartSql = buildFindRelationshipKeysetDeletedSinceScanStartSQL(

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -22,8 +22,11 @@ import com.linkedin.metadata.query.LocalRelationshipCriterionArray;
 import com.linkedin.metadata.query.LocalRelationshipFilter;
 import com.linkedin.metadata.query.RelationshipDirection;
 import io.ebean.EbeanServer;
+import io.ebean.SqlQuery;
 import io.ebean.SqlRow;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,6 +64,8 @@ public class EbeanLocalRelationshipQueryDAO {
   private static final String IDX_DESTINATION_DELETED_TS = "idx_destination_deleted_ts";
   private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_destination_deleted_ts) ";
   private static final String DESTINATION_FIELD =  "destination";
+  private static final DateTimeFormatter MYSQL_TIMESTAMP_6_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -284,7 +289,7 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Keyset (seek) paginated, current-only ({@code deleted_ts IS NULL}) variant of
+   * Keyset (seek) paginated, scan-start membership variant of
    * {@link #findRelationships(Class, LocalRelationshipFilter, Class, LocalRelationshipFilter, Class,
    * LocalRelationshipFilter, int, int)} that walks the matching set in bounded pages. Ranked/
    * non-current pagination is unsupported because it could not bound the per-page DB work.
@@ -293,9 +298,10 @@ public class EbeanLocalRelationshipQueryDAO {
    * relationship row id when paging starts ({@code COALESCE(MAX(id), 0)}), and returns rows with
    * {@code 0 < rt.id <= maxId} ordered by id, up to {@code pageSize}. Later inserts get larger ids
    * and are excluded, keeping the scan finite. Continuation: pass the next cursor from the previous
-   * {@link RelationshipKeysetPage}. The combined pages are not a point-in-time snapshot: existing
-   * rows updated or soft-deleted between page calls can change which rows a later page returns (see
-   * {@link RelationshipKeysetCursor}).</p>
+   * {@link RelationshipKeysetPage}. The cursor also carries a database scan-start timestamp. Later
+   * pages include rows that were current at scan start even if they were soft-deleted before that
+   * later page is read. Rows inserted after the scan started are still excluded by the fixed
+   * {@code maxId} bound.</p>
    *
    * <p>Supported only when {@code SchemaConfig} is {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY}
    * and {@code DUAL_SCHEMA} (deprecated) throw {@link UnsupportedOperationException}.</p>
@@ -347,7 +353,7 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Keyset (seek) paginated, current-only ({@code deleted_ts IS NULL}) variant of
+   * Keyset (seek) paginated, scan-start membership variant of
    * {@link #findRelationshipsV4(String, LocalRelationshipFilter, String, LocalRelationshipFilter,
    * Class, LocalRelationshipFilter, Class, Map, int, int, RelationshipLookUpContext)} that walks the
    * matching set in bounded pages and returns the same wrapped {@code ASSET_RELATIONSHIP} records.
@@ -357,10 +363,10 @@ public class EbeanLocalRelationshipQueryDAO {
    * <p>First page: pass {@code cursor = null}; the DAO captures {@code maxId}, the largest
    * relationship row id when paging starts ({@code COALESCE(MAX(id), 0)}), and returns rows with
    * {@code 0 < rt.id <= maxId} ordered by id, up to {@code pageSize}. Continuation: pass the next
-   * cursor from the previous {@link RelationshipKeysetPage}. Later inserts get larger ids and are
-   * excluded, keeping the scan finite. The combined pages are not a point-in-time snapshot: existing
-   * rows updated or soft-deleted between page calls can change which rows a later page returns (see
-   * {@link RelationshipKeysetCursor}).</p>
+   * cursor from the previous {@link RelationshipKeysetPage}. The cursor also carries a database
+   * scan-start timestamp. Later pages include rows that were current at scan start even if they were
+   * soft-deleted before that later page is read. Rows inserted after the scan started are still
+   * excluded by the fixed {@code maxId} bound.</p>
    *
    * <p>Supported only when {@code SchemaConfig} is {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY}
    * and {@code DUAL_SCHEMA} (deprecated) throw {@link UnsupportedOperationException}.</p>
@@ -414,10 +420,11 @@ public class EbeanLocalRelationshipQueryDAO {
   /**
    * Shared row-level keyset core for {@link #findRelationshipsByKeyset} and
    * {@link #findRelationshipsV4ByKeyset}: captures the first-page {@code maxId} (largest row id when
-   * paging starts), runs the current-only keyset SQL, validates strictly increasing id progress and
-   * computes the next cursor. Callers resolve their own table names/filters and map the returned
-   * rows. Supported only for {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY} and {@code DUAL_SCHEMA}
-   * (deprecated) throw {@link UnsupportedOperationException} before any SQL is built or executed.
+   * paging starts) and database scan-start timestamp, runs the keyset SQL, validates strictly
+   * increasing id progress and computes the next cursor. Callers resolve their own table
+   * names/filters and map the returned rows. Supported only for {@code NEW_SCHEMA_ONLY};
+   * {@code OLD_SCHEMA_ONLY} and {@code DUAL_SCHEMA} (deprecated) throw
+   * {@link UnsupportedOperationException} before any SQL is built or executed.
    */
   @Nonnull
   private KeysetScanResult findRelationshipsByKeysetCore(@Nonnull final String relationshipTableName,
@@ -436,12 +443,17 @@ public class EbeanLocalRelationshipQueryDAO {
     }
     final long lastId;
     final long maxId;
+    final Timestamp scanStartTime;
     if (cursor == null) {
       lastId = 0L;
-      maxId = fetchHighWaterId(relationshipTableName);
+      final KeysetHighWaterMark highWaterMark = fetchHighWaterMark(relationshipTableName);
+      maxId = highWaterMark.getMaxId();
+      scanStartTime = highWaterMark.getScanStartTime();
     } else {
+      validateKeysetCursorTable(cursor, relationshipTableName);
       lastId = cursor.getLastId();
       maxId = cursor.getMaxId();
+      scanStartTime = cursor.getScanStartTime();
     }
 
     // Nothing left to scan (empty table, or the previous page reached maxId).
@@ -449,10 +461,21 @@ public class EbeanLocalRelationshipQueryDAO {
       return new KeysetScanResult(Collections.emptyList(), maxId, null);
     }
 
-    final String sql = buildFindRelationshipKeysetSQL(relationshipTableName, relationshipFilter, sourceTableName,
-        sourceEntityFilter, destTableName, destinationEntityFilter, pageSize, lastId, maxId);
+    final String currentSql = buildFindRelationshipKeysetCurrentSQL(relationshipTableName, relationshipFilter,
+        sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter, pageSize, lastId, maxId);
 
-    final List<SqlRow> rows = executeSqlWithIndexCheck(sql, relationshipTableName);
+    // Query current rows first. If a row is soft-deleted between the two reads, Query B may also see
+    // the same id; mergeKeysetRows dedups that id. Running B first could turn the race into a drop.
+    final List<SqlRow> currentRows = executeSqlWithIndexCheck(currentSql, relationshipTableName);
+    afterKeysetCurrentRowsFetched(relationshipTableName, currentRows);
+    final long deletedUpperId = currentRows.size() == pageSize ? currentRows.get(currentRows.size() - 1).getLong("id")
+        : maxId;
+    final String deletedSinceScanStartSql = buildFindRelationshipKeysetDeletedSinceScanStartSQL(
+        relationshipTableName, relationshipFilter, sourceTableName, sourceEntityFilter, destTableName,
+        destinationEntityFilter, pageSize, lastId, deletedUpperId, scanStartTime);
+    final List<SqlRow> deletedSinceScanStartRows =
+        executeSqlWithIndexCheck(deletedSinceScanStartSql, relationshipTableName, scanStartTime);
+    final List<SqlRow> rows = mergeKeysetRows(currentRows, deletedSinceScanStartRows, pageSize);
 
     long previousId = lastId;
     long lastRowId = lastId;
@@ -470,10 +493,75 @@ public class EbeanLocalRelationshipQueryDAO {
     // A next cursor is only warranted when the page was full and did not reach maxId.
     RelationshipKeysetCursor nextCursor = null;
     if (rows.size() == pageSize && lastRowId < maxId) {
-      nextCursor = new RelationshipKeysetCursor(lastRowId, maxId);
+      nextCursor = new RelationshipKeysetCursor(lastRowId, maxId, scanStartTime, relationshipTableName);
     }
 
     return new KeysetScanResult(rows, maxId, nextCursor);
+  }
+
+  private static void validateKeysetCursorTable(@Nonnull RelationshipKeysetCursor cursor,
+      @Nonnull String relationshipTableName) {
+    final String cursorRelationshipTableName = cursor.getRelationshipTableName();
+    if (!cursorRelationshipTableName.equals(relationshipTableName)) {
+      throw new IllegalArgumentException("Relationship keyset cursor belongs to table '"
+          + cursorRelationshipTableName + "' but this query targets table '" + relationshipTableName + "'.");
+    }
+  }
+
+  @Nonnull
+  private static List<SqlRow> mergeKeysetRows(@Nonnull List<SqlRow> currentRows,
+      @Nonnull List<SqlRow> deletedSinceScanStartRows, int pageSize) {
+    List<SqlRow> merged = new ArrayList<>(Math.min(pageSize, currentRows.size() + deletedSinceScanStartRows.size()));
+    int currentIndex = 0;
+    int deletedIndex = 0;
+    while (merged.size() < pageSize
+        && (currentIndex < currentRows.size() || deletedIndex < deletedSinceScanStartRows.size())) {
+      if (currentIndex >= currentRows.size()) {
+        merged.add(deletedSinceScanStartRows.get(deletedIndex++));
+      } else if (deletedIndex >= deletedSinceScanStartRows.size()) {
+        merged.add(currentRows.get(currentIndex++));
+      } else {
+        long currentId = currentRows.get(currentIndex).getLong("id");
+        long deletedId = deletedSinceScanStartRows.get(deletedIndex).getLong("id");
+        if (currentId == deletedId) {
+          merged.add(currentRows.get(currentIndex++));
+          deletedIndex++;
+        } else if (currentId < deletedId) {
+          merged.add(currentRows.get(currentIndex++));
+        } else {
+          merged.add(deletedSinceScanStartRows.get(deletedIndex++));
+        }
+      }
+    }
+    return merged;
+  }
+
+  @VisibleForTesting
+  protected void afterKeysetCurrentRowsFetched(@Nonnull String relationshipTableName,
+      @Nonnull List<SqlRow> currentRows) {
+    // Test seam for deterministic simulation of a soft-delete between Query A and Query B.
+  }
+
+  /**
+   * Immutable holder for one keyset scan's insertion high-water id and database start time.
+   */
+  private static final class KeysetHighWaterMark {
+    private final long _maxId;
+    private final Timestamp _scanStartTime;
+
+    KeysetHighWaterMark(long maxId, @Nonnull Timestamp scanStartTime) {
+      _maxId = maxId;
+      _scanStartTime = copyTimestamp(scanStartTime);
+    }
+
+    long getMaxId() {
+      return _maxId;
+    }
+
+    @Nonnull
+    Timestamp getScanStartTime() {
+      return copyTimestamp(_scanStartTime);
+    }
   }
 
   /**
@@ -507,12 +595,20 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Returns COALESCE(MAX(id), 0), the largest relationship row id ({@code maxId}), for the table.
+   * Returns the largest relationship row id ({@code maxId}) and the database timestamp for the
+   * start of the scan. Both values come from one statement so the timestamp and high-water id are
+   * captured against the same DB clock.
    */
-  private long fetchHighWaterId(@Nonnull final String relationshipTableName) {
-    final String sql = "SELECT COALESCE(MAX(id), 0) AS max_id FROM " + relationshipTableName;
+  private KeysetHighWaterMark fetchHighWaterMark(@Nonnull final String relationshipTableName) {
+    final String sql =
+        "SELECT COALESCE(MAX(id), 0) AS max_id, DATE_FORMAT(NOW(6), '%Y-%m-%d %H:%i:%s.%f') AS scan_start_time FROM "
+            + relationshipTableName;
     final List<SqlRow> rows = _server.createSqlQuery(sql).findList();
-    return rows.isEmpty() ? 0L : rows.get(0).getLong("max_id");
+    if (rows.isEmpty()) {
+      throw new IllegalStateException("High-water query returned no rows for table " + relationshipTableName);
+    }
+    return new KeysetHighWaterMark(rows.get(0).getLong("max_id"),
+        Timestamp.valueOf(rows.get(0).getString("scan_start_time")));
   }
 
   /**
@@ -1115,23 +1211,53 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Keyset (seek) pagination counterpart of {@link #buildFindRelationshipSQL}: same join/filter
-   * construction plus keyset bounds ({@code rt.id > lastId AND rt.id <= maxId}, {@code maxId} being
-   * the largest relationship row id when paging starts), ascending id order and
-   * {@code LIMIT pageSize}. Kept separate to leave {@link #buildFindRelationshipSQL} untouched.
+   * Keyset (seek) pagination counterpart of {@link #buildFindRelationshipSQL} for rows that are
+   * still current: same join/filter construction plus {@code rt.deleted_ts IS NULL}, keyset bounds
+   * ({@code rt.id > lastId AND rt.id <= maxId}, {@code maxId} being the largest relationship row id
+   * when paging starts), ascending id order and {@code LIMIT pageSize}. Kept separate to leave
+   * {@link #buildFindRelationshipSQL} untouched.
    *
-   * <p>Always current-only ({@code deleted_ts IS NULL}); ranked/non-current pagination is
-   * unsupported because it could not bound the per-page DB work.</p>
+   * <p>Ranked/non-current pagination is unsupported because it could not bound the per-page DB
+   * work.</p>
    *
    * <p>Supported only for {@code NEW_SCHEMA_ONLY}; {@code OLD_SCHEMA_ONLY} and {@code DUAL_SCHEMA}
    * (deprecated) throw {@link UnsupportedOperationException} before any SQL is built.</p>
    */
   @Nonnull
   @VisibleForTesting
-  public String buildFindRelationshipKeysetSQL(@Nonnull final String relationshipTableName,
+  public String buildFindRelationshipKeysetCurrentSQL(@Nonnull final String relationshipTableName,
       @Nonnull LocalRelationshipFilter relationshipFilter, @Nullable final String sourceTableName,
       @Nullable LocalRelationshipFilter sourceEntityFilter, @Nullable final String destTableName,
       @Nullable LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId) {
+    return buildFindRelationshipKeysetSQL(relationshipTableName, relationshipFilter, sourceTableName, sourceEntityFilter,
+        destTableName, destinationEntityFilter, pageSize, lastId, maxId, "rt.deleted_ts is NULL");
+  }
+
+  /**
+   * Supplementary keyset query for rows that were current when the scan started but were
+   * soft-deleted before this page is read.
+   */
+  @Nonnull
+  @VisibleForTesting
+  public String buildFindRelationshipKeysetDeletedSinceScanStartSQL(@Nonnull final String relationshipTableName,
+      @Nonnull LocalRelationshipFilter relationshipFilter, @Nullable final String sourceTableName,
+      @Nullable LocalRelationshipFilter sourceEntityFilter, @Nullable final String destTableName,
+      @Nullable LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId,
+      @Nonnull Timestamp scanStartTime) {
+    if (scanStartTime == null) {
+      throw new IllegalArgumentException("scanStartTime must not be null");
+    }
+    return buildFindRelationshipKeysetSQL(relationshipTableName, relationshipFilter, sourceTableName, sourceEntityFilter,
+        destTableName, destinationEntityFilter, pageSize, lastId, maxId,
+        "rt.deleted_ts > STR_TO_DATE(:scanStartTime, '%Y-%m-%d %H:%i:%s.%f')");
+  }
+
+  @Nonnull
+  private String buildFindRelationshipKeysetSQL(@Nonnull final String relationshipTableName,
+      @Nonnull LocalRelationshipFilter relationshipFilter, @Nullable final String sourceTableName,
+      @Nullable LocalRelationshipFilter sourceEntityFilter, @Nullable final String destTableName,
+      @Nullable LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId,
+      @Nonnull String deletedTsPredicate) {
     if (pageSize < 1 || pageSize > MAX_KEYSET_PAGE_SIZE) {
       throw new IllegalArgumentException(
           "pageSize must be between 1 and " + MAX_KEYSET_PAGE_SIZE + " but was " + pageSize);
@@ -1183,7 +1309,7 @@ public class EbeanLocalRelationshipQueryDAO {
           _eBeanDAOConfig.isNonDollarVirtualColumnsEnabled(), _schemaValidatorUtil,
           filters.toArray(new Triplet[filters.size()]));
 
-      sqlBuilder.append("WHERE rt.deleted_ts is NULL");
+      sqlBuilder.append("WHERE ").append(deletedTsPredicate);
       if (whereClause != null) {
         sqlBuilder.append(" AND ").append(whereClause);
       }
@@ -1220,19 +1346,46 @@ public class EbeanLocalRelationshipQueryDAO {
     try {
       return _server.createSqlQuery(sql).findList();
     } catch (PersistenceException e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof SQLException && cause.getMessage() != null
-          && cause.getMessage().contains("doesn't exist in table")) {
-        String errorMsg = String.format(
-            "Missing index when querying table '%s'. "
-                + "Make sure FORCE INDEX targets like idx_destination_deleted_ts or idx_source_deleted_ts are created.",
-            relationshipTableName);
-        log.error(errorMsg);
-        throw new IllegalStateException(errorMsg, e);
-      }
-
+      handleSqlExecutionException(e, relationshipTableName);
       throw new RuntimeException("Failed to execute SQL query for relationships", e);
     }
+  }
+
+  private List<SqlRow> executeSqlWithIndexCheck(String sql, String relationshipTableName,
+      @Nonnull Timestamp scanStartTime) {
+    try {
+      SqlQuery query = _server.createSqlQuery(sql);
+      query.setParameter("scanStartTime", formatTimestamp6(scanStartTime));
+      return query.findList();
+    } catch (PersistenceException e) {
+      handleSqlExecutionException(e, relationshipTableName);
+      throw new RuntimeException("Failed to execute SQL query for relationships", e);
+    }
+  }
+
+  private void handleSqlExecutionException(PersistenceException e, String relationshipTableName) {
+    Throwable cause = e.getCause();
+    if (cause instanceof SQLException && cause.getMessage() != null
+        && cause.getMessage().contains("doesn't exist in table")) {
+      String errorMsg = String.format(
+          "Missing index when querying table '%s'. "
+              + "Make sure FORCE INDEX targets like idx_destination_deleted_ts or idx_source_deleted_ts are created.",
+          relationshipTableName);
+      log.error(errorMsg);
+      throw new IllegalStateException(errorMsg, e);
+    }
+  }
+
+  @Nonnull
+  private static Timestamp copyTimestamp(@Nonnull Timestamp timestamp) {
+    Timestamp copy = new Timestamp(timestamp.getTime());
+    copy.setNanos(timestamp.getNanos());
+    return copy;
+  }
+
+  @Nonnull
+  private static String formatTimestamp6(@Nonnull Timestamp timestamp) {
+    return timestamp.toLocalDateTime().format(MYSQL_TIMESTAMP_6_FORMATTER);
   }
 
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -463,7 +463,9 @@ public class EbeanLocalRelationshipQueryDAO {
     // Query current rows first. If a row is soft-deleted between the two reads, Query B may also see
     // the same id; mergeKeysetRows dedups that id. Running B first could turn the race into a drop.
     final List<SqlRow> currentRows = executeSqlWithIndexCheck(currentSql, relationshipTableName);
-    // No-op seam that tests override to inject a soft-delete between Query A and Query B.
+    // No-op seam. The A/B race spans two separate statements, so there is no way to land a
+    // soft-delete between them from outside the DAO; tests override this to inject one
+    // deterministically instead of relying on timing.
     afterKeysetCurrentRowsFetched(relationshipTableName, currentRows);
     // Cap Query B at Query A's frontier when A filled the page. Query B is itself
     // ORDER BY id LIMIT pageSize, so this bounds per-page work rather than changing which rows the
@@ -606,10 +608,8 @@ public class EbeanLocalRelationshipQueryDAO {
     final String sql =
         "SELECT COALESCE(MAX(id), 0) AS max_id, DATE_FORMAT(NOW(6), '%Y-%m-%d %H:%i:%s.%f') AS scan_start_time FROM "
             + relationshipTableName;
+    // Aggregate without GROUP BY, so this always yields exactly one row.
     final SqlRow row = _server.createSqlQuery(sql).findOne();
-    if (row == null) {
-      throw new IllegalStateException("Scan-start query returned no rows for table " + relationshipTableName);
-    }
     return new KeysetScanStart(row.getLong("max_id"), row.getString("scan_start_time"));
   }
 

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
@@ -48,7 +48,10 @@ public final class RelationshipKeysetCursor {
    *               Must be non-negative.
    * @param maxId largest relationship row id when paging starts; bounds the scan. Must be
    *              non-negative and {@code >= lastId}.
-   * @param scanStartTime database time when the scan started. Must not be null.
+   * @param scanStartTime database time when the scan started, as a database-local timestamp in
+   *                      exactly {@code yyyy-MM-dd HH:mm:ss.SSSSSS} form. Six fractional digits are
+   *                      required: {@code deleted_ts} is {@code DATETIME(6)}, and coarser precision
+   *                      would place a delete before a scan it actually followed. Must not be null.
    * @param relationshipTableName relationship table this cursor belongs to. Must not be null or
    *                              empty.
    */

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
@@ -1,5 +1,7 @@
 package com.linkedin.metadata.dao;
 
+import java.sql.Timestamp;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 
 
@@ -7,14 +9,16 @@ import lombok.Getter;
  * Immutable position of a keyset (seek) pagination scan over a single relationship table, used by
  * {@link EbeanLocalRelationshipQueryDAO#findRelationshipsByKeyset}.
  *
- * <p>{@code lastId} is the id of the last row returned; the next page starts strictly after it
+ * <p>{@code scanStartTime} is captured from the database clock when the first page starts and is
+ * used by later pages to include rows that were current at scan start even if they were soft-deleted
+ * before a later page is read. {@code relationshipTableName} identifies the relationship table this
+ * cursor belongs to and is validated by the DAO before continuing a scan. {@code lastId} is the id
+ * of the last row returned; the next page starts strictly after it
  * ({@code rt.id > lastId}) and is {@code 0} for the first page. {@code maxId} is the largest
  * relationship row id when paging starts, captured on the first page
  * ({@code COALESCE(MAX(id), 0)}); every page is bounded by {@code rt.id <= maxId}. Later inserts get
- * larger ids and are excluded, which keeps the scan finite. The combined pages are not a
- * point-in-time snapshot: existing rows updated or soft-deleted between page calls can change which
- * rows a later page returns, so callers must not assume they see every row that was current when
- * paging started. Both values are non-negative and {@code lastId <= maxId} always holds.</p>
+ * larger ids and are excluded, which keeps the scan finite. Numeric values are non-negative and
+ * {@code lastId <= maxId} always holds.</p>
  */
 public final class RelationshipKeysetCursor {
 
@@ -22,6 +26,11 @@ public final class RelationshipKeysetCursor {
   private final long lastId;
   @Getter
   private final long maxId;
+  @Getter
+  @Nonnull
+  private final String relationshipTableName;
+  @Nonnull
+  private final Timestamp scanStartTime;
 
   /**
    * Creates a cursor.
@@ -30,8 +39,12 @@ public final class RelationshipKeysetCursor {
    *               Must be non-negative.
    * @param maxId largest relationship row id when paging starts; bounds the scan. Must be
    *              non-negative and {@code >= lastId}.
+   * @param scanStartTime database time when the scan started. Must not be null.
+   * @param relationshipTableName relationship table this cursor belongs to. Must not be null or
+   *                              empty.
    */
-  public RelationshipKeysetCursor(long lastId, long maxId) {
+  public RelationshipKeysetCursor(long lastId, long maxId, @Nonnull Timestamp scanStartTime,
+      @Nonnull String relationshipTableName) {
     if (lastId < 0) {
       throw new IllegalArgumentException("lastId must be non-negative but was " + lastId);
     }
@@ -42,7 +55,27 @@ public final class RelationshipKeysetCursor {
       throw new IllegalArgumentException(
           "lastId (" + lastId + ") must not be greater than maxId (" + maxId + ")");
     }
+    if (scanStartTime == null) {
+      throw new IllegalArgumentException("scanStartTime must not be null");
+    }
+    if (relationshipTableName == null || relationshipTableName.trim().isEmpty()) {
+      throw new IllegalArgumentException("relationshipTableName must not be null or empty");
+    }
     this.lastId = lastId;
     this.maxId = maxId;
+    this.scanStartTime = copyTimestamp(scanStartTime);
+    this.relationshipTableName = relationshipTableName;
+  }
+
+  @Nonnull
+  public Timestamp getScanStartTime() {
+    return copyTimestamp(scanStartTime);
+  }
+
+  @Nonnull
+  private static Timestamp copyTimestamp(@Nonnull Timestamp timestamp) {
+    Timestamp copy = new Timestamp(timestamp.getTime());
+    copy.setNanos(timestamp.getNanos());
+    return copy;
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetCursor.java
@@ -1,6 +1,10 @@
 package com.linkedin.metadata.dao;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 
@@ -21,6 +25,10 @@ import lombok.Getter;
  * {@code lastId <= maxId} always holds.</p>
  */
 public final class RelationshipKeysetCursor {
+  private static final Pattern SCAN_START_TIME_PATTERN =
+      Pattern.compile("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}");
+  private static final DateTimeFormatter SCAN_START_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSSSSS").withResolverStyle(ResolverStyle.STRICT);
 
   @Getter
   private final long lastId;
@@ -29,8 +37,9 @@ public final class RelationshipKeysetCursor {
   @Getter
   @Nonnull
   private final String relationshipTableName;
+  @Getter
   @Nonnull
-  private final Timestamp scanStartTime;
+  private final String scanStartTime;
 
   /**
    * Creates a cursor.
@@ -43,7 +52,7 @@ public final class RelationshipKeysetCursor {
    * @param relationshipTableName relationship table this cursor belongs to. Must not be null or
    *                              empty.
    */
-  public RelationshipKeysetCursor(long lastId, long maxId, @Nonnull Timestamp scanStartTime,
+  public RelationshipKeysetCursor(long lastId, long maxId, @Nonnull String scanStartTime,
       @Nonnull String relationshipTableName) {
     if (lastId < 0) {
       throw new IllegalArgumentException("lastId must be non-negative but was " + lastId);
@@ -58,24 +67,27 @@ public final class RelationshipKeysetCursor {
     if (scanStartTime == null) {
       throw new IllegalArgumentException("scanStartTime must not be null");
     }
+    if (scanStartTime.trim().isEmpty()) {
+      throw new IllegalArgumentException("scanStartTime must not be empty");
+    }
+    validateScanStartTime(scanStartTime);
     if (relationshipTableName == null || relationshipTableName.trim().isEmpty()) {
       throw new IllegalArgumentException("relationshipTableName must not be null or empty");
     }
     this.lastId = lastId;
     this.maxId = maxId;
-    this.scanStartTime = copyTimestamp(scanStartTime);
+    this.scanStartTime = scanStartTime;
     this.relationshipTableName = relationshipTableName;
   }
 
-  @Nonnull
-  public Timestamp getScanStartTime() {
-    return copyTimestamp(scanStartTime);
-  }
-
-  @Nonnull
-  private static Timestamp copyTimestamp(@Nonnull Timestamp timestamp) {
-    Timestamp copy = new Timestamp(timestamp.getTime());
-    copy.setNanos(timestamp.getNanos());
-    return copy;
+  private static void validateScanStartTime(@Nonnull String scanStartTime) {
+    if (!SCAN_START_TIME_PATTERN.matcher(scanStartTime).matches()) {
+      throw new IllegalArgumentException("scanStartTime must use yyyy-MM-dd HH:mm:ss.SSSSSS");
+    }
+    try {
+      LocalDateTime.parse(scanStartTime, SCAN_START_TIME_FORMATTER);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("scanStartTime must use yyyy-MM-dd HH:mm:ss.SSSSSS", e);
+    }
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetPage.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetPage.java
@@ -21,7 +21,7 @@ public final class RelationshipKeysetPage<R extends RecordTemplate> {
   @Nonnull
   private final List<R> relationships;
   @Getter
-  private final long highWaterId;
+  private final long maxId;
   @Getter
   @Nullable
   private final RelationshipKeysetCursor nextCursor;
@@ -31,29 +31,29 @@ public final class RelationshipKeysetPage<R extends RecordTemplate> {
    *
    * @param relationships the relationships in this page, in ascending {@code id} order. Copied
    *                      defensively and exposed as an unmodifiable list.
-   * @param highWaterId the largest relationship row {@code id} when paging started (the
-   *                    {@code maxId} captured on the first page), which bounds the scan. Must be
-   *                    non-negative.
+   * @param maxId the largest relationship row {@code id} at the time paging started, captured on
+   *              the first page. Bounds the scan so rows inserted mid-scan are excluded. Must be
+   *              non-negative.
    * @param nextCursor cursor to fetch the next page, or {@code null} if this is the last page.
-   *                   When non-null it must preserve the same {@code maxId} as {@code highWaterId}.
+   *                   When non-null its own {@code maxId} must equal this page's {@code maxId}.
    */
-  public RelationshipKeysetPage(@Nonnull List<R> relationships, long highWaterId,
+  public RelationshipKeysetPage(@Nonnull List<R> relationships, long maxId,
       @Nullable RelationshipKeysetCursor nextCursor) {
     if (relationships == null) {
       throw new IllegalArgumentException("relationships must not be null");
     }
-    if (highWaterId < 0) {
+    if (maxId < 0) {
       throw new IllegalArgumentException(
-          "highWaterId must be non-negative but was " + highWaterId);
+          "maxId must be non-negative but was " + maxId);
     }
-    if (nextCursor != null && nextCursor.getMaxId() != highWaterId) {
+    if (nextCursor != null && nextCursor.getMaxId() != maxId) {
       throw new IllegalArgumentException(
-          "nextCursor maxId (" + nextCursor.getMaxId() + ") must match highWaterId ("
-              + highWaterId + ")");
+          "nextCursor maxId (" + nextCursor.getMaxId() + ") must match page maxId ("
+              + maxId + ")");
     }
     this.relationships =
         Collections.unmodifiableList(new ArrayList<>(relationships));
-    this.highWaterId = highWaterId;
+    this.maxId = maxId;
     this.nextCursor = nextCursor;
   }
 }

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/SQLStatementUtils.java
@@ -160,10 +160,10 @@ public class SQLStatementUtils {
   private static final String INSERT_LOCAL_RELATIONSHIPS_WITH_ASPECT_VALUES = "(:metadata%1$d, :source%1$d, :destination%1$d, :source_type%1$d,"
       + " :destination_type%1$d, :lastmodifiedon, :lastmodifiedby, :aspect)";
 
-  private static final String DELETE_BY_SOURCE = "UPDATE %s SET deleted_ts=NOW() "
+  private static final String DELETE_BY_SOURCE = "UPDATE %s SET deleted_ts=NOW(6) "
       + "WHERE source = :source AND deleted_ts IS NULL";
 
-  private static final String DELETE_BY_SOURCE_AND_ASPECT = "UPDATE %s SET deleted_ts=NOW() "
+  private static final String DELETE_BY_SOURCE_AND_ASPECT = "UPDATE %s SET deleted_ts=NOW(6) "
       + "WHERE source = :source AND (aspect = :aspect OR aspect = :pegasus_aspect) AND deleted_ts IS NULL";
 
   private static final String SQL_BROWSE_ASPECT_TEMPLATE =

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -2752,6 +2752,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     List<ReportsTo> drained = new ArrayList<>();
     RelationshipKeysetPage<ReportsTo> first = keysetPage(observingQueryDAO, 2, cursor);
+    // Direct enforcement of Query B's frontier. This pins the per-page work bound; it is not a
+    // proof of data correctness, since the merge would select the same rows without the cap.
     assertEquals(firstDeletedUpperId[0], 4L);
     assertSourcesInOrder(first.getRelationships(), sources.get(0), sources.get(1));
     assertNotNull(first.getNextCursor());

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -2335,7 +2335,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     RelationshipKeysetPage<ReportsTo> page = keysetPage(3, null);
     assertTrue(page.getRelationships().isEmpty());
     assertNull(page.getNextCursor());
-    assertEquals(page.getHighWaterId(), 0L);
+    assertEquals(page.getMaxId(), 0L);
   }
 
   @Test
@@ -2352,7 +2352,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     RelationshipKeysetPage<ReportsTo> page = keysetPage(5, null);
     assertEquals(page.getRelationships().size(), 2);
     assertNull(page.getNextCursor());
-    assertEquals(page.getHighWaterId(), 2L);
+    assertEquals(page.getMaxId(), 2L);
   }
 
   @Test
@@ -2363,7 +2363,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     RelationshipKeysetPage<ReportsTo> first = keysetPage(3, null);
     assertEquals(first.getRelationships().size(), 3);
     assertNull(first.getNextCursor());
-    assertEquals(first.getHighWaterId(), 3L);
+    assertEquals(first.getMaxId(), 3L);
   }
 
   @Test
@@ -2380,7 +2380,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _server.createSqlUpdate("UPDATE metadata_relationship_reportsto SET deleted_ts='2000-01-01 00:00:00' "
         + "WHERE deleted_ts IS NOT NULL").execute();
 
-    // Current rows toward dest #1: only id 1. High-water id is 5 because later nonmatching rows
+    // Current rows toward dest #1: only id 1. Max id is 5 because later nonmatching rows
     // (ids 4/5 pointing elsewhere) set maxId. A page size of 1 fills fully with id 1 (below maxId
     // 5), so a next cursor is produced; that continuation query is empty because ids 2 and 3 are
     // soft-deleted and 4/5 point elsewhere, so one final empty page is needed to end the scan.
@@ -2435,16 +2435,16 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
-  public void testFindRelationshipsByKeysetHighWaterExcludesLaterInsert() throws URISyntaxException {
+  public void testFindRelationshipsByKeysetMaxIdExcludesLaterInsert() throws URISyntaxException {
     addReportsToChain(5, new FooUrn(1));
 
-    // Capture the high-water id on the first page.
+    // Capture the max id on the first page.
     RelationshipKeysetCursor cursor = null;
     List<ReportsTo> drained = new ArrayList<>();
     RelationshipKeysetPage<ReportsTo> page = keysetPage(2, null);
     drained.addAll(page.getRelationships());
     cursor = page.getNextCursor();
-    assertEquals(page.getHighWaterId(), 5L);
+    assertEquals(page.getMaxId(), 5L);
 
     // Insert more rows after the scan started; they must not be observed. These later inserts are
     // deterministically excluded by the fixed maxId (best effort only covers updates/deletes of
@@ -2592,9 +2592,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
     _localRelationshipWriterDAO.addRelationships(d, AspectFoo.class,
         Collections.singletonList(new ReportsTo().setSource(d).setDestination(dest)), false);
 
-    // Page 1 (size 2) captures the insertion high-water id maxId = 4 and returns ids 1,2 (a, b).
+    // Page 1 (size 2) captures the largest row id maxId = 4 and returns ids 1,2 (a, b).
     RelationshipKeysetPage<ReportsTo> first = keysetPage(2, null);
-    assertEquals(first.getHighWaterId(), 4L);
+    assertEquals(first.getMaxId(), 4L);
     assertNotNull(first.getNextCursor());
     List<ReportsTo> drained = new ArrayList<>(first.getRelationships());
 
@@ -2727,7 +2727,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertNotNull(page.getNextCursor());
     expectThrows(UnsupportedOperationException.class, () -> page.getRelationships().add(null));
 
-    // next cursor maxId must match highWaterId.
+    // next cursor maxId must match maxId.
     expectThrows(IllegalArgumentException.class, () ->
         new RelationshipKeysetPage<>(new ArrayList<ReportsTo>(), 10,
             new RelationshipKeysetCursor(5, 9, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto")));
@@ -2805,7 +2805,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
       RelationshipKeysetPage<AssetRelationship> page = _localRelationshipQueryDAO.findRelationshipsV4ByKeyset(
           "foo", srcFilter, "foo", destFilter, BelongsToV2.class, relationshipFilter,
           AssetRelationship.class, wrapOptions, 2, cursor);
-      assertEquals(page.getHighWaterId(), 7L);
+      assertEquals(page.getMaxId(), 7L);
       drained.addAll(page.getRelationships());
       cursor = page.getNextCursor();
       pages++;
@@ -2858,7 +2858,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
         "foo", srcFilter, "NON_MG_ASSET", null, BelongsToV2.class, relationshipFilter,
         AssetRelationship.class, wrapOptions, 10, null);
 
-    assertEquals(page.getHighWaterId(), 1L);
+    assertEquals(page.getMaxId(), 1L);
     assertNull(page.getNextCursor());
     assertEquals(page.getRelationships().size(), 1);
     AssetRelationship wrapped = page.getRelationships().get(0);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2219,19 +2218,72 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   private RelationshipKeysetPage<ReportsTo> keysetPage(int pageSize, RelationshipKeysetCursor cursor) {
-    return _localRelationshipQueryDAO.findRelationshipsByKeyset(
+    return keysetPage(_localRelationshipQueryDAO, pageSize, cursor);
+  }
+
+  private RelationshipKeysetPage<ReportsTo> keysetPage(EbeanLocalRelationshipQueryDAO queryDAO, int pageSize,
+      RelationshipKeysetCursor cursor) {
+    return queryDAO.findRelationshipsByKeyset(
         null, emptyFilter(), null, emptyFilter(), ReportsTo.class, outgoingEmptyFilter(), pageSize, cursor);
   }
 
   private List<ReportsTo> drainKeyset(int pageSize) {
+    return drainKeyset(pageSize, null);
+  }
+
+  private List<ReportsTo> drainKeyset(int pageSize, RelationshipKeysetCursor cursor) {
     List<ReportsTo> all = new ArrayList<>();
-    RelationshipKeysetCursor cursor = null;
     do {
       RelationshipKeysetPage<ReportsTo> page = keysetPage(pageSize, cursor);
       all.addAll(page.getRelationships());
       cursor = page.getNextCursor();
     } while (cursor != null);
     return all;
+  }
+
+  private String captureScanStartTime() {
+    return _server.createSqlQuery("SELECT DATE_FORMAT(NOW(6), '%Y-%m-%d %H:%i:%s.%f') AS scan_start_time")
+        .findOne()
+        .getString("scan_start_time");
+  }
+
+  private long maxRelationshipId(String relationshipTableName) {
+    return _server.createSqlQuery("SELECT COALESCE(MAX(id), 0) AS max_id FROM " + relationshipTableName)
+        .findOne()
+        .getLong("max_id");
+  }
+
+  private void softDeleteReportsToAfterScanStart(String scanStartTime, FooUrn... sources) {
+    for (FooUrn source : sources) {
+      _server.createSqlUpdate("UPDATE metadata_relationship_reportsto "
+          + "SET deleted_ts=DATE_ADD(STR_TO_DATE(:scanStartTime, '%Y-%m-%d %H:%i:%s.%f'), INTERVAL 1 MICROSECOND) "
+          + "WHERE source=:source AND deleted_ts IS NULL")
+          .setParameter("scanStartTime", scanStartTime)
+          .setParameter("source", source.toString())
+          .execute();
+    }
+  }
+
+  private RelationshipKeysetCursor reportsToCursorAtScanStart(long lastId, String scanStartTime) {
+    String relationshipTableName = SQLSchemaUtils.getRelationshipTableName(ReportsTo.class);
+    return new RelationshipKeysetCursor(lastId, maxRelationshipId(relationshipTableName), scanStartTime,
+        relationshipTableName);
+  }
+
+  private void assertSourcesInOrder(List<ReportsTo> relationships, FooUrn... expectedSources) {
+    assertEquals(relationships.size(), expectedSources.length);
+    for (int i = 0; i < expectedSources.length; i++) {
+      assertEquals(makeFooUrn(relationships.get(i).getSource().toString()), expectedSources[i]);
+    }
+  }
+
+  private void assertSourcesExactlyOnce(List<ReportsTo> relationships, Set<FooUrn> expectedSources) {
+    assertEquals(relationships.size(), expectedSources.size());
+    Set<FooUrn> actualSources = relationships.stream()
+        .map(r -> makeFooUrn(r.getSource().toString()))
+        .collect(Collectors.toSet());
+    assertEquals(actualSources.size(), relationships.size());
+    assertEquals(actualSources, expectedSources);
   }
 
   @Test
@@ -2255,7 +2307,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetDeletedSinceScanStartSQL("relationship_table_name",
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         "source_table_name", null, "destination_table_name", null,
-        10, 5, 20, Timestamp.valueOf("2026-08-05 12:34:56.789"));
+        10, 5, 20, "2026-08-05 12:34:56.789000");
 
     assertEquals(sql,
         "SELECT rt.* FROM relationship_table_name rt INNER JOIN destination_table_name dt ON dt.urn=rt.destination "
@@ -2408,7 +2460,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     List<ReportsTo> drained = new ArrayList<>();
     RelationshipKeysetCursor cursor = null;
-    Timestamp scanStartTime = null;
+    String scanStartTime = null;
     String relationshipTableName = SQLSchemaUtils.getRelationshipTableName(ReportsTo.class);
     do {
       RelationshipKeysetPage<ReportsTo> page = keysetPage(2, cursor);
@@ -2675,29 +2727,145 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
+  public void testFindRelationshipsByKeysetDefersCurrentRowsWhenDeletedRowsTruncateMergedPage()
+      throws URISyntaxException {
+    List<FooUrn> sources = addReportsToChain(6, new FooUrn(1));
+    String scanStartTime = captureScanStartTime();
+    RelationshipKeysetCursor cursor = reportsToCursorAtScanStart(0, scanStartTime);
+    softDeleteReportsToAfterScanStart(scanStartTime, sources.get(0), sources.get(1));
+    long[] firstDeletedUpperId = {-1L};
+    EbeanLocalRelationshipQueryDAO observingQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig) {
+      @Override
+      public String buildFindRelationshipKeysetDeletedSinceScanStartSQL(String relationshipTableName,
+          LocalRelationshipFilter relationshipFilter, String sourceTableName,
+          LocalRelationshipFilter sourceEntityFilter, String destTableName,
+          LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId,
+          String scanStartTime) {
+        if (firstDeletedUpperId[0] == -1L) {
+          firstDeletedUpperId[0] = maxId;
+        }
+        return super.buildFindRelationshipKeysetDeletedSinceScanStartSQL(relationshipTableName, relationshipFilter,
+            sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter, pageSize, lastId, maxId,
+            scanStartTime);
+      }
+    };
+
+    List<ReportsTo> drained = new ArrayList<>();
+    RelationshipKeysetPage<ReportsTo> first = keysetPage(observingQueryDAO, 2, cursor);
+    assertEquals(firstDeletedUpperId[0], 4L);
+    assertSourcesInOrder(first.getRelationships(), sources.get(0), sources.get(1));
+    assertNotNull(first.getNextCursor());
+    assertEquals(first.getNextCursor().getLastId(), 2L);
+    drained.addAll(first.getRelationships());
+
+    RelationshipKeysetPage<ReportsTo> second = keysetPage(observingQueryDAO, 2, first.getNextCursor());
+    assertSourcesInOrder(second.getRelationships(), sources.get(2), sources.get(3));
+    assertNotNull(second.getNextCursor());
+    assertEquals(second.getNextCursor().getLastId(), 4L);
+    drained.addAll(second.getRelationships());
+
+    RelationshipKeysetPage<ReportsTo> third = keysetPage(observingQueryDAO, 2, second.getNextCursor());
+    assertSourcesInOrder(third.getRelationships(), sources.get(4), sources.get(5));
+    assertNull(third.getNextCursor());
+    drained.addAll(third.getRelationships());
+
+    assertSourcesExactlyOnce(drained, new java.util.HashSet<>(sources));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetDeletedRowsCanFillWholePage()
+      throws URISyntaxException {
+    List<FooUrn> sources = addReportsToChain(4, new FooUrn(1));
+    String scanStartTime = captureScanStartTime();
+    RelationshipKeysetCursor cursor = reportsToCursorAtScanStart(0, scanStartTime);
+    softDeleteReportsToAfterScanStart(scanStartTime, sources.toArray(new FooUrn[sources.size()]));
+
+    RelationshipKeysetPage<ReportsTo> first = keysetPage(2, cursor);
+    assertSourcesInOrder(first.getRelationships(), sources.get(0), sources.get(1));
+    assertNotNull(first.getNextCursor());
+
+    RelationshipKeysetPage<ReportsTo> second = keysetPage(2, first.getNextCursor());
+    assertSourcesInOrder(second.getRelationships(), sources.get(2), sources.get(3));
+    assertNull(second.getNextCursor());
+
+    List<ReportsTo> drained = new ArrayList<>();
+    drained.addAll(first.getRelationships());
+    drained.addAll(second.getRelationships());
+    assertSourcesExactlyOnce(drained, new java.util.HashSet<>(sources));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetInterleavesDeletedRowsAroundCurrentRows()
+      throws URISyntaxException {
+    List<FooUrn> sources = addReportsToChain(6, new FooUrn(1));
+    String scanStartTime = captureScanStartTime();
+    RelationshipKeysetCursor cursor = reportsToCursorAtScanStart(0, scanStartTime);
+    softDeleteReportsToAfterScanStart(scanStartTime, sources.get(1), sources.get(3), sources.get(5));
+
+    RelationshipKeysetPage<ReportsTo> first = keysetPage(4, cursor);
+    assertSourcesInOrder(first.getRelationships(), sources.get(0), sources.get(1), sources.get(2), sources.get(3));
+    assertNotNull(first.getNextCursor());
+
+    RelationshipKeysetPage<ReportsTo> second = keysetPage(4, first.getNextCursor());
+    assertSourcesInOrder(second.getRelationships(), sources.get(4), sources.get(5));
+    assertNull(second.getNextCursor());
+
+    List<ReportsTo> drained = new ArrayList<>();
+    drained.addAll(first.getRelationships());
+    drained.addAll(second.getRelationships());
+    assertSourcesExactlyOnce(drained, new java.util.HashSet<>(sources));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetFinalMergedPageCanLandOnMaxId()
+      throws URISyntaxException {
+    List<FooUrn> sources = addReportsToChain(4, new FooUrn(1));
+    String scanStartTime = captureScanStartTime();
+    RelationshipKeysetCursor cursor = reportsToCursorAtScanStart(0, scanStartTime);
+    softDeleteReportsToAfterScanStart(scanStartTime, sources.get(3));
+
+    RelationshipKeysetPage<ReportsTo> first = keysetPage(2, cursor);
+    assertSourcesInOrder(first.getRelationships(), sources.get(0), sources.get(1));
+    assertNotNull(first.getNextCursor());
+
+    RelationshipKeysetPage<ReportsTo> second = keysetPage(2, first.getNextCursor());
+    assertSourcesInOrder(second.getRelationships(), sources.get(2), sources.get(3));
+    assertNull(second.getNextCursor());
+
+    List<ReportsTo> drained = new ArrayList<>();
+    drained.addAll(first.getRelationships());
+    drained.addAll(second.getRelationships());
+    assertSourcesExactlyOnce(drained, new java.util.HashSet<>(sources));
+  }
+
+  @Test
   public void testRelationshipKeysetCursorValidationAndGetters() {
-    Timestamp scanStartTime = Timestamp.valueOf("2026-08-05 12:34:56.789");
+    String scanStartTime = "2026-08-05 12:34:56.789000";
     RelationshipKeysetCursor cursor =
         new RelationshipKeysetCursor(3, 10, scanStartTime, "metadata_relationship_reportsto");
     assertEquals(cursor.getLastId(), 3L);
     assertEquals(cursor.getMaxId(), 10L);
     assertEquals(cursor.getScanStartTime(), scanStartTime);
     assertEquals(cursor.getRelationshipTableName(), "metadata_relationship_reportsto");
-    scanStartTime.setTime(0);
-    assertNotEquals(cursor.getScanStartTime(), scanStartTime);
 
     expectThrows(IllegalArgumentException.class, () ->
-        new RelationshipKeysetCursor(-1, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto"));
+        new RelationshipKeysetCursor(-1, 10, "2026-08-05 12:34:56.789000", "metadata_relationship_reportsto"));
     expectThrows(IllegalArgumentException.class, () ->
-        new RelationshipKeysetCursor(3, -1, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto"));
+        new RelationshipKeysetCursor(3, -1, "2026-08-05 12:34:56.789000", "metadata_relationship_reportsto"));
     expectThrows(IllegalArgumentException.class, () ->
-        new RelationshipKeysetCursor(11, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto"));
+        new RelationshipKeysetCursor(11, 10, "2026-08-05 12:34:56.789000", "metadata_relationship_reportsto"));
     expectThrows(IllegalArgumentException.class, () ->
         new RelationshipKeysetCursor(3, 10, null, "metadata_relationship_reportsto"));
     expectThrows(IllegalArgumentException.class, () ->
-        new RelationshipKeysetCursor(3, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), null));
+        new RelationshipKeysetCursor(3, 10, "", "metadata_relationship_reportsto"));
     expectThrows(IllegalArgumentException.class, () ->
-        new RelationshipKeysetCursor(3, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), ""));
+        new RelationshipKeysetCursor(3, 10, "2026-08-05 12:34:56.789", "metadata_relationship_reportsto"));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(3, 10, "2026-02-30 12:34:56.789000", "metadata_relationship_reportsto"));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(3, 10, "2026-08-05 12:34:56.789000", null));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(3, 10, "2026-08-05 12:34:56.789000", ""));
   }
 
   @Test
@@ -2705,7 +2873,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     String belongsToTable = SQLSchemaUtils.getRelationshipTableName(BelongsToV2.class);
     String reportsToTable = SQLSchemaUtils.getRelationshipTableName(ReportsTo.class);
     RelationshipKeysetCursor wrongTypeCursor =
-        new RelationshipKeysetCursor(0, 1, Timestamp.valueOf("2026-08-05 12:34:56.789"), belongsToTable);
+        new RelationshipKeysetCursor(0, 1, "2026-08-05 12:34:56.789000", belongsToTable);
 
     IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> keysetPage(2, wrongTypeCursor));
     assertTrue(exception.getMessage().contains(belongsToTable));
@@ -2717,7 +2885,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     List<ReportsTo> source = new ArrayList<>();
     source.add(new ReportsTo().setSource(new FooUrn(1)).setDestination(new FooUrn(2)));
     RelationshipKeysetCursor nextCursor =
-        new RelationshipKeysetCursor(5, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto");
+        new RelationshipKeysetCursor(5, 10, "2026-08-05 12:34:56.789000", "metadata_relationship_reportsto");
     RelationshipKeysetPage<ReportsTo> page =
         new RelationshipKeysetPage<>(source, 10, nextCursor);
 
@@ -2730,7 +2898,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // next cursor maxId must match maxId.
     expectThrows(IllegalArgumentException.class, () ->
         new RelationshipKeysetPage<>(new ArrayList<ReportsTo>(), 10,
-            new RelationshipKeysetCursor(5, 9, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto")));
+            new RelationshipKeysetCursor(5, 9, "2026-08-05 12:34:56.789000", "metadata_relationship_reportsto")));
     expectThrows(IllegalArgumentException.class, () ->
         new RelationshipKeysetPage<ReportsTo>(null, 10, null));
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2234,10 +2235,11 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
-  public void testBuildFindRelationshipKeysetSQL() {
+  public void testBuildFindRelationshipKeysetCurrentSQL() {
     // Unlike the existing offset builder, the keyset builder adds `id > lastId`, `id <= maxId`,
-    // `ORDER BY rt.id ASC` and a finite LIMIT.
-    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+    // `ORDER BY rt.id ASC` and a finite LIMIT. The current-row query keeps the original
+    // `deleted_ts is NULL` predicate so the hot path keeps the old index plan.
+    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         "source_table_name", null, "destination_table_name", null,
         10, 5, 20);
@@ -2249,13 +2251,27 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
+  public void testBuildFindRelationshipKeysetDeletedSinceScanStartSQL() {
+    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetDeletedSinceScanStartSQL("relationship_table_name",
+        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+        "source_table_name", null, "destination_table_name", null,
+        10, 5, 20, Timestamp.valueOf("2026-08-05 12:34:56.789"));
+
+    assertEquals(sql,
+        "SELECT rt.* FROM relationship_table_name rt INNER JOIN destination_table_name dt ON dt.urn=rt.destination "
+            + "INNER JOIN source_table_name st ON st.urn=rt.source WHERE "
+            + "rt.deleted_ts > STR_TO_DATE(:scanStartTime, '%Y-%m-%d %H:%i:%s.%f') "
+            + "AND rt.id > 5 AND rt.id <= 20 ORDER BY rt.id ASC LIMIT 10");
+  }
+
+  @Test
   public void testBuildFindRelationshipKeysetSQLWithSource() {
     LocalRelationshipCriterion filterCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(LocalRelationshipValue.create("Alice"),
         Condition.EQUAL,
         new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"));
     LocalRelationshipFilter srcFilter = new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray(filterCriterion));
 
-    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
         new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
         "metadata_entity_foo", srcFilter, "destination_table_name", null,
         10, 5, 20);
@@ -2271,18 +2287,22 @@ public class EbeanLocalRelationshipQueryDAOTest {
   public void testBuildFindRelationshipKeysetSQLRejectsInvalidPageSize() {
     // Zero and negative are rejected.
     expectThrows(IllegalArgumentException.class, () ->
-        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
             new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
             null, null, null, null, 0, 0, 20));
     expectThrows(IllegalArgumentException.class, () ->
-        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
             new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
             null, null, null, null, -1, 0, 20));
     // Above the hard upper bound of 1000 is rejected.
     expectThrows(IllegalArgumentException.class, () ->
-        _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
             new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
             null, null, null, null, 1001, 0, 20));
+    expectThrows(IllegalArgumentException.class, () ->
+        _localRelationshipQueryDAO.buildFindRelationshipKeysetDeletedSinceScanStartSQL("relationship_table_name",
+            new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
+            null, null, null, null, 10, 0, 20, null));
   }
 
   @Test
@@ -2302,7 +2322,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
       // The public SQL builder rejects the mode as well.
       expectThrows(UnsupportedOperationException.class, () ->
-          _localRelationshipQueryDAO.buildFindRelationshipKeysetSQL("relationship_table_name",
+          _localRelationshipQueryDAO.buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
               new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray()).setDirection(RelationshipDirection.UNDIRECTED),
               null, null, null, null, 10, 5, 20));
 
@@ -2357,6 +2377,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
         Collections.singletonList(new ReportsTo().setSource(sources.get(1)).setDestination(new FooUrn(2))), false);
     _localRelationshipWriterDAO.addRelationships(sources.get(2), AspectFoo.class,
         Collections.singletonList(new ReportsTo().setSource(sources.get(2)).setDestination(new FooUrn(2))), false);
+    _server.createSqlUpdate("UPDATE metadata_relationship_reportsto SET deleted_ts='2000-01-01 00:00:00' "
+        + "WHERE deleted_ts IS NOT NULL").execute();
 
     // Current rows toward dest #1: only id 1. High-water id is 5 because later nonmatching rows
     // (ids 4/5 pointing elsewhere) set maxId. A page size of 1 fills fully with id 1 (below maxId
@@ -2384,7 +2406,24 @@ public class EbeanLocalRelationshipQueryDAOTest {
   public void testFindRelationshipsByKeysetMultiPageOrderedComplete() throws URISyntaxException {
     Set<FooUrn> expectedSources = new java.util.HashSet<>(addReportsToChain(7, new FooUrn(1)));
 
-    List<ReportsTo> drained = drainKeyset(2);
+    List<ReportsTo> drained = new ArrayList<>();
+    RelationshipKeysetCursor cursor = null;
+    Timestamp scanStartTime = null;
+    String relationshipTableName = SQLSchemaUtils.getRelationshipTableName(ReportsTo.class);
+    do {
+      RelationshipKeysetPage<ReportsTo> page = keysetPage(2, cursor);
+      drained.addAll(page.getRelationships());
+      cursor = page.getNextCursor();
+      if (cursor != null) {
+        assertNotNull(cursor.getScanStartTime());
+        assertEquals(cursor.getRelationshipTableName(), relationshipTableName);
+        if (scanStartTime == null) {
+          scanStartTime = cursor.getScanStartTime();
+        } else {
+          assertEquals(cursor.getScanStartTime(), scanStartTime);
+        }
+      }
+    } while (cursor != null);
 
     assertEquals(drained.size(), 7);
     Set<FooUrn> actualSources = drained.stream()
@@ -2441,6 +2480,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
     // Re-adding B soft-deletes its first row and inserts a new one, creating an id gap.
     _localRelationshipWriterDAO.addRelationships(b, AspectFoo.class,
         Collections.singletonList(new ReportsTo().setSource(b).setDestination(dest)), false);
+    _server.createSqlUpdate("UPDATE metadata_relationship_reportsto SET deleted_ts='2000-01-01 00:00:00' "
+        + "WHERE source=:source AND deleted_ts IS NOT NULL")
+        .setParameter("source", b.toString()).execute();
 
     List<ReportsTo> drained = drainKeyset(2);
 
@@ -2533,7 +2575,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   @Test
-  public void testFindRelationshipsByKeysetBestEffortMembershipUnderConcurrentReplacement()
+  public void testFindRelationshipsByKeysetPreservesScanStartMembershipUnderConcurrentReplacement()
       throws URISyntaxException {
     FooUrn dest = new FooUrn(1);
     FooUrn a = new FooUrn(101);
@@ -2558,10 +2600,7 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // Between pages, "concurrently" replace c: this soft-deletes id 3 (which is <= maxId) and
     // inserts a fresh current row id 5 (which is > maxId). The replacement row is excluded by the
-    // fixed maxId bound and the original id 3 is soft-deleted, so c may disappear from the scan even
-    // though it was current when the scan began. Because each page is a separate statement, maxId is
-    // only an insertion high-water mark, not a stable/complete snapshot: this is the documented
-    // best-effort membership behavior, chosen so the scan stays finite.
+    // fixed maxId bound, but the original id 3 is retained because it was alive at scan start.
     _localRelationshipWriterDAO.addRelationships(c, AspectFoo.class,
         Collections.singletonList(new ReportsTo().setSource(c).setDestination(dest)), false);
 
@@ -2572,32 +2611,115 @@ public class EbeanLocalRelationshipQueryDAOTest {
       cursor = page.getNextCursor();
     }
 
-    // c is missing: the scan reflects rows current when each page ran, not a snapshot of the
-    // rows that were current when the scan started.
     Set<FooUrn> actual = drained.stream()
         .map(r -> makeFooUrn(r.getSource().toString()))
         .collect(Collectors.toSet());
-    assertEquals(actual, ImmutableSet.of(a, b, d));
-    assertFalse(actual.contains(c));
+    assertEquals(actual, ImmutableSet.of(a, b, c, d));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetDedupsRowDeletedBetweenCurrentAndDeletedQueries()
+      throws URISyntaxException {
+    FooUrn dest = new FooUrn(1);
+    FooUrn source = new FooUrn(101);
+    _localRelationshipWriterDAO.addRelationships(source, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(source).setDestination(dest)), false);
+
+    boolean[] injected = {false};
+    EbeanLocalRelationshipQueryDAO racyQueryDAO = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig) {
+      @Override
+      protected void afterKeysetCurrentRowsFetched(String relationshipTableName,
+          List<io.ebean.SqlRow> currentRows) {
+        if (!injected[0] && !currentRows.isEmpty()
+            && relationshipTableName.equals(SQLSchemaUtils.getRelationshipTableName(ReportsTo.class))) {
+          injected[0] = true;
+          _server.createSqlUpdate("UPDATE metadata_relationship_reportsto "
+              + "SET deleted_ts='2099-01-01 00:00:00.000000' WHERE id=:id")
+              .setParameter("id", currentRows.get(0).getLong("id"))
+              .execute();
+        }
+      }
+    };
+
+    RelationshipKeysetPage<ReportsTo> page = racyQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, outgoingEmptyFilter(), 10, null);
+
+    assertTrue(injected[0]);
+    assertEquals(page.getRelationships().size(), 1);
+    assertEquals(makeFooUrn(page.getRelationships().get(0).getSource().toString()), source);
+    assertNull(page.getNextCursor());
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetDoesNotDuplicateRelationshipRewrittenImmediatelyBeforeScan()
+      throws URISyntaxException {
+    FooUrn dest = new FooUrn(1);
+    FooUrn source = new FooUrn(101);
+    _localRelationshipWriterDAO.addRelationships(source, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(source).setDestination(dest)), false);
+
+    // This rewrite completes before the first page captures scanStartTime. Only the replacement row
+    // was current at scan start, so the old soft-deleted row must not be returned too.
+    _localRelationshipWriterDAO.addRelationships(source, AspectFoo.class,
+        Collections.singletonList(new ReportsTo().setSource(source).setDestination(dest)), false);
+
+    io.ebean.SqlRow liveRow = _server.createSqlQuery("SELECT COUNT(*) AS live_count FROM metadata_relationship_reportsto "
+        + "WHERE source=:source AND deleted_ts IS NULL")
+        .setParameter("source", source.toString())
+        .findOne();
+    assertEquals(liveRow.getLong("live_count").longValue(), 1L);
+
+    List<ReportsTo> drained = drainKeyset(10);
+    assertEquals(drained.size(), 1);
+    assertEquals(makeFooUrn(drained.get(0).getSource().toString()), source);
   }
 
   @Test
   public void testRelationshipKeysetCursorValidationAndGetters() {
-    RelationshipKeysetCursor cursor = new RelationshipKeysetCursor(3, 10);
+    Timestamp scanStartTime = Timestamp.valueOf("2026-08-05 12:34:56.789");
+    RelationshipKeysetCursor cursor =
+        new RelationshipKeysetCursor(3, 10, scanStartTime, "metadata_relationship_reportsto");
     assertEquals(cursor.getLastId(), 3L);
     assertEquals(cursor.getMaxId(), 10L);
+    assertEquals(cursor.getScanStartTime(), scanStartTime);
+    assertEquals(cursor.getRelationshipTableName(), "metadata_relationship_reportsto");
+    scanStartTime.setTime(0);
+    assertNotEquals(cursor.getScanStartTime(), scanStartTime);
 
-    expectThrows(IllegalArgumentException.class, () -> new RelationshipKeysetCursor(-1, 10));
-    expectThrows(IllegalArgumentException.class, () -> new RelationshipKeysetCursor(3, -1));
-    expectThrows(IllegalArgumentException.class, () -> new RelationshipKeysetCursor(11, 10));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(-1, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto"));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(3, -1, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto"));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(11, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto"));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(3, 10, null, "metadata_relationship_reportsto"));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(3, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), null));
+    expectThrows(IllegalArgumentException.class, () ->
+        new RelationshipKeysetCursor(3, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), ""));
+  }
+
+  @Test
+  public void testFindRelationshipsByKeysetRejectsCursorForDifferentRelationshipTable() {
+    String belongsToTable = SQLSchemaUtils.getRelationshipTableName(BelongsToV2.class);
+    String reportsToTable = SQLSchemaUtils.getRelationshipTableName(ReportsTo.class);
+    RelationshipKeysetCursor wrongTypeCursor =
+        new RelationshipKeysetCursor(0, 1, Timestamp.valueOf("2026-08-05 12:34:56.789"), belongsToTable);
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> keysetPage(2, wrongTypeCursor));
+    assertTrue(exception.getMessage().contains(belongsToTable));
+    assertTrue(exception.getMessage().contains(reportsToTable));
   }
 
   @Test
   public void testRelationshipKeysetPageDefensiveAndValidation() throws URISyntaxException {
     List<ReportsTo> source = new ArrayList<>();
     source.add(new ReportsTo().setSource(new FooUrn(1)).setDestination(new FooUrn(2)));
+    RelationshipKeysetCursor nextCursor =
+        new RelationshipKeysetCursor(5, 10, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto");
     RelationshipKeysetPage<ReportsTo> page =
-        new RelationshipKeysetPage<>(source, 10, new RelationshipKeysetCursor(5, 10));
+        new RelationshipKeysetPage<>(source, 10, nextCursor);
 
     // Defensive copy: mutating the input list cannot alter the returned page contents.
     source.clear();
@@ -2607,7 +2729,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     // next cursor maxId must match highWaterId.
     expectThrows(IllegalArgumentException.class, () ->
-        new RelationshipKeysetPage<>(new ArrayList<ReportsTo>(), 10, new RelationshipKeysetCursor(5, 9)));
+        new RelationshipKeysetPage<>(new ArrayList<ReportsTo>(), 10,
+            new RelationshipKeysetCursor(5, 9, Timestamp.valueOf("2026-08-05 12:34:56.789"), "metadata_relationship_reportsto")));
     expectThrows(IllegalArgumentException.class, () ->
         new RelationshipKeysetPage<ReportsTo>(null, 10, null));
   }


### PR DESCRIPTION
## Summary

Follow-up to #632, addressing both post-merge review comments.

- Keyset scans now use scan-start membership: a row is returned if it was alive when the scan began. The cursor carries the scan start time, and each page merges two queries by id — current rows (`deleted_ts IS NULL`) and rows deleted after scan start (`deleted_ts > scanStartTime`).
- Relationship soft-deletes use `NOW(6)` instead of `NOW()`, in `DELETE_BY_SOURCE` and `DELETE_BY_SOURCE_AND_ASPECT` only. Asset soft-deletes are untouched.
- `RelationshipKeysetCursor` carries the relationship table name and rejects reuse against a different table. All four fields are required; the two-argument constructor is removed.
- Renames the "high-water" terminology to `maxId`, which the code already used for the same value.

`addRelationships` soft-deletes existing edges and then plain-`INSERT`s the replacements, so a relationship rewritten mid-scan failed `deleted_ts IS NULL` on its old row and `id <= maxId` on its new one, and appeared on no page at all.

`NOW()` truncates `deleted_ts` to the second while scan start is captured at full precision, so a delete at `10:00:00.500` recorded as `10:00:00.000000` looks earlier than a scan started at `10:00:00.123456` — the same vanishing-row bug inside a sub-second window.

Related issue: [META-24161](https://linkedin.atlassian.net/browse/META-24161)

### Why two queries instead of one `OR`

`(deleted_ts IS NULL OR deleted_ts > scanStartTime)` spans two disjoint `deleted_ts` ranges, so MySQL can no longer walk the index in `id` order and must sort, materializing every edge for that destination before `LIMIT` applies. On a 500k-row fixture with ~49.5k destinations and one 5,000-edge supernode: 1.59ms / 1,000 rows scanned for the current predicate, versus 8.19ms / 5,000 rows with the `OR`. The gap scales with supernode size, which is the case this work exists for.

Query A runs before Query B deliberately. A row soft-deleted between the two is returned by both, so the merge dedups equal primary-key ids; running B first would turn that race into a dropped row instead.

### Known limitations

- Not fully transactional. `deleted_ts` is statement time but rows become visible at commit, so a writer that deletes at T0, with a scan starting at T1 > T0 and committing at T2 > T1, still loses the edge. This exists on master today and is narrowed rather than closed here; fixing it needs stable logical relationship ids or a commit-ordered version marker.
- Cursor validation is table-scoped only. A cursor reused across the same table with different filters is still accepted. Happy to add a scan fingerprint if reviewers want that closed.
- The `NOW(6)` change is not yet covered by a test that fails without it; truncation causes under-inclusion, not the duplication the current test checks. Adding that next.

## Testing Done

- `./gradlew :dao-impl:ebean-dao:test --tests com.linkedin.metadata.dao.localrelationship.EbeanLocalRelationshipQueryDAOTest` — 176 tests passed
- `./gradlew :dao-impl:ebean-dao:compileJava :dao-impl:ebean-dao:compileTestJava`
- `git diff --check`
- Tests run on linux/amd64; the embedded MariaDB4j harness does not run on macOS hosts.
- New coverage for the vanishing-row bug, the Query A/B race (deterministic via a test seam rather than timing), rewrite-immediately-before-scan, cursor table scoping, and the generated SQL for both queries.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
