### PR TITLE
perf(ebean-dao): optimize single-destination keyset scans

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -20,6 +20,7 @@ import io.ebean.config.ServerConfig;
 import com.linkedin.metadata.query.LocalRelationshipCriterion;
 import com.linkedin.metadata.query.LocalRelationshipCriterionArray;
 import com.linkedin.metadata.query.LocalRelationshipFilter;
+import com.linkedin.metadata.query.LocalRelationshipValue;
 import com.linkedin.metadata.query.RelationshipDirection;
 import io.ebean.EbeanServer;
 import io.ebean.SqlQuery;
@@ -62,6 +63,8 @@ public class EbeanLocalRelationshipQueryDAO {
   private static final String IDX_DESTINATION_DELETED_TS = "idx_destination_deleted_ts";
   private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_destination_deleted_ts) ";
   private static final String DESTINATION_FIELD =  "destination";
+  // Default UrnField.name (see UrnField.pdl); a destination entity filter joined on dt.urn carries it.
+  private static final String URN_FIELD = "urn";
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -1283,6 +1286,15 @@ public class EbeanLocalRelationshipQueryDAO {
     sqlBuilder.append("SELECT rt.*");
     sqlBuilder.append(" FROM ").append(relationshipTableName).append(" rt ");
 
+    // META-24159 (keyset builder only): when the destination filter pins exactly one urn (a direct,
+    // non-negated urn EQUAL or single-value IN leaf), force idx_destination_deleted_ts. InnoDB suffixes
+    // secondary indexes with the PK id, so (destination, deleted_ts) also satisfies ORDER BY rt.id ASC
+    // without a filesort. Joins/filters are always retained; the hint fires only when the index exists.
+    if (destTableName != null && isDirectSingleUrnLeaf(destinationEntityFilter, URN_FIELD)
+        && _schemaValidatorUtil.indexExists(relationshipTableName, IDX_DESTINATION_DELETED_TS)) {
+      sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
+    }
+
     final List<Triplet<LocalRelationshipFilter, String, String>> filters = new ArrayList<>();
 
     if (_schemaConfig == EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY) {
@@ -1295,6 +1307,11 @@ public class EbeanLocalRelationshipQueryDAO {
       } else if (destinationEntityFilter != null) {
         validateEntityFilterOnlyOneUrn(destinationEntityFilter);
         filters.add(new Triplet<>(destinationEntityFilter, "rt", relationshipTableName));
+      } else if (isDirectSingleUrnLeaf(relationshipFilter, DESTINATION_FIELD)
+          && _schemaValidatorUtil.indexExists(relationshipTableName, IDX_DESTINATION_DELETED_TS)) {
+        // No destination entity table: a direct single-urn `destination` leaf pins rt.destination,
+        // so apply the same guarded idx_destination_deleted_ts hint.
+        sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
       }
 
       if (sourceTableName != null) {
@@ -1324,6 +1341,67 @@ public class EbeanLocalRelationshipQueryDAO {
     sqlBuilder.append(" ORDER BY rt.id ASC LIMIT ").append(pageSize);
 
     return sqlBuilder.toString();
+  }
+
+  /**
+   * Whether {@code filter} is a single, direct, non-negated urn leaf pinning exactly one value
+   * ({@code urn EQUAL '<value>'} as a scalar string, or {@code urn IN ('<value>')} as a one-element
+   * array), eligible for the META-24159 {@code idx_destination_deleted_ts} hint. Any {@code AND}/
+   * {@code OR}/{@code NOT} wrapper, extra criteria, a non-urn field, a scalar {@code IN}, or a multi-
+   * value (or non-scalar {@code EQUAL}) value is ineligible. The urn field must be named
+   * {@code expectedUrnFieldName} ({@code "destination"} for the relationship filter, else {@code "urn"}).
+   */
+  private boolean isDirectSingleUrnLeaf(@Nullable final LocalRelationshipFilter filter,
+      @Nonnull final String expectedUrnFieldName) {
+    final LocalRelationshipCriterion leaf = topLevelDirectCriterion(filter);
+    if (leaf == null || !leaf.hasField() || !leaf.getField().isUrnField()) {
+      return false;
+    }
+
+    if (!expectedUrnFieldName.equals(leaf.getField().getUrnField().getName())) {
+      return false;
+    }
+
+    final LocalRelationshipValue value = leaf.getValue();
+    if (value == null) {
+      return false;
+    }
+
+    switch (leaf.getCondition()) {
+      case EQUAL:
+        return value.isString();
+      case IN:
+        return value.isArray() && value.getArray().size() == 1;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Returns the single top-level {@link LocalRelationshipCriterion} of {@code filter}, or
+   * {@code null} when it is empty, has more than one criterion, or wraps its criterion in any logical
+   * operation ({@code AND}/{@code OR}/{@code NOT}). The logical tree is intentionally not flattened,
+   * so negated or grouped filters stay ineligible for the single-destination hint.
+   */
+  @Nullable
+  private LocalRelationshipCriterion topLevelDirectCriterion(@Nullable final LocalRelationshipFilter filter) {
+    if (filter == null) {
+      return null;
+    }
+
+    if (filter.hasLogicalExpressionCriteria() && filter.getLogicalExpressionCriteria() != null) {
+      final LogicalExpressionLocalRelationshipCriterion node = filter.getLogicalExpressionCriteria();
+      if (node.hasExpr() && node.getExpr().isCriterion()) {
+        return node.getExpr().getCriterion();
+      }
+      return null;
+    }
+
+    if (filter.hasCriteria() && filter.getCriteria().size() == 1) {
+      return filter.getCriteria().get(0);
+    }
+
+    return null;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -72,7 +72,7 @@ public class EbeanLocalRelationshipQueryDAO {
 
   private Set<String> _mgEntityTypeNameSet;
   private EbeanLocalDAO.SchemaConfig _schemaConfig = EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY;
-  private SchemaValidatorUtil _schemaValidatorUtil;
+  private final SchemaValidatorUtil _schemaValidatorUtil;
 
   public EbeanLocalRelationshipQueryDAO(EbeanServer server, ServerConfig serverConfig,
       EBeanDAOConfig eBeanDAOConfig) {
@@ -93,6 +93,19 @@ public class EbeanLocalRelationshipQueryDAO {
     _server = server;
     _eBeanDAOConfig = new EBeanDAOConfig();
     _schemaValidatorUtil = new SchemaValidatorUtil(server);
+    _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS, _schemaValidatorUtil);
+  }
+
+  /**
+   * Wires an explicit validator so tests can drive index presence without a live schema. Both the validator
+   * field and the SQL generator are built from the same instance, so the DAO is never left half-configured.
+   */
+  @VisibleForTesting
+  public EbeanLocalRelationshipQueryDAO(EbeanServer server, EBeanDAOConfig eBeanDAOConfig,
+      SchemaValidatorUtil schemaValidatorUtil) {
+    _server = server;
+    _eBeanDAOConfig = eBeanDAOConfig;
+    _schemaValidatorUtil = schemaValidatorUtil;
     _sqlGenerator = new MultiHopsTraversalSqlGenerator(SUPPORTED_CONDITIONS, _schemaValidatorUtil);
   }
 
@@ -1286,11 +1299,21 @@ public class EbeanLocalRelationshipQueryDAO {
     sqlBuilder.append("SELECT rt.*");
     sqlBuilder.append(" FROM ").append(relationshipTableName).append(" rt ");
 
-    // META-24159 (keyset builder only): when the destination filter pins exactly one urn (a direct,
-    // non-negated urn EQUAL or single-value IN leaf), force idx_destination_deleted_ts. InnoDB suffixes
-    // secondary indexes with the PK id, so (destination, deleted_ts) also satisfies ORDER BY rt.id ASC
-    // without a filesort. Joins/filters are always retained; the hint fires only when the index exists.
-    if (destTableName != null && isDirectSingleUrnLeaf(destinationEntityFilter, URN_FIELD)
+    // META-24159 (keyset builder only): force idx_destination_deleted_ts when the query pins rt.destination to
+    // exactly one urn (a direct, non-negated urn EQUAL or single-value IN leaf). InnoDB suffixes secondary
+    // indexes with the PK id, so (destination, deleted_ts) also satisfies ORDER BY rt.id ASC without a
+    // filesort. Joins/filters are always retained; the hint fires only when the index exists.
+    //
+    // Which filter pins the destination depends on the call shape, so all three are considered here rather
+    // than at the branch that happens to render each one. A caller that passes no destination entity class and
+    // an empty destination entity filter still pins the destination through the relationship filter, which is
+    // how reverse-lineage reads arrive.
+    final boolean destinationPinnedToOneUrn = destTableName != null
+        ? isDirectSingleUrnLeaf(destinationEntityFilter, URN_FIELD)
+        : isDirectSingleUrnLeaf(destinationEntityFilter, DESTINATION_FIELD)
+            || isDirectSingleUrnLeaf(relationshipFilter, DESTINATION_FIELD);
+
+    if (destinationPinnedToOneUrn
         && _schemaValidatorUtil.indexExists(relationshipTableName, IDX_DESTINATION_DELETED_TS)) {
       sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
     }
@@ -1307,11 +1330,6 @@ public class EbeanLocalRelationshipQueryDAO {
       } else if (destinationEntityFilter != null) {
         validateEntityFilterOnlyOneUrn(destinationEntityFilter);
         filters.add(new Triplet<>(destinationEntityFilter, "rt", relationshipTableName));
-      } else if (isDirectSingleUrnLeaf(relationshipFilter, DESTINATION_FIELD)
-          && _schemaValidatorUtil.indexExists(relationshipTableName, IDX_DESTINATION_DELETED_TS)) {
-        // No destination entity table: a direct single-urn `destination` leaf pins rt.destination,
-        // so apply the same guarded idx_destination_deleted_ts hint.
-        sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
       }
 
       if (sourceTableName != null) {
@@ -1397,10 +1415,8 @@ public class EbeanLocalRelationshipQueryDAO {
       return null;
     }
 
-    if (filter.hasCriteria() && filter.getCriteria().size() == 1) {
-      return filter.getCriteria().get(0);
-    }
-
+    // The only caller normalizes the filter first, which either moves `criteria` into
+    // `logicalExpressionCriteria` or leaves it empty, so a populated `criteria` never reaches here.
     return null;
   }
 

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3073,14 +3073,19 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   // Keyset (seek) pagination: META-24159 single-destination FORCE INDEX hint.
+
+  // Mirrors the private constant of the same name on EbeanLocalRelationshipQueryDAO. Declared here rather
+  // than widening the production constant's visibility, so a change to that constant fails these tests.
+  private static final String IDX_DESTINATION_DELETED_TS = "idx_destination_deleted_ts";
+  private static final String TEST_RELATIONSHIP_TABLE = "relationship_table_name";
+
   // A DAO whose SchemaValidatorUtil is a mock so tests drive indexExists deterministically (the embedded
-  // relationship tables carry no idx_destination_deleted_ts). Uses the package-private constructor so the
-  // validator and the SQL generator are built from the same instance.
+  // relationship tables carry no idx_destination_deleted_ts). Uses the constructor that wires the validator
+  // and the SQL generator from the same instance.
   private EbeanLocalRelationshipQueryDAO daoWithMockedIndex(boolean indexPresent) {
     SchemaValidatorUtil mockValidator = mock(SchemaValidatorUtil.class);
-    // Pinned to the exact table and index name. The production constant is private, so the literal is used here
-    // deliberately: if that constant is ever changed, these tests fail rather than silently passing.
-    when(mockValidator.indexExists(eq("relationship_table_name"), eq("idx_destination_deleted_ts")))
+    // Pinned to the exact table and index, so a typo in either fails rather than matching anything.
+    when(mockValidator.indexExists(eq(TEST_RELATIONSHIP_TABLE), eq(IDX_DESTINATION_DELETED_TS)))
         .thenReturn(indexPresent);
     EbeanLocalRelationshipQueryDAO dao =
         new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig, mockValidator);
@@ -3129,8 +3134,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
   private static void assertForceIndexHint(String sql, boolean expected) {
     if (expected) {
-      assertTrue(sql.contains("FORCE INDEX (idx_destination_deleted_ts)"), sql);
-      assertTrue(sql.indexOf("FROM relationship_table_name rt") < sql.indexOf("FORCE INDEX"), sql);
+      assertTrue(sql.contains("FORCE INDEX (" + IDX_DESTINATION_DELETED_TS + ")"), sql);
+      assertTrue(sql.indexOf("FROM " + TEST_RELATIONSHIP_TABLE + " rt") < sql.indexOf("FORCE INDEX"), sql);
     } else {
       assertFalse(sql.contains("FORCE INDEX"), sql);
     }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -21,6 +21,7 @@ import com.linkedin.metadata.dao.utils.EmbeddedMariaInstance;
 import com.linkedin.metadata.dao.utils.RelationshipLookUpContext;
 import com.linkedin.metadata.dao.utils.SQLSchemaUtils;
 import com.linkedin.metadata.dao.utils.SQLStatementUtils;
+import com.linkedin.metadata.dao.utils.SchemaValidatorUtil;
 import com.linkedin.metadata.query.AspectField;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.LocalRelationshipCriterion;
@@ -3071,4 +3072,210 @@ public class EbeanLocalRelationshipQueryDAOTest {
             AssetRelationship.class, wrapOptions, 2, null));
   }
 
+  // Keyset (seek) pagination: META-24159 single-destination FORCE INDEX hint.
+  // A DAO whose SchemaValidatorUtil is a mock so tests drive indexExists deterministically (the embedded
+  // relationship tables carry no idx_destination_deleted_ts); injected via reflection to avoid a
+  // test-only setter on the production class.
+  private EbeanLocalRelationshipQueryDAO daoWithMockedIndex(boolean indexPresent) {
+    SchemaValidatorUtil mockValidator = mock(SchemaValidatorUtil.class);
+    when(mockValidator.indexExists(anyString(), anyString())).thenReturn(indexPresent);
+    EbeanLocalRelationshipQueryDAO dao = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
+    try {
+      java.lang.reflect.Field field = EbeanLocalRelationshipQueryDAO.class.getDeclaredField("_schemaValidatorUtil");
+      field.setAccessible(true);
+      field.set(dao, mockValidator);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+    dao.setSchemaConfig(EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY);
+    return dao;
+  }
+
+  private static LocalRelationshipFilter emptyLogicalRelationshipFilter() {
+    return new LocalRelationshipFilter()
+        .setLogicalExpressionCriteria(new LogicalExpressionLocalRelationshipCriterion())
+        .setDirection(RelationshipDirection.OUTGOING);
+  }
+
+  private static UrnField urnField(String name) {
+    UrnField field = new UrnField();
+    return name == null ? field : field.setName(name);
+  }
+
+  private static LocalRelationshipCriterion urnEqual(String urn, String fieldName) {
+    return EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create(urn), Condition.EQUAL, urnField(fieldName));
+  }
+
+  // EQUAL paired with a one-element array instead of a scalar string: a degenerate, hint-ineligible shape.
+  private static LocalRelationshipCriterion urnEqualArray(String fieldName, String urn) {
+    return EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create(new StringArray(urn)), Condition.EQUAL, urnField(fieldName));
+  }
+
+  private static LocalRelationshipCriterion urnIn(String fieldName, String... urns) {
+    return EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create(new StringArray(Arrays.asList(urns))), Condition.IN, urnField(fieldName));
+  }
+
+  private static LocalRelationshipFilter leafFilter(LocalRelationshipCriterion criterion) {
+    return new LocalRelationshipFilter().setLogicalExpressionCriteria(wrapCriterionAsLogicalExpression(criterion));
+  }
+
+  private static LocalRelationshipFilter groupFilter(Operator op, LocalRelationshipCriterion... criteria) {
+    LogicalExpressionLocalRelationshipCriterionArray array = new LogicalExpressionLocalRelationshipCriterionArray();
+    for (LocalRelationshipCriterion criterion : criteria) {
+      array.add(wrapCriterionAsLogicalExpression(criterion));
+    }
+    return new LocalRelationshipFilter().setLogicalExpressionCriteria(buildLogicalGroup(op, array));
+  }
+
+  private static void assertForceIndexHint(String sql, boolean expected) {
+    if (expected) {
+      assertTrue(sql.contains("FORCE INDEX (idx_destination_deleted_ts)"), sql);
+      assertTrue(sql.indexOf("FROM relationship_table_name rt") < sql.indexOf("FORCE INDEX"), sql);
+    } else {
+      assertFalse(sql.contains("FORCE INDEX"), sql);
+    }
+    assertTrue(sql.endsWith("ORDER BY rt.id ASC LIMIT 10"), sql);
+  }
+
+  // Structural eligibility matrix on the relationship-filter `destination` path (no destination entity
+  // join, so predicates land on rt). The hint fires only for a direct, non-negated, single-value urn
+  // leaf named "destination" when the index exists; every other shape emits no hint. NOT/AND/OR collapse
+  // to the same ineligible branch, so one grouped case (OR) plus NOT cover the grouped path.
+  @DataProvider(name = "relationshipFilterDestinationCases")
+  public Object[][] relationshipFilterDestinationCases() {
+    return new Object[][]{
+        {"destination EQUAL, index present", leafFilter(urnEqual("urn:li:foo:1", "destination")), true, true,
+            "rt.destination='urn:li:foo:1'"},
+        {"single-value destination IN, index present", leafFilter(urnIn("destination", "urn:li:foo:1")), true, true,
+            "rt.destination IN ('urn:li:foo:1')"},
+        {"NOT-wrapped destination", groupFilter(Operator.NOT, urnEqual("urn:li:foo:1", "destination")), true, false,
+            "(NOT rt.destination='urn:li:foo:1')"},
+        {"OR-grouped destinations", groupFilter(Operator.OR, urnEqual("urn:li:foo:1", "destination"),
+            urnEqual("urn:li:foo:2", "destination")), true, false,
+            "rt.destination='urn:li:foo:1' OR rt.destination='urn:li:foo:2'"},
+        {"multi-value destination IN", leafFilter(urnIn("destination", "urn:li:foo:1", "urn:li:foo:2")), true, false,
+            "rt.destination IN ('urn:li:foo:1', 'urn:li:foo:2')"},
+        {"single-array destination EQUAL", leafFilter(urnEqualArray("destination", "urn:li:foo:1")), true, false,
+            "rt.destination='('urn:li:foo:1')'"},
+        {"urn field not named destination", leafFilter(urnEqual("urn:li:foo:1", null)), true, false,
+            "rt.urn='urn:li:foo:1'"}
+    };
+  }
+
+  @Test(dataProvider = "relationshipFilterDestinationCases")
+  public void testKeysetSqlRelationshipFilterDestinationHint(String desc, LocalRelationshipFilter relationshipFilter,
+      boolean indexPresent, boolean expectHint, String expectedPredicate) {
+    String sql = daoWithMockedIndex(indexPresent).buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
+        relationshipFilter, null, null, null, null, 10, 5, 20);
+
+    assertForceIndexHint(sql, expectHint);
+    assertFalse(sql.contains(" dt "), sql);
+    assertTrue(sql.contains(expectedPredicate), sql);
+  }
+
+  // Destination entity-table path: the INNER JOIN on dt is always retained, and the guard here requires
+  // the entity urn leaf to be named "urn" (the relationship path requires "destination"). These cases
+  // prove join retention, the indexExists guard, and the "urn" name requirement.
+  @DataProvider(name = "destinationEntityFilterCases")
+  public Object[][] destinationEntityFilterCases() {
+    return new Object[][]{
+        {"urn EQUAL, index present", leafFilter(urnEqual("urn:li:foo:1", null)), true, null, true,
+            "dt.urn='urn:li:foo:1'"},
+        {"single-value urn IN with source join, index present", leafFilter(urnIn(null, "urn:li:foo:1")), true,
+            "source_table_name", true, "dt.urn IN ('urn:li:foo:1')"},
+        {"eligible shape but index missing", leafFilter(urnEqual("urn:li:foo:1", null)), false, null, false,
+            "dt.urn='urn:li:foo:1'"},
+        {"urn field named destination", leafFilter(urnEqual("urn:li:foo:1", "destination")), true, null, false,
+            "dt.destination='urn:li:foo:1'"}
+    };
+  }
+
+  @Test(dataProvider = "destinationEntityFilterCases")
+  public void testKeysetSqlDestinationEntityFilterJoinAndHint(String desc, LocalRelationshipFilter destFilter,
+      boolean indexPresent, String sourceTable, boolean expectHint, String expectedPredicate) {
+    String sql = daoWithMockedIndex(indexPresent).buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
+        emptyLogicalRelationshipFilter(), sourceTable, null, "metadata_entity_bar", destFilter, 10, 5, 20);
+
+    String join = "INNER JOIN metadata_entity_bar dt ON dt.urn=rt.destination";
+    assertTrue(sql.contains(join), sql);
+    assertForceIndexHint(sql, expectHint);
+    if (expectHint) {
+      assertTrue(sql.indexOf("FORCE INDEX") < sql.indexOf(join), sql);
+    }
+    assertTrue(sql.contains(expectedPredicate), sql);
+    if (sourceTable != null) {
+      assertTrue(sql.contains("INNER JOIN " + sourceTable + " st ON st.urn=rt.source"), sql);
+    }
+  }
+
+  @Test
+  public void testKeysetSqlNonUrnDestinationRetainsJoinNoHint() {
+    // A non-urn (aspect) destination filter is ineligible: keep the join, add no hint. Real validator
+    // so the aspect virtual column resolves.
+    LocalRelationshipCriterion aspectCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("Alice"), Condition.EQUAL,
+        new AspectField().setAspect(AspectFoo.class.getCanonicalName()).setPath("/value"));
+
+    String sql = _localRelationshipQueryDAO.buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
+        emptyLogicalRelationshipFilter(), null, null, "metadata_entity_bar", leafFilter(aspectCriterion), 10, 5, 20);
+
+    assertTrue(sql.contains("INNER JOIN metadata_entity_bar dt ON dt.urn=rt.destination"), sql);
+    assertFalse(sql.contains("FORCE INDEX"), sql);
+    assertTrue(sql.contains("dt.i_aspectfoo"
+        + (_eBeanDAOConfig.isNonDollarVirtualColumnsEnabled() ? "0" : "$") + "value='Alice'"), sql);
+  }
+
+  @Test
+  public void testFindRelationshipsV4ByKeysetSingleUrnDestinationRetainsJoinExcludesOrphans()
+      throws URISyntaxException {
+    // Owner entity plus five cars belonging to it; every destination entity exists.
+    FooUrn owner = new FooUrn(1000);
+    _fooUrnEBeanLocalAccess.add(owner, new AspectFoo().setValue("Owner"), AspectFoo.class, new AuditStamp(), null, false);
+    Set<String> expectedSources = new java.util.HashSet<>();
+    for (int i = 1; i <= 5; i++) {
+      FooUrn car = new FooUrn(i);
+      _fooUrnEBeanLocalAccess.add(car, new AspectFoo().setValue("Car"), AspectFoo.class, new AuditStamp(), null, false);
+      BelongsToV2 belongsTo = new BelongsToV2();
+      belongsTo.setDestination(BelongsToV2.Destination.create(owner.toString()));
+      _localRelationshipWriterDAO.addRelationships(car, AspectFoo.class, Collections.singletonList(belongsTo), false);
+      expectedSources.add(car.toString());
+    }
+
+    // Orphan: source exists but its destination foo entity (foo:9999) was never created, so the
+    // destination INNER JOIN must exclude it.
+    FooUrn orphanSource = new FooUrn(4242);
+    _fooUrnEBeanLocalAccess.add(orphanSource, new AspectFoo().setValue("Car"), AspectFoo.class, new AuditStamp(), null, false);
+    BelongsToV2 orphan = new BelongsToV2();
+    orphan.setDestination(BelongsToV2.Destination.create(new FooUrn(9999).toString()));
+    _localRelationshipWriterDAO.addRelationships(orphanSource, AspectFoo.class, Collections.singletonList(orphan), false);
+
+    // No filter: the destination INNER JOIN alone drops the orphan and returns the five cars.
+    assertEquals(drainV4Sources(null, owner), expectedSources);
+
+    // Single-urn destination entity filter (the hint-eligible shape) returns the same five, orphan excluded.
+    assertEquals(drainV4Sources(leafFilter(urnEqual(owner.toString(), null)), owner), expectedSources);
+  }
+
+  // Drains every AssetRelationship page for a BelongsToV2 keyset scan over destination entity "foo",
+  // asserts each row's destination equals expectedDestination, returns the source urns.
+  private Set<String> drainV4Sources(LocalRelationshipFilter destFilter, FooUrn expectedDestination) {
+    Map<String, Object> wrapOptions = new HashMap<>();
+    wrapOptions.put(RELATIONSHIP_RETURN_TYPE, MG_INTERNAL_ASSET_RELATIONSHIP_TYPE);
+    Set<String> sources = new java.util.HashSet<>();
+    RelationshipKeysetCursor cursor = null;
+    do {
+      RelationshipKeysetPage<AssetRelationship> page = _localRelationshipQueryDAO.findRelationshipsV4ByKeyset(
+          "foo", null, "foo", destFilter, BelongsToV2.class, emptyLogicalRelationshipFilter(),
+          AssetRelationship.class, wrapOptions, 2, cursor);
+      for (AssetRelationship rel : page.getRelationships()) {
+        sources.add(rel.getSource());
+        assertEquals(rel.getRelatedTo().getBelongsToV2().getDestination().getString(), expectedDestination.toString());
+      }
+      cursor = page.getNextCursor();
+    } while (cursor != null);
+    return sources;
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3074,19 +3074,16 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
   // Keyset (seek) pagination: META-24159 single-destination FORCE INDEX hint.
   // A DAO whose SchemaValidatorUtil is a mock so tests drive indexExists deterministically (the embedded
-  // relationship tables carry no idx_destination_deleted_ts); injected via reflection to avoid a
-  // test-only setter on the production class.
+  // relationship tables carry no idx_destination_deleted_ts). Uses the package-private constructor so the
+  // validator and the SQL generator are built from the same instance.
   private EbeanLocalRelationshipQueryDAO daoWithMockedIndex(boolean indexPresent) {
     SchemaValidatorUtil mockValidator = mock(SchemaValidatorUtil.class);
-    when(mockValidator.indexExists(anyString(), anyString())).thenReturn(indexPresent);
-    EbeanLocalRelationshipQueryDAO dao = new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig);
-    try {
-      java.lang.reflect.Field field = EbeanLocalRelationshipQueryDAO.class.getDeclaredField("_schemaValidatorUtil");
-      field.setAccessible(true);
-      field.set(dao, mockValidator);
-    } catch (ReflectiveOperationException e) {
-      throw new RuntimeException(e);
-    }
+    // Pinned to the exact table and index name. The production constant is private, so the literal is used here
+    // deliberately: if that constant is ever changed, these tests fail rather than silently passing.
+    when(mockValidator.indexExists(eq("relationship_table_name"), eq("idx_destination_deleted_ts")))
+        .thenReturn(indexPresent);
+    EbeanLocalRelationshipQueryDAO dao =
+        new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig, mockValidator);
     dao.setSchemaConfig(EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY);
     return dao;
   }
@@ -3174,6 +3171,24 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertForceIndexHint(sql, expectHint);
     assertFalse(sql.contains(" dt "), sql);
     assertTrue(sql.contains(expectedPredicate), sql);
+  }
+
+  /**
+   * Reverse-lineage reads pass no destination entity class and an empty destination entity filter, pinning the
+   * destination through the relationship filter instead. That is the shape this hint exists for, so it must be
+   * hinted even though a non-null destination entity filter is present.
+   */
+  @Test
+  public void testKeysetSqlHintsWhenDestinationEntityFilterIsEmptyAndRelationshipFilterPins() {
+    final LocalRelationshipFilter emptyDestinationEntityFilter =
+        new LocalRelationshipFilter().setCriteria(new LocalRelationshipCriterionArray());
+
+    String sql = daoWithMockedIndex(true).buildFindRelationshipKeysetCurrentSQL("relationship_table_name",
+        leafFilter(urnEqual("urn:li:foo:1", "destination")), null, null, null, emptyDestinationEntityFilter, 10, 5, 20);
+
+    assertForceIndexHint(sql, true);
+    assertFalse(sql.contains(" dt "), sql);
+    assertTrue(sql.contains("rt.destination='urn:li:foo:1'"), sql);
   }
 
   // Destination entity-table path: the INNER JOIN on dt is always retained, and the guard here requires


### PR DESCRIPTION
## Summary

### Why

`buildFindRelationshipSQL` applies `FORCE INDEX (idx_destination_deleted_ts)` when the query filters on
`destination`. The keyset builders added for META-24161 never emitted it, so the keyset path lost a hint the
legacy path had.

It matters more on the keyset path than it did on the legacy one. Keyset paging adds `rt.id > ? AND rt.id <= ?`
plus `ORDER BY rt.id ASC`, which gives the optimizer a primary-key option the unbounded query never had.

Verified on the corp `metagalaxy` replica against `metadata_relationship_downstreamof`, first page
of a real reverse-lineage read:

|  | `key` | `rows` | `filtered` | `Extra` |
| --- | --- | --- | --- | --- |
| without hint | `PRIMARY` | 76,240,730 | 0 | Using where |
| with hint | `idx_destination_deleted_ts` | 39,597,970 | 100 | Using index condition |

Without the hint the optimizer walks the primary key in id order and expects roughly none of the rows it
visits to match the destination, so it cannot stop early. With the hint it seeks into the destination's index
entries, every row it touches is a match, and because InnoDB suffixes secondary indexes with the primary key
the index also satisfies `ORDER BY rt.id ASC`, so `LIMIT` stops the scan without a filesort.

Measured on the same replica, the plan the optimizer picks is not stable across destinations: three different
destinations produced a primary-key range scan, an index-merge intersect, and the destination index. Forcing
the index was the fastest of the three in every case and never slower.

### What

Emit the existing `FORCE_IDX_ON_DESTINATION` hint from the keyset builder, so it covers both statements each
page issues (current rows, and rows soft-deleted since scan start).

The hint is applied only when both hold:

- the destination is pinned to one urn by a direct, non-negated single-urn leaf (`EQUAL`, or `IN` with one
  value) on either the destination entity filter or the relationship filter, and
- `SchemaValidatorUtil.indexExists` reports the index is present on that relationship table.

Joins and filters are unchanged. Tables without the index, multi-urn filters and negated leaves are unaffected.

Bug: [META-24159](https://linkedin.atlassian.net/browse/META-24159)

## Testing Done

- New unit tests cover: `EQUAL` and single-value `IN` leaves emit the hint; multi-value `IN`, negated leaves and
  a missing index do not; the hint is placed immediately after the relationship table alias; and both the
  destination-entity-table and no-join shapes are covered. `SchemaValidatorUtil` is mocked so index presence is
  driven deterministically rather than depending on the embedded database.
- `./gradlew :dao-impl:ebean-dao:compileTestJava` passes.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
