### PR TITLE
perf(ebean-dao): optimize keyset scans pinned to a single urn

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -1447,8 +1447,13 @@ public class EbeanLocalRelationshipQueryDAO {
       return isSingleUrnLeafCriterion(expr.getCriterion(), expectedUrnFieldName);
     }
 
-    // The expr union has exactly two members, so anything that is not a criterion is a logical
-    // operation. Flattening and where-clause construction make the same assumption.
+    // An expr union with neither member set is representable, and getLogical() returns null for it,
+    // so this cannot be inferred from isCriterion() alone. Flattening skips such a node rather than
+    // failing, so the filter reaches here and must be treated as pinning nothing.
+    if (!expr.isLogical()) {
+      return false;
+    }
+
     final LogicalOperation operation = expr.getLogical();
     if (operation.getOp() != Operator.AND) {
       return false;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -1430,8 +1430,7 @@ public class EbeanLocalRelationshipQueryDAO {
    */
   private boolean pinsUrnFieldToOneValue(@Nullable final LocalRelationshipFilter filter,
       @Nonnull final String expectedUrnFieldName) {
-    if (filter == null || !filter.hasLogicalExpressionCriteria()
-        || filter.getLogicalExpressionCriteria() == null) {
+    if (filter == null || !filter.hasLogicalExpressionCriteria()) {
       return false;
     }
     return pinsUrnFieldToOneValue(filter.getLogicalExpressionCriteria(), expectedUrnFieldName, 0);
@@ -1448,12 +1447,10 @@ public class EbeanLocalRelationshipQueryDAO {
       return isSingleUrnLeafCriterion(expr.getCriterion(), expectedUrnFieldName);
     }
 
-    if (!expr.isLogical()) {
-      return false;
-    }
-
+    // The expr union has exactly two members, so anything that is not a criterion is a logical
+    // operation. Flattening and where-clause construction make the same assumption.
     final LogicalOperation operation = expr.getLogical();
-    if (operation.getOp() != Operator.AND || operation.getExpressions() == null) {
+    if (operation.getOp() != Operator.AND) {
       return false;
     }
 
@@ -1473,9 +1470,9 @@ public class EbeanLocalRelationshipQueryDAO {
    * composite index also satisfy {@code ORDER BY rt.id ASC}, since the id suffix is ordered only within a
    * single leading-column value.
    */
-  private boolean isSingleUrnLeafCriterion(@Nullable final LocalRelationshipCriterion leaf,
+  private boolean isSingleUrnLeafCriterion(@Nonnull final LocalRelationshipCriterion leaf,
       @Nonnull final String expectedUrnFieldName) {
-    if (leaf == null || !leaf.hasField() || !leaf.getField().isUrnField()) {
+    if (!leaf.getField().isUrnField()) {
       return false;
     }
 
@@ -1484,10 +1481,6 @@ public class EbeanLocalRelationshipQueryDAO {
     }
 
     final LocalRelationshipValue value = leaf.getValue();
-    if (value == null) {
-      return false;
-    }
-
     switch (leaf.getCondition()) {
       case EQUAL:
         return value.isString();

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -63,6 +63,11 @@ public class EbeanLocalRelationshipQueryDAO {
   private static final String IDX_DESTINATION_DELETED_TS = "idx_destination_deleted_ts";
   private static final String FORCE_IDX_ON_DESTINATION = " FORCE INDEX (idx_destination_deleted_ts) ";
   private static final String DESTINATION_FIELD =  "destination";
+  private static final String IDX_SOURCE_DELETED_TS = "idx_source_deleted_ts";
+  private static final String FORCE_IDX_ON_SOURCE = " FORCE INDEX (idx_source_deleted_ts) ";
+  // The UrnField.name a source-pinning leaf carries. Deliberately separate from the public SOURCE
+  // constant above, which names a result-set column and a DataMap key rather than a filter field.
+  private static final String SOURCE_FIELD = "source";
   // Default UrnField.name (see UrnField.pdl); a destination entity filter joined on dt.urn carries it.
   private static final String URN_FIELD = "urn";
   private final EbeanServer _server;
@@ -1146,18 +1151,17 @@ public class EbeanLocalRelationshipQueryDAO {
         // non-mg entity case, applying dest filter on relationship table
         filters.add(new Triplet<>(destinationEntityFilter, "rt", relationshipTableName));
       } else if (filterHasNonEmptyCriteria(relationshipFilter)) {
-        // Apply FORCE INDEX if destination field is being filtered, and the index exists
+        // Apply FORCE INDEX if the destination or source field is being filtered, and the index exists.
+        // This branch is reached only when no destination entity join was appended, so the hint still lands
+        // directly after "FROM <table> rt" and ahead of the source join added below.
         final LocalRelationshipCriterionArray relationshipCriteria =
             flattenLogicalExpressionLocalRelationshipCriterion(relationshipFilter.getLogicalExpressionCriteria());
-        for (LocalRelationshipCriterion criterion : relationshipCriteria) {
-          LocalRelationshipCriterion.Field field = criterion.getField();
-          if (field.getUrnField() != null && DESTINATION_FIELD.equals(field.getUrnField().getName())) {
-            // Check if index exists on 'destination' before applying FORCE INDEX
-            if (_schemaValidatorUtil.indexExists(relationshipTableName, IDX_DESTINATION_DELETED_TS)) {
-              sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
-            }
-            break;
-          }
+        // Destination is checked first and short-circuits, so a destination-filtered query keeps exactly the
+        // plan it had before META-24386 added the source arm.
+        if (!appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, DESTINATION_FIELD,
+            IDX_DESTINATION_DELETED_TS, FORCE_IDX_ON_DESTINATION)) {
+          appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, SOURCE_FIELD,
+              IDX_SOURCE_DELETED_TS, FORCE_IDX_ON_SOURCE);
         }
       }
 
@@ -1313,9 +1317,26 @@ public class EbeanLocalRelationshipQueryDAO {
         : isDirectSingleUrnLeaf(destinationEntityFilter, DESTINATION_FIELD)
             || isDirectSingleUrnLeaf(relationshipFilter, DESTINATION_FIELD);
 
+    // META-24386: the mirror image on the source side. Forward-lineage reads pin rt.source instead, and
+    // before this they got no hint at all, leaving them on the PRIMARY scan this hint exists to avoid.
+    //
+    // Two shapes can pin the source, not the three the destination has. When sourceTableName is null the
+    // builder below never renders sourceEntityFilter (the destination has an `else if` that moves its filter
+    // onto rt; the source has no such branch), so hinting from a filter that never reaches the WHERE clause
+    // would drive the plan off a predicate the query does not contain.
+    final boolean sourcePinnedToOneUrn = sourceTableName != null
+        ? isDirectSingleUrnLeaf(sourceEntityFilter, URN_FIELD)
+        : isDirectSingleUrnLeaf(relationshipFilter, SOURCE_FIELD);
+
+    // Only one FORCE INDEX can be emitted, so a query pinning both sides has to pick. Destination wins:
+    // it is the path already validated in production, so every currently hinted query stays byte identical.
+    // A both-pinned query selects the edges between one specific pair and is narrow under either index.
     if (destinationPinnedToOneUrn
         && _schemaValidatorUtil.indexExists(relationshipTableName, IDX_DESTINATION_DELETED_TS)) {
       sqlBuilder.append(FORCE_IDX_ON_DESTINATION);
+    } else if (sourcePinnedToOneUrn
+        && _schemaValidatorUtil.indexExists(relationshipTableName, IDX_SOURCE_DELETED_TS)) {
+      sqlBuilder.append(FORCE_IDX_ON_SOURCE);
     }
 
     final List<Triplet<LocalRelationshipFilter, String, String>> filters = new ArrayList<>();
@@ -1362,12 +1383,38 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
+   * Appends {@code forceIndexClause} to {@code sqlBuilder} when {@code criteria} contains a urn leaf named
+   * {@code urnFieldName} and {@code indexName} exists on {@code relationshipTableName}.
+   *
+   * <p>Returns whether such a leaf was found, independently of whether the hint was appended. A caller
+   * chaining destination then source uses that to stop after the first side the query filters on, so a
+   * destination-filtered query is never additionally considered for the source hint even when the
+   * destination index is absent.</p>
+   */
+  private boolean appendUrnFieldIndexHint(@Nonnull final StringBuilder sqlBuilder,
+      @Nonnull final LocalRelationshipCriterionArray criteria, @Nonnull final String relationshipTableName,
+      @Nonnull final String urnFieldName, @Nonnull final String indexName,
+      @Nonnull final String forceIndexClause) {
+    for (LocalRelationshipCriterion criterion : criteria) {
+      final LocalRelationshipCriterion.Field field = criterion.getField();
+      if (field.getUrnField() != null && urnFieldName.equals(field.getUrnField().getName())) {
+        if (_schemaValidatorUtil.indexExists(relationshipTableName, indexName)) {
+          sqlBuilder.append(forceIndexClause);
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Whether {@code filter} is a single, direct, non-negated urn leaf pinning exactly one value
    * ({@code urn EQUAL '<value>'} as a scalar string, or {@code urn IN ('<value>')} as a one-element
-   * array), eligible for the META-24159 {@code idx_destination_deleted_ts} hint. Any {@code AND}/
-   * {@code OR}/{@code NOT} wrapper, extra criteria, a non-urn field, a scalar {@code IN}, or a multi-
-   * value (or non-scalar {@code EQUAL}) value is ineligible. The urn field must be named
-   * {@code expectedUrnFieldName} ({@code "destination"} for the relationship filter, else {@code "urn"}).
+   * array), eligible for the {@code idx_destination_deleted_ts} (META-24159) or
+   * {@code idx_source_deleted_ts} (META-24386) hint. Any {@code AND}/{@code OR}/{@code NOT} wrapper,
+   * extra criteria, a non-urn field, a scalar {@code IN}, or a multi-value (or non-scalar
+   * {@code EQUAL}) value is ineligible. The urn field must be named {@code expectedUrnFieldName}
+   * ({@code "destination"} or {@code "source"} for the relationship filter, else {@code "urn"}).
    */
   private boolean isDirectSingleUrnLeaf(@Nullable final LocalRelationshipFilter filter,
       @Nonnull final String expectedUrnFieldName) {

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -1156,8 +1156,9 @@ public class EbeanLocalRelationshipQueryDAO {
         // directly after "FROM <table> rt" and ahead of the source join added below.
         final LocalRelationshipCriterionArray relationshipCriteria =
             flattenLogicalExpressionLocalRelationshipCriterion(relationshipFilter.getLogicalExpressionCriteria());
-        // Destination is checked first and short-circuits, so a destination-filtered query keeps exactly the
-        // plan it had before META-24386 added the source arm.
+        // Destination is checked first, so a destination-filtered query keeps the plan it had before
+        // META-24386 added the source arm. The source arm is reached when the destination is not pinned,
+        // or is pinned but its index is absent, matching the keyset builder's else-if.
         if (!appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, DESTINATION_FIELD,
             IDX_DESTINATION_DELETED_TS, FORCE_IDX_ON_DESTINATION)) {
           appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, SOURCE_FIELD,
@@ -1386,10 +1387,9 @@ public class EbeanLocalRelationshipQueryDAO {
    * Appends {@code forceIndexClause} to {@code sqlBuilder} when {@code criteria} contains a urn leaf named
    * {@code urnFieldName} and {@code indexName} exists on {@code relationshipTableName}.
    *
-   * <p>Returns whether such a leaf was found, independently of whether the hint was appended. A caller
-   * chaining destination then source uses that to stop after the first side the query filters on, so a
-   * destination-filtered query is never additionally considered for the source hint even when the
-   * destination index is absent.</p>
+   * <p>Returns whether the clause was appended, so a caller chaining destination then source falls through
+   * to the source arm when the destination index is absent. That matches the keyset builder, where the
+   * equivalent {@code else if} is reached for the same reason.</p>
    */
   private boolean appendUrnFieldIndexHint(@Nonnull final StringBuilder sqlBuilder,
       @Nonnull final LocalRelationshipCriterionArray criteria, @Nonnull final String relationshipTableName,
@@ -1400,8 +1400,9 @@ public class EbeanLocalRelationshipQueryDAO {
       if (field.getUrnField() != null && urnFieldName.equals(field.getUrnField().getName())) {
         if (_schemaValidatorUtil.indexExists(relationshipTableName, indexName)) {
           sqlBuilder.append(forceIndexClause);
+          return true;
         }
-        return true;
+        return false;
       }
     }
     return false;

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -70,6 +70,9 @@ public class EbeanLocalRelationshipQueryDAO {
   private static final String SOURCE_FIELD = "source";
   // Default UrnField.name (see UrnField.pdl); a destination entity filter joined on dt.urn carries it.
   private static final String URN_FIELD = "urn";
+  // Bounds the AND-tree walk that decides index-hint eligibility, so a pathologically nested filter
+  // cannot turn hint selection into deep recursion. Real filters nest one or two levels.
+  private static final int MAX_HINT_FILTER_DEPTH = 16;
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -1156,9 +1159,9 @@ public class EbeanLocalRelationshipQueryDAO {
         // directly after "FROM <table> rt" and ahead of the source join added below.
         final LocalRelationshipCriterionArray relationshipCriteria =
             flattenLogicalExpressionLocalRelationshipCriterion(relationshipFilter.getLogicalExpressionCriteria());
-        // Destination is checked first, so a destination-filtered query keeps the plan it had before
-        // META-24386 added the source arm. The source arm is reached when the destination is not pinned,
-        // or is pinned but its index is absent, matching the keyset builder's else-if.
+        // Destination takes precedence, so a query pinning both sides is hinted on the destination.
+        // The source arm is reached when the destination is not pinned, or is pinned but its index is
+        // absent, matching the keyset builder's else-if.
         if (!appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, DESTINATION_FIELD,
             IDX_DESTINATION_DELETED_TS, FORCE_IDX_ON_DESTINATION)) {
           appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, SOURCE_FIELD,
@@ -1304,30 +1307,30 @@ public class EbeanLocalRelationshipQueryDAO {
     sqlBuilder.append("SELECT rt.*");
     sqlBuilder.append(" FROM ").append(relationshipTableName).append(" rt ");
 
-    // META-24159 (keyset builder only): force idx_destination_deleted_ts when the query pins rt.destination to
-    // exactly one urn (a direct, non-negated urn EQUAL or single-value IN leaf). InnoDB suffixes secondary
-    // indexes with the PK id, so (destination, deleted_ts) also satisfies ORDER BY rt.id ASC without a
-    // filesort. Joins/filters are always retained; the hint fires only when the index exists.
+    // META-24159: force idx_destination_deleted_ts when the query pins rt.destination to exactly one urn.
+    // InnoDB suffixes secondary indexes with the PK id, so (destination, deleted_ts) also satisfies
+    // ORDER BY rt.id ASC without a filesort. Joins/filters are always retained; the hint fires only when
+    // the index exists.
     //
     // Which filter pins the destination depends on the call shape, so all three are considered here rather
     // than at the branch that happens to render each one. A caller that passes no destination entity class and
     // an empty destination entity filter still pins the destination through the relationship filter, which is
     // how reverse-lineage reads arrive.
     final boolean destinationPinnedToOneUrn = destTableName != null
-        ? isDirectSingleUrnLeaf(destinationEntityFilter, URN_FIELD)
-        : isDirectSingleUrnLeaf(destinationEntityFilter, DESTINATION_FIELD)
-            || isDirectSingleUrnLeaf(relationshipFilter, DESTINATION_FIELD);
+        ? pinsUrnFieldToOneValue(destinationEntityFilter, URN_FIELD)
+        : pinsUrnFieldToOneValue(destinationEntityFilter, DESTINATION_FIELD)
+            || pinsUrnFieldToOneValue(relationshipFilter, DESTINATION_FIELD);
 
-    // META-24386: the mirror image on the source side. Forward-lineage reads pin rt.source instead, and
-    // before this they got no hint at all, leaving them on the PRIMARY scan this hint exists to avoid.
+    // META-24386: the mirror image on the source side. Forward-lineage reads pin rt.source, and the source
+    // index keeps them off the PRIMARY scan this hint exists to avoid.
     //
     // Two shapes can pin the source, not the three the destination has. When sourceTableName is null the
     // builder below never renders sourceEntityFilter (the destination has an `else if` that moves its filter
     // onto rt; the source has no such branch), so hinting from a filter that never reaches the WHERE clause
     // would drive the plan off a predicate the query does not contain.
     final boolean sourcePinnedToOneUrn = sourceTableName != null
-        ? isDirectSingleUrnLeaf(sourceEntityFilter, URN_FIELD)
-        : isDirectSingleUrnLeaf(relationshipFilter, SOURCE_FIELD);
+        ? pinsUrnFieldToOneValue(sourceEntityFilter, URN_FIELD)
+        : pinsUrnFieldToOneValue(relationshipFilter, SOURCE_FIELD);
 
     // Only one FORCE INDEX can be emitted, so a query pinning both sides has to pick. Destination wins:
     // it is the path already validated in production, so every currently hinted query stays byte identical.
@@ -1409,17 +1412,69 @@ public class EbeanLocalRelationshipQueryDAO {
   }
 
   /**
-   * Whether {@code filter} is a single, direct, non-negated urn leaf pinning exactly one value
-   * ({@code urn EQUAL '<value>'} as a scalar string, or {@code urn IN ('<value>')} as a one-element
-   * array), eligible for the {@code idx_destination_deleted_ts} (META-24159) or
-   * {@code idx_source_deleted_ts} (META-24386) hint. Any {@code AND}/{@code OR}/{@code NOT} wrapper,
-   * extra criteria, a non-urn field, a scalar {@code IN}, or a multi-value (or non-scalar
-   * {@code EQUAL}) value is ineligible. The urn field must be named {@code expectedUrnFieldName}
-   * ({@code "destination"} or {@code "source"} for the relationship filter, else {@code "urn"}).
+   * Whether {@code filter} constrains {@code expectedUrnFieldName} to exactly one urn value, making the
+   * {@code idx_destination_deleted_ts} (META-24159) or {@code idx_source_deleted_ts} (META-24386) hint
+   * safe to emit.
+   *
+   * <p>A bare urn leaf qualifies, and so does a urn leaf nested anywhere inside a tree of {@code AND}
+   * groups: every conjunct has to hold, so one conjunct pinning the urn pins it for the whole expression
+   * and the remaining conjuncts only narrow the row set further. A lineage read that also filters on
+   * relationship type arrives in exactly that shape.</p>
+   *
+   * <p>{@code OR}, {@code NOT} and unspecified operators are not descended into. A row can satisfy an
+   * {@code OR} without matching the urn predicate at all, so the index would no longer cover the query,
+   * and a negated predicate pins nothing.</p>
+   *
+   * <p>{@code expectedUrnFieldName} is {@code "destination"} or {@code "source"} for the relationship
+   * filter, and {@code "urn"} for an entity filter rendered against a joined table.</p>
    */
-  private boolean isDirectSingleUrnLeaf(@Nullable final LocalRelationshipFilter filter,
+  private boolean pinsUrnFieldToOneValue(@Nullable final LocalRelationshipFilter filter,
       @Nonnull final String expectedUrnFieldName) {
-    final LocalRelationshipCriterion leaf = topLevelDirectCriterion(filter);
+    if (filter == null || !filter.hasLogicalExpressionCriteria()
+        || filter.getLogicalExpressionCriteria() == null) {
+      return false;
+    }
+    return pinsUrnFieldToOneValue(filter.getLogicalExpressionCriteria(), expectedUrnFieldName, 0);
+  }
+
+  private boolean pinsUrnFieldToOneValue(@Nonnull final LogicalExpressionLocalRelationshipCriterion node,
+      @Nonnull final String expectedUrnFieldName, final int depth) {
+    if (depth > MAX_HINT_FILTER_DEPTH || !node.hasExpr()) {
+      return false;
+    }
+
+    final LogicalExpressionLocalRelationshipCriterion.Expr expr = node.getExpr();
+    if (expr.isCriterion()) {
+      return isSingleUrnLeafCriterion(expr.getCriterion(), expectedUrnFieldName);
+    }
+
+    if (!expr.isLogical()) {
+      return false;
+    }
+
+    final LogicalOperation operation = expr.getLogical();
+    if (operation.getOp() != Operator.AND || operation.getExpressions() == null) {
+      return false;
+    }
+
+    for (LogicalExpressionLocalRelationshipCriterion child : operation.getExpressions()) {
+      if (pinsUrnFieldToOneValue(child, expectedUrnFieldName, depth + 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether {@code leaf} is a urn criterion named {@code expectedUrnFieldName} that pins it to exactly one
+   * value ({@code urn EQUAL '<value>'} as a scalar string, or {@code urn IN ('<value>')} as a one-element
+   * array). A non-urn field, a differently named urn field, a multi-value {@code IN}, a scalar {@code IN},
+   * a non-scalar {@code EQUAL}, or any other condition is ineligible. Pinning to one value is what lets the
+   * composite index also satisfy {@code ORDER BY rt.id ASC}, since the id suffix is ordered only within a
+   * single leading-column value.
+   */
+  private boolean isSingleUrnLeafCriterion(@Nullable final LocalRelationshipCriterion leaf,
+      @Nonnull final String expectedUrnFieldName) {
     if (leaf == null || !leaf.hasField() || !leaf.getField().isUrnField()) {
       return false;
     }
@@ -1441,31 +1496,6 @@ public class EbeanLocalRelationshipQueryDAO {
       default:
         return false;
     }
-  }
-
-  /**
-   * Returns the single top-level {@link LocalRelationshipCriterion} of {@code filter}, or
-   * {@code null} when it is empty, has more than one criterion, or wraps its criterion in any logical
-   * operation ({@code AND}/{@code OR}/{@code NOT}). The logical tree is intentionally not flattened,
-   * so negated or grouped filters stay ineligible for the single-destination hint.
-   */
-  @Nullable
-  private LocalRelationshipCriterion topLevelDirectCriterion(@Nullable final LocalRelationshipFilter filter) {
-    if (filter == null) {
-      return null;
-    }
-
-    if (filter.hasLogicalExpressionCriteria() && filter.getLogicalExpressionCriteria() != null) {
-      final LogicalExpressionLocalRelationshipCriterion node = filter.getLogicalExpressionCriteria();
-      if (node.hasExpr() && node.getExpr().isCriterion()) {
-        return node.getExpr().getCriterion();
-      }
-      return null;
-    }
-
-    // The only caller normalizes the filter first, which either moves `criteria` into
-    // `logicalExpressionCriteria` or leaves it empty, so a populated `criteria` never reaches here.
-    return null;
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -22,6 +22,7 @@ import com.linkedin.metadata.query.LocalRelationshipCriterionArray;
 import com.linkedin.metadata.query.LocalRelationshipFilter;
 import com.linkedin.metadata.query.LocalRelationshipValue;
 import com.linkedin.metadata.query.RelationshipDirection;
+import com.linkedin.metadata.query.UrnField;
 import io.ebean.EbeanServer;
 import io.ebean.SqlQuery;
 import io.ebean.SqlRow;
@@ -563,6 +564,37 @@ public class EbeanLocalRelationshipQueryDAO {
   protected void afterKeysetCurrentRowsFetched(@Nonnull String relationshipTableName,
       @Nonnull List<SqlRow> currentRows) {
     // Test seam for deterministic simulation of a soft-delete between Query A and Query B.
+  }
+
+  /**
+   * Rewrites an entity filter so it can be applied to the relationship table when the entity has no
+   * table of its own to join against.
+   *
+   * <p>An entity filter constrains the entity, and names its urn field after the entity rather than
+   * after the relationship column, so a caller filtering an asset on {@code urn} produces a criterion
+   * named {@code urn}. Applied verbatim to {@code rt} that renders {@code rt.urn}, which relationship
+   * tables do not have. The equivalent constraint on the relationship row is the column holding that
+   * urn, so the field is renamed to {@code relationshipColumn} and the condition and value are kept.</p>
+   *
+   * <p>Only ever called after {@link #validateEntityFilterOnlyOneUrn}, which guarantees a single
+   * criterion on a urn field.</p>
+   */
+  @Nonnull
+  private LocalRelationshipFilter entityFilterOnRelationshipColumn(
+      @Nonnull final LocalRelationshipFilter entityFilter, @Nonnull final String relationshipColumn) {
+    final LocalRelationshipCriterion urnCriterion =
+        flattenLogicalExpressionLocalRelationshipCriterion(entityFilter.getLogicalExpressionCriteria()).get(0);
+
+    final LocalRelationshipCriterion.Field renamedField = new LocalRelationshipCriterion.Field();
+    renamedField.setUrnField(new UrnField().setName(relationshipColumn));
+
+    final LocalRelationshipCriterion renamed = new LocalRelationshipCriterion()
+        .setField(renamedField)
+        .setValue(urnCriterion.getValue())
+        .setCondition(urnCriterion.getCondition());
+
+    return new LocalRelationshipFilter()
+        .setLogicalExpressionCriteria(wrapCriterionAsLogicalExpression(renamed));
   }
 
   /**
@@ -1182,7 +1214,8 @@ public class EbeanLocalRelationshipQueryDAO {
         validateEntityFilterOnlyOneUrn(sourceEntityFilter);
         // non-mg entity case, applying source filter on relationship table. See the keyset builder
         // for why this is gated on non-empty criteria rather than non-null.
-        filters.add(new Triplet<>(sourceEntityFilter, "rt", relationshipTableName));
+        filters.add(new Triplet<>(entityFilterOnRelationshipColumn(sourceEntityFilter, SOURCE_FIELD),
+            "rt", relationshipTableName));
       }
 
       if (!includeNonCurrentRelationships) {
@@ -1333,10 +1366,13 @@ public class EbeanLocalRelationshipQueryDAO {
     // index keeps them off the PRIMARY scan this hint exists to avoid.
     //
     // The same three shapes the destination has. When sourceTableName is null the source entity filter is
-    // rendered against rt, so it pins the source there just as the relationship filter does.
+    // rendered against rt, so it pins the source there just as the relationship filter does. An entity
+    // filter names its urn field after the entity rather than the relationship column, so either name
+    // qualifies; entityFilterOnRelationshipColumn renames it when the predicate is rendered.
     final boolean sourcePinnedToOneUrn = sourceTableName != null
         ? pinsUrnFieldToOneValue(sourceEntityFilter, URN_FIELD)
         : pinsUrnFieldToOneValue(sourceEntityFilter, SOURCE_FIELD)
+            || pinsUrnFieldToOneValue(sourceEntityFilter, URN_FIELD)
             || pinsUrnFieldToOneValue(relationshipFilter, SOURCE_FIELD);
 
     // Only one FORCE INDEX can be emitted, so a query pinning both sides has to pick. Destination wins:
@@ -1373,11 +1409,12 @@ public class EbeanLocalRelationshipQueryDAO {
       } else if (filterHasNonEmptyCriteria(sourceEntityFilter)) {
         validateEntityFilterOnlyOneUrn(sourceEntityFilter);
         // non-mg entity case, applying source filter on relationship table. Gated on non-empty
-        // criteria rather than non-null: an empty filter contributes nothing to the WHERE clause,
-        // and validateEntityFilterOnlyOneUrn reads criteria.get(0) without a size check, so an
-        // empty logical-expression filter would fail there. The destination arm above predates this
-        // and is left as it is.
-        filters.add(new Triplet<>(sourceEntityFilter, "rt", relationshipTableName));
+        // criteria rather than non-null because validateEntityFilterOnlyOneUrn reads the first
+        // criterion without a size check, so an empty logical-expression filter would fail there,
+        // and an empty filter contributes nothing to the WHERE clause in any case. The destination
+        // arm above gates on non-null and carries that hazard.
+        filters.add(new Triplet<>(entityFilterOnRelationshipColumn(sourceEntityFilter, SOURCE_FIELD),
+            "rt", relationshipTableName));
       }
 
       filters.add(new Triplet<>(relationshipFilter, "rt", relationshipTableName));

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -70,9 +70,6 @@ public class EbeanLocalRelationshipQueryDAO {
   private static final String SOURCE_FIELD = "source";
   // Default UrnField.name (see UrnField.pdl); a destination entity filter joined on dt.urn carries it.
   private static final String URN_FIELD = "urn";
-  // Bounds the AND-tree walk that decides index-hint eligibility, so a pathologically nested filter
-  // cannot turn hint selection into deep recursion. Real filters nest one or two levels.
-  private static final int MAX_HINT_FILTER_DEPTH = 16;
   private final EbeanServer _server;
   private final MultiHopsTraversalSqlGenerator _sqlGenerator;
 
@@ -1162,10 +1159,16 @@ public class EbeanLocalRelationshipQueryDAO {
         // Destination takes precedence, so a query pinning both sides is hinted on the destination.
         // The source arm is reached when the destination is not pinned, or is pinned but its index is
         // absent, matching the keyset builder's else-if.
+        //
+        // The destination arm matches on field name alone, which also hints shapes that do not pin the
+        // column to one value, such as a negated or multi-value leaf. That predates this method and is
+        // left alone so currently hinted queries keep their plan. The source arm is new, so it uses the
+        // stricter rule the keyset builder applies rather than inheriting that looseness.
         if (!appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, DESTINATION_FIELD,
-            IDX_DESTINATION_DELETED_TS, FORCE_IDX_ON_DESTINATION)) {
-          appendUrnFieldIndexHint(sqlBuilder, relationshipCriteria, relationshipTableName, SOURCE_FIELD,
-              IDX_SOURCE_DELETED_TS, FORCE_IDX_ON_SOURCE);
+            IDX_DESTINATION_DELETED_TS, FORCE_IDX_ON_DESTINATION)
+            && pinsUrnFieldToOneValue(relationshipFilter, SOURCE_FIELD)
+            && _schemaValidatorUtil.indexExists(relationshipTableName, IDX_SOURCE_DELETED_TS)) {
+          sqlBuilder.append(FORCE_IDX_ON_SOURCE);
         }
       }
 
@@ -1175,6 +1178,11 @@ public class EbeanLocalRelationshipQueryDAO {
         if (sourceEntityFilter != null) {
           filters.add(new Triplet<>(sourceEntityFilter, "st", sourceTableName));
         }
+      } else if (filterHasNonEmptyCriteria(sourceEntityFilter)) {
+        validateEntityFilterOnlyOneUrn(sourceEntityFilter);
+        // non-mg entity case, applying source filter on relationship table. See the keyset builder
+        // for why this is gated on non-empty criteria rather than non-null.
+        filters.add(new Triplet<>(sourceEntityFilter, "rt", relationshipTableName));
       }
 
       if (!includeNonCurrentRelationships) {
@@ -1324,13 +1332,12 @@ public class EbeanLocalRelationshipQueryDAO {
     // META-24386: the mirror image on the source side. Forward-lineage reads pin rt.source, and the source
     // index keeps them off the PRIMARY scan this hint exists to avoid.
     //
-    // Two shapes can pin the source, not the three the destination has. When sourceTableName is null the
-    // builder below never renders sourceEntityFilter (the destination has an `else if` that moves its filter
-    // onto rt; the source has no such branch), so hinting from a filter that never reaches the WHERE clause
-    // would drive the plan off a predicate the query does not contain.
+    // The same three shapes the destination has. When sourceTableName is null the source entity filter is
+    // rendered against rt, so it pins the source there just as the relationship filter does.
     final boolean sourcePinnedToOneUrn = sourceTableName != null
         ? pinsUrnFieldToOneValue(sourceEntityFilter, URN_FIELD)
-        : pinsUrnFieldToOneValue(relationshipFilter, SOURCE_FIELD);
+        : pinsUrnFieldToOneValue(sourceEntityFilter, SOURCE_FIELD)
+            || pinsUrnFieldToOneValue(relationshipFilter, SOURCE_FIELD);
 
     // Only one FORCE INDEX can be emitted, so a query pinning both sides has to pick. Destination wins:
     // it is the path already validated in production, so every currently hinted query stays byte identical.
@@ -1363,6 +1370,14 @@ public class EbeanLocalRelationshipQueryDAO {
         if (sourceEntityFilter != null) {
           filters.add(new Triplet<>(sourceEntityFilter, "st", sourceTableName));
         }
+      } else if (filterHasNonEmptyCriteria(sourceEntityFilter)) {
+        validateEntityFilterOnlyOneUrn(sourceEntityFilter);
+        // non-mg entity case, applying source filter on relationship table. Gated on non-empty
+        // criteria rather than non-null: an empty filter contributes nothing to the WHERE clause,
+        // and validateEntityFilterOnlyOneUrn reads criteria.get(0) without a size check, so an
+        // empty logical-expression filter would fail there. The destination arm above predates this
+        // and is left as it is.
+        filters.add(new Triplet<>(sourceEntityFilter, "rt", relationshipTableName));
       }
 
       filters.add(new Triplet<>(relationshipFilter, "rt", relationshipTableName));
@@ -1433,12 +1448,12 @@ public class EbeanLocalRelationshipQueryDAO {
     if (filter == null || !filter.hasLogicalExpressionCriteria()) {
       return false;
     }
-    return pinsUrnFieldToOneValue(filter.getLogicalExpressionCriteria(), expectedUrnFieldName, 0);
+    return pinsUrnFieldToOneValue(filter.getLogicalExpressionCriteria(), expectedUrnFieldName);
   }
 
   private boolean pinsUrnFieldToOneValue(@Nonnull final LogicalExpressionLocalRelationshipCriterion node,
-      @Nonnull final String expectedUrnFieldName, final int depth) {
-    if (depth > MAX_HINT_FILTER_DEPTH || !node.hasExpr()) {
+      @Nonnull final String expectedUrnFieldName) {
+    if (!node.hasExpr()) {
       return false;
     }
 
@@ -1460,7 +1475,7 @@ public class EbeanLocalRelationshipQueryDAO {
     }
 
     for (LogicalExpressionLocalRelationshipCriterion child : operation.getExpressions()) {
-      if (pinsUrnFieldToOneValue(child, expectedUrnFieldName, depth + 1)) {
+      if (pinsUrnFieldToOneValue(child, expectedUrnFieldName)) {
         return true;
       }
     }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3697,6 +3697,24 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
+   * An expr union with neither member set pins nothing. Flattening skips such a node instead of
+   * failing, so the filter is not rejected earlier and eligibility has to handle it rather than
+   * assuming anything that is not a criterion is a logical operation.
+   */
+  @Test
+  public void testKeysetSqlNoHintWhenExpressionIsNeitherCriterionNorLogical() {
+    String sql = daoWithMockedIndexes(true, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE,
+        new LocalRelationshipFilter()
+            .setLogicalExpressionCriteria(new LogicalExpressionLocalRelationshipCriterion()
+                .setExpr(new LogicalExpressionLocalRelationshipCriterion.Expr()))
+            .setDirection(RelationshipDirection.OUTGOING),
+        null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, null);
+  }
+
+  /**
    * Only EQUAL and single-value IN pin a urn to one value. An inequality matches a range, which the
    * composite index cannot also order by id, so it is ineligible even though the SQL layer supports it.
    */

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3666,6 +3666,37 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
+   * The non-MG destination case: with no destination entity class the destination filter is moved onto
+   * {@code rt}, so it pins the destination directly and is hint-eligible without a join.
+   */
+  @Test
+  public void testKeysetSqlHintsDestinationEntityFilterRenderedOnRelationshipTable() {
+    String sql = daoWithMockedIndexes(true, false).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, emptyLogicalRelationshipFilter(), null, null,
+        null, leafFilter(urnEqual("urn:li:foo:1", "destination")), 10, 5, 20);
+
+    assertHintIndex(sql, IDX_DESTINATION_DELETED_TS);
+    assertFalse(sql.contains(" dt "), sql);
+    assertTrue(sql.contains("rt.destination='urn:li:foo:1'"), sql);
+  }
+
+  /**
+   * IN paired with a scalar rather than an array pins nothing, so no hint is emitted. The SQL layer
+   * rejects that pairing outright, which is what makes the shape unusable rather than merely unhinted.
+   */
+  @Test
+  public void testKeysetSqlRejectsInPairedWithScalarValue() {
+    LocalRelationshipCriterion scalarIn = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("urn:li:foo:1"), Condition.IN, urnField("source"));
+
+    IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+        daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+            TEST_RELATIONSHIP_TABLE, leafFilter(scalarIn), null, null, null, null, 10, 5, 20));
+
+    assertTrue(e.getMessage().contains("IN condition must be paired with array value"), e.getMessage());
+  }
+
+  /**
    * Only EQUAL and single-value IN pin a urn to one value. An inequality matches a range, which the
    * composite index cannot also order by id, so it is ineligible even though the SQL layer supports it.
    */

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3634,6 +3634,26 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
+   * The legacy {@code criteria} field is not hint-eligible. Eligibility is decided before the filter is
+   * normalized into a logical expression, so a caller still using {@code criteria} gets its predicate
+   * rendered but no hint.
+   */
+  @Test
+  public void testKeysetSqlNoHintWhenFilterUsesLegacyCriteriaField() {
+    LocalRelationshipFilter legacy = new LocalRelationshipFilter()
+        .setCriteria(new LocalRelationshipCriterionArray(urnEqual("urn:li:foo:1", "source")))
+        .setDirection(RelationshipDirection.OUTGOING);
+
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, legacy, null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, null);
+    // The predicate is still rendered, so the missing hint is the eligibility rule rather than a
+    // filter that was dropped.
+    assertTrue(sql.contains("rt.source") && sql.contains("urn:li:foo:1"), sql);
+  }
+
+  /**
    * Only EQUAL and single-value IN pin a urn to one value. An inequality matches a range, which the
    * composite index cannot also order by id, so it is ineligible even though the SQL layer supports it.
    */

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3632,4 +3632,48 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     assertHintIndex(sql, null);
   }
+
+  /**
+   * Only EQUAL and single-value IN pin a urn to one value. An inequality matches a range, which the
+   * composite index cannot also order by id, so it is ineligible even though the SQL layer supports it.
+   */
+  @Test
+  public void testKeysetSqlNoHintForConditionOtherThanEqualOrIn() {
+    LocalRelationshipCriterion greaterThan = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("urn:li:foo:1"), Condition.GREATER_THAN, urnField("source"));
+
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, leafFilter(greaterThan), null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, null);
+    // The criterion really is in the query, so the missing hint is the eligibility rule rather than a
+    // filter that was silently dropped.
+    assertTrue(sql.contains("rt.source") && sql.contains("urn:li:foo:1"), sql);
+  }
+
+  /**
+   * The walk stops descending past {@code MAX_HINT_FILTER_DEPTH} so a pathologically nested filter
+   * cannot turn hint selection into deep recursion. Dropping the hint is the safe outcome: the query
+   * still runs, just without a forced plan.
+   */
+  @Test
+  public void testKeysetSqlNoHintWhenFilterNestingExceedsDepthLimit() {
+    // One AND level beyond the limit, with two children per level so buildLogicalGroup's
+    // single-child collapse cannot flatten the tree back under it.
+    LocalRelationshipCriterion filler = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("COPY"), Condition.EQUAL, new RelationshipField().setPath("/type"));
+
+    LogicalExpressionLocalRelationshipCriterion node =
+        wrapCriterionAsLogicalExpression(urnEqual("urn:li:foo:1", "source"));
+    for (int i = 0; i < 18; i++) {
+      node = nestedGroup(Operator.AND, wrapCriterionAsLogicalExpression(filler), node);
+    }
+
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE,
+        new LocalRelationshipFilter().setLogicalExpressionCriteria(node),
+        null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, null);
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3145,6 +3145,16 @@ public class EbeanLocalRelationshipQueryDAOTest {
     return new LocalRelationshipFilter().setLogicalExpressionCriteria(buildLogicalGroup(op, array));
   }
 
+  /** Builds a group whose children are themselves expressions, so filters can nest more than one level. */
+  private static LogicalExpressionLocalRelationshipCriterion nestedGroup(Operator op,
+      LogicalExpressionLocalRelationshipCriterion... children) {
+    LogicalExpressionLocalRelationshipCriterionArray array = new LogicalExpressionLocalRelationshipCriterionArray();
+    for (LogicalExpressionLocalRelationshipCriterion child : children) {
+      array.add(child);
+    }
+    return buildLogicalGroup(op, array);
+  }
+
   private static void assertForceIndexHint(String sql, boolean expected) {
     if (expected) {
       assertTrue(sql.contains("FORCE INDEX (" + IDX_DESTINATION_DELETED_TS + ")"), sql);
@@ -3399,8 +3409,33 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
-   * Only one FORCE INDEX can be emitted. Destination wins so every query hinted before META-24386 keeps
-   * exactly the plan it had.
+   * A relationship filter that pins one side inside an AND group is still pinned: every conjunct holds, so
+   * the extra predicates only narrow the row set. This is the shape a lineage read takes when the caller
+   * also filters on relationship type, and it is the query observed running unhinted in production.
+   */
+  @Test
+  public void testKeysetSqlHintsUrnPinnedInsideAndGroup() {
+    LocalRelationshipCriterion typeCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("COPY"), Condition.EQUAL, new RelationshipField().setPath("/type"));
+
+    String destinationPinned = daoWithMockedIndexes(true, false).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE,
+        groupFilter(Operator.AND, urnEqual("urn:li:foo:1", "destination"), typeCriterion),
+        null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(destinationPinned, IDX_DESTINATION_DELETED_TS);
+
+    String sourcePinned = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE,
+        groupFilter(Operator.AND, urnEqual("urn:li:foo:1", "source"), typeCriterion),
+        null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sourcePinned, IDX_SOURCE_DELETED_TS);
+  }
+
+  /**
+   * Only one FORCE INDEX can be emitted, so a query pinning both sides has to choose, and the destination
+   * hint is the one emitted.
    */
   @Test
   public void testKeysetSqlDestinationWinsWhenBothSidesPinned() {
@@ -3409,8 +3444,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
         groupFilter(Operator.AND, urnEqual("urn:li:foo:1", "destination"), urnEqual("urn:li:foo:2", "source")),
         null, null, null, null, 10, 5, 20);
 
-    // An AND group is not a direct single leaf, so neither side is eligible through the relationship filter.
-    assertHintIndex(sql, null);
+    // Both conjuncts pin their side, so both are eligible and the destination hint wins.
+    assertHintIndex(sql, IDX_DESTINATION_DELETED_TS);
+    assertFalse(sql.contains(IDX_SOURCE_DELETED_TS), sql);
 
     // Pin the destination through the relationship filter and the source through the entity join: both are
     // eligible, and the destination hint is the one emitted.
@@ -3437,9 +3473,8 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   // --------------------------------------------------------------------------------------------
-  // Legacy (offset) builder: the same destination-then-source hint chain. #637 added the
-  // destination hint here without covering it, and META-24386 adds the source arm beside it, so
-  // both are exercised together below.
+  // Legacy (offset) builder: the same destination-then-source hint chain as the keyset builder, with
+  // destination taking precedence and source acting as the fallback.
   // --------------------------------------------------------------------------------------------
 
   // The legacy hint branch is reached only when no destination entity table and no destination
@@ -3547,5 +3582,53 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     assertTrue(sql.contains("FORCE INDEX (" + IDX_SOURCE_DELETED_TS + ")"), sql);
     assertFalse(sql.contains(IDX_DESTINATION_DELETED_TS), sql);
+  }
+
+  /**
+   * An AND nested inside an AND still pins, since both levels must hold.
+   */
+  @Test
+  public void testKeysetSqlHintsUrnPinnedInNestedAndGroup() {
+    LocalRelationshipCriterion typeCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("COPY"), Condition.EQUAL, new RelationshipField().setPath("/type"));
+    LocalRelationshipCriterion actorCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("urn:li:corpuser:tester"), Condition.EQUAL,
+        new RelationshipField().setPath("/auditStampActor"));
+
+    // The inner group needs two children: buildLogicalGroup collapses a single-child non-NOT group,
+    // which would flatten this back into the one-level case.
+    LocalRelationshipFilter nested = new LocalRelationshipFilter()
+        .setLogicalExpressionCriteria(nestedGroup(Operator.AND,
+            wrapCriterionAsLogicalExpression(typeCriterion),
+            nestedGroup(Operator.AND,
+                wrapCriterionAsLogicalExpression(urnEqual("urn:li:foo:1", "source")),
+                wrapCriterionAsLogicalExpression(actorCriterion))));
+
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, nested, null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
+  }
+
+  /**
+   * An OR nested inside an AND must not be treated as pinning. Rows can satisfy the OR through the other
+   * branch, so the urn predicate does not hold for every row the index would be steered onto.
+   */
+  @Test
+  public void testKeysetSqlNoHintWhenUrnIsOnlyPinnedInsideNestedOr() {
+    LocalRelationshipCriterion typeCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("COPY"), Condition.EQUAL, new RelationshipField().setPath("/type"));
+
+    LocalRelationshipFilter nested = new LocalRelationshipFilter()
+        .setLogicalExpressionCriteria(nestedGroup(Operator.AND,
+            wrapCriterionAsLogicalExpression(typeCriterion),
+            nestedGroup(Operator.OR,
+                wrapCriterionAsLogicalExpression(urnEqual("urn:li:foo:1", "source")),
+                wrapCriterionAsLogicalExpression(urnEqual("urn:li:foo:2", "source")))));
+
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, nested, null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, null);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3569,8 +3569,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
    *
    * <p>This is the shape production actually sends: a caller that passes a lineage type gets a
    * relationship filter carrying both a source urn and a relationship-field predicate on the
-   * relationship's own type. Note the divergence from the keyset builder, which declines to hint a
-   * multi-criterion group at all -- see {@code testKeysetSqlDestinationWinsWhenBothSidesPinned}.
+   * relationship's own type. Both builders hint it, by different routes: this one flattens the whole
+   * logical tree, while the keyset builder descends only through {@code AND} groups -- see
+   * {@code pinsUrnFieldToOneValue}.
    */
   @Test
   public void testLegacySqlSkipsNonUrnCriterionWhenLocatingSourceUrn() {

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3634,12 +3634,12 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
-   * The legacy {@code criteria} field is not hint-eligible. Eligibility is decided before the filter is
-   * normalized into a logical expression, so a caller still using {@code criteria} gets its predicate
-   * rendered but no hint.
+   * A filter still using the legacy {@code criteria} field is hint-eligible, because the builder
+   * normalizes all three filters into logical expressions before deciding eligibility. Both filter
+   * shapes therefore behave the same way.
    */
   @Test
-  public void testKeysetSqlNoHintWhenFilterUsesLegacyCriteriaField() {
+  public void testKeysetSqlHintsFilterUsingLegacyCriteriaField() {
     LocalRelationshipFilter legacy = new LocalRelationshipFilter()
         .setCriteria(new LocalRelationshipCriterionArray(urnEqual("urn:li:foo:1", "source")))
         .setDirection(RelationshipDirection.OUTGOING);
@@ -3647,10 +3647,22 @@ public class EbeanLocalRelationshipQueryDAOTest {
     String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
         TEST_RELATIONSHIP_TABLE, legacy, null, null, null, null, 10, 5, 20);
 
-    assertHintIndex(sql, null);
-    // The predicate is still rendered, so the missing hint is the eligibility rule rather than a
-    // filter that was dropped.
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
     assertTrue(sql.contains("rt.source") && sql.contains("urn:li:foo:1"), sql);
+  }
+
+  /**
+   * A filter carrying neither criteria field pins nothing. Normalization leaves an empty filter
+   * untouched, so eligibility sees no logical expression to walk and no hint is emitted.
+   */
+  @Test
+  public void testKeysetSqlNoHintWhenFilterHasNeitherCriteriaField() {
+    String sql = daoWithMockedIndexes(true, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE,
+        new LocalRelationshipFilter().setDirection(RelationshipDirection.OUTGOING),
+        null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, null);
   }
 
   /**

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3077,16 +3077,26 @@ public class EbeanLocalRelationshipQueryDAOTest {
   // Mirrors the private constant of the same name on EbeanLocalRelationshipQueryDAO. Declared here rather
   // than widening the production constant's visibility, so a change to that constant fails these tests.
   private static final String IDX_DESTINATION_DELETED_TS = "idx_destination_deleted_ts";
+  private static final String IDX_SOURCE_DELETED_TS = "idx_source_deleted_ts";
   private static final String TEST_RELATIONSHIP_TABLE = "relationship_table_name";
 
   // A DAO whose SchemaValidatorUtil is a mock so tests drive indexExists deterministically (the embedded
   // relationship tables carry no idx_destination_deleted_ts). Uses the constructor that wires the validator
   // and the SQL generator from the same instance.
   private EbeanLocalRelationshipQueryDAO daoWithMockedIndex(boolean indexPresent) {
+    return daoWithMockedIndexes(indexPresent, false);
+  }
+
+  // Same, with the destination and source indexes controlled independently so the precedence and
+  // fall-through cases between the two hints can be driven directly.
+  private EbeanLocalRelationshipQueryDAO daoWithMockedIndexes(boolean destinationIndexPresent,
+      boolean sourceIndexPresent) {
     SchemaValidatorUtil mockValidator = mock(SchemaValidatorUtil.class);
     // Pinned to the exact table and index, so a typo in either fails rather than matching anything.
     when(mockValidator.indexExists(eq(TEST_RELATIONSHIP_TABLE), eq(IDX_DESTINATION_DELETED_TS)))
-        .thenReturn(indexPresent);
+        .thenReturn(destinationIndexPresent);
+    when(mockValidator.indexExists(eq(TEST_RELATIONSHIP_TABLE), eq(IDX_SOURCE_DELETED_TS)))
+        .thenReturn(sourceIndexPresent);
     EbeanLocalRelationshipQueryDAO dao =
         new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig, mockValidator);
     dao.setSchemaConfig(EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY);
@@ -3297,5 +3307,129 @@ public class EbeanLocalRelationshipQueryDAOTest {
       cursor = page.getNextCursor();
     } while (cursor != null);
     return sources;
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Keyset (seek) pagination: META-24386 single-source FORCE INDEX hint.
+  // Mirrors the destination cases above; only the pinned side and the expected index differ.
+  // --------------------------------------------------------------------------------------------
+
+  private static void assertHintIndex(String sql, String expectedIndex) {
+    if (expectedIndex == null) {
+      assertFalse(sql.contains("FORCE INDEX"), sql);
+    } else {
+      assertTrue(sql.contains("FORCE INDEX (" + expectedIndex + ")"), sql);
+      assertTrue(sql.indexOf("FROM " + TEST_RELATIONSHIP_TABLE + " rt") < sql.indexOf("FORCE INDEX"), sql);
+    }
+    assertTrue(sql.endsWith("ORDER BY rt.id ASC LIMIT 10"), sql);
+  }
+
+  // Structural eligibility matrix on the relationship-filter `source` path, matching the destination
+  // matrix case for case so the two sides cannot drift apart.
+  @DataProvider(name = "relationshipFilterSourceCases")
+  public Object[][] relationshipFilterSourceCases() {
+    return new Object[][]{
+        {"source EQUAL, index present", leafFilter(urnEqual("urn:li:foo:1", "source")), true, true,
+            "rt.source='urn:li:foo:1'"},
+        {"single-value source IN, index present", leafFilter(urnIn("source", "urn:li:foo:1")), true, true,
+            "rt.source IN ('urn:li:foo:1')"},
+        {"eligible shape but index missing", leafFilter(urnEqual("urn:li:foo:1", "source")), false, false,
+            "rt.source='urn:li:foo:1'"},
+        {"NOT-wrapped source", groupFilter(Operator.NOT, urnEqual("urn:li:foo:1", "source")), true, false,
+            "(NOT rt.source='urn:li:foo:1')"},
+        {"OR-grouped sources", groupFilter(Operator.OR, urnEqual("urn:li:foo:1", "source"),
+            urnEqual("urn:li:foo:2", "source")), true, false,
+            "rt.source='urn:li:foo:1' OR rt.source='urn:li:foo:2'"},
+        {"multi-value source IN", leafFilter(urnIn("source", "urn:li:foo:1", "urn:li:foo:2")), true, false,
+            "rt.source IN ('urn:li:foo:1', 'urn:li:foo:2')"},
+        {"single-array source EQUAL", leafFilter(urnEqualArray("source", "urn:li:foo:1")), true, false,
+            "rt.source='('urn:li:foo:1')'"},
+        {"urn field not named source", leafFilter(urnEqual("urn:li:foo:1", null)), true, false,
+            "rt.urn='urn:li:foo:1'"}
+    };
+  }
+
+  @Test(dataProvider = "relationshipFilterSourceCases")
+  public void testKeysetSqlRelationshipFilterSourceHint(String desc, LocalRelationshipFilter relationshipFilter,
+      boolean indexPresent, boolean expectHint, String expectedPredicate) {
+    String sql = daoWithMockedIndexes(false, indexPresent).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, relationshipFilter, null, null, null, null, 10, 5, 20);
+
+    assertHintIndex(sql, expectHint ? IDX_SOURCE_DELETED_TS : null);
+    assertFalse(sql.contains(" st "), sql);
+    assertTrue(sql.contains(expectedPredicate), sql);
+  }
+
+  /**
+   * Source entity-table path: the INNER JOIN on st is always retained, and the entity urn leaf must be
+   * named "urn" because it is rendered against st, not rt.
+   */
+  @Test
+  public void testKeysetSqlSourceEntityFilterJoinAndHint() {
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, emptyLogicalRelationshipFilter(), "metadata_entity_foo",
+        leafFilter(urnEqual("urn:li:foo:1", null)), null, null, 10, 5, 20);
+
+    String join = "INNER JOIN metadata_entity_foo st ON st.urn=rt.source";
+    assertTrue(sql.contains(join), sql);
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
+    assertTrue(sql.indexOf("FORCE INDEX") < sql.indexOf(join), sql);
+    assertTrue(sql.contains("st.urn='urn:li:foo:1'"), sql);
+  }
+
+  /**
+   * The source side has only two pinning shapes where the destination has three. With no source entity
+   * class the builder never renders sourceEntityFilter at all (the destination has an `else if` that moves
+   * its filter onto rt; the source has no such branch), so an otherwise hint-eligible source entity filter
+   * must not produce a hint here. Hinting would drive the plan off a predicate absent from the WHERE clause.
+   */
+  @Test
+  public void testKeysetSqlNoSourceHintWhenSourceEntityFilterIsNotRendered() {
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, emptyLogicalRelationshipFilter(), null,
+        leafFilter(urnEqual("urn:li:foo:1", "source")), null, null, 10, 5, 20);
+
+    assertHintIndex(sql, null);
+    assertFalse(sql.contains(" st "), sql);
+    // The filter really is absent from the query, which is what makes the hint unsound.
+    assertFalse(sql.contains("urn:li:foo:1"), sql);
+  }
+
+  /**
+   * Only one FORCE INDEX can be emitted. Destination wins so every query hinted before META-24386 keeps
+   * exactly the plan it had.
+   */
+  @Test
+  public void testKeysetSqlDestinationWinsWhenBothSidesPinned() {
+    String sql = daoWithMockedIndexes(true, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE,
+        groupFilter(Operator.AND, urnEqual("urn:li:foo:1", "destination"), urnEqual("urn:li:foo:2", "source")),
+        null, null, null, null, 10, 5, 20);
+
+    // An AND group is not a direct single leaf, so neither side is eligible through the relationship filter.
+    assertHintIndex(sql, null);
+
+    // Pin the destination through the relationship filter and the source through the entity join: both are
+    // eligible, and the destination hint is the one emitted.
+    String bothEligible = daoWithMockedIndexes(true, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, leafFilter(urnEqual("urn:li:foo:1", "destination")),
+        "metadata_entity_foo", leafFilter(urnEqual("urn:li:foo:2", null)), null, null, 10, 5, 20);
+
+    assertHintIndex(bothEligible, IDX_DESTINATION_DELETED_TS);
+    assertFalse(bothEligible.contains(IDX_SOURCE_DELETED_TS), bothEligible);
+    assertTrue(bothEligible.contains("INNER JOIN metadata_entity_foo st ON st.urn=rt.source"), bothEligible);
+  }
+
+  /**
+   * When the destination is pinned but its index is absent, an eligible source still gets its hint rather
+   * than the query falling back to a full primary-key scan.
+   */
+  @Test
+  public void testKeysetSqlFallsThroughToSourceWhenDestinationIndexMissing() {
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, leafFilter(urnEqual("urn:li:foo:1", "destination")),
+        "metadata_entity_foo", leafFilter(urnEqual("urn:li:foo:2", null)), null, null, 10, 5, 20);
+
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3432,4 +3432,96 @@ public class EbeanLocalRelationshipQueryDAOTest {
 
     assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
   }
+
+  // --------------------------------------------------------------------------------------------
+  // Legacy (offset) builder: the same destination-then-source hint chain. #637 added the
+  // destination hint here without covering it, and META-24386 adds the source arm beside it, so
+  // both are exercised together below.
+  // --------------------------------------------------------------------------------------------
+
+  // The legacy hint branch is reached only when no destination entity table and no destination
+  // entity filter are supplied, so the relationship filter is what pins a side.
+  private String legacySqlWithRelationshipFilter(EbeanLocalRelationshipQueryDAO dao,
+      LocalRelationshipFilter relationshipFilter) {
+    return dao.buildFindRelationshipSQL(TEST_RELATIONSHIP_TABLE, relationshipFilter,
+        null, null, null, null, -1, -1, new RelationshipLookUpContext());
+  }
+
+  @DataProvider(name = "legacyRelationshipFilterHintCases")
+  public Object[][] legacyRelationshipFilterHintCases() {
+    return new Object[][]{
+        // desc, filter, destIndexPresent, sourceIndexPresent, expectedIndex (null = no hint)
+        {"destination pinned, its index present", leafFilter(urnEqual("urn:li:foo:1", "destination")),
+            true, true, IDX_DESTINATION_DELETED_TS},
+        {"source pinned, its index present", leafFilter(urnEqual("urn:li:foo:1", "source")),
+            true, true, IDX_SOURCE_DELETED_TS},
+        {"destination pinned but its index missing, no source leaf", leafFilter(urnEqual("urn:li:foo:1", "destination")),
+            false, true, null},
+        {"source pinned but its index missing", leafFilter(urnEqual("urn:li:foo:1", "source")),
+            true, false, null},
+        {"neither side pinned", leafFilter(urnEqual("urn:li:foo:1", null)), true, true, null}
+    };
+  }
+
+  /**
+   * Unlike the keyset builder, the legacy builder flattens the logical tree, so it hints on any urn
+   * leaf naming the side rather than requiring a single direct leaf.
+   */
+  @Test(dataProvider = "legacyRelationshipFilterHintCases")
+  public void testLegacySqlRelationshipFilterHint(String desc, LocalRelationshipFilter relationshipFilter,
+      boolean destIndexPresent, boolean sourceIndexPresent, String expectedIndex) {
+    String sql = legacySqlWithRelationshipFilter(
+        daoWithMockedIndexes(destIndexPresent, sourceIndexPresent), relationshipFilter);
+
+    if (expectedIndex == null) {
+      assertFalse(sql.contains("FORCE INDEX"), desc + ": " + sql);
+    } else {
+      assertTrue(sql.contains("FORCE INDEX (" + expectedIndex + ")"), desc + ": " + sql);
+      assertTrue(sql.indexOf("FROM " + TEST_RELATIONSHIP_TABLE + " rt") < sql.indexOf("FORCE INDEX"),
+          desc + ": " + sql);
+    }
+  }
+
+  /**
+   * Both builders fall through to the source arm when the destination is pinned but its index is
+   * absent, rather than emitting no hint at all. Mirrors
+   * {@code testKeysetSqlFallsThroughToSourceWhenDestinationIndexMissing}.
+   */
+  @Test
+  public void testLegacySqlFallsThroughToSourceWhenDestinationIndexMissing() {
+    String sql = legacySqlWithRelationshipFilter(daoWithMockedIndexes(false, true),
+        groupFilter(Operator.AND, urnEqual("urn:li:foo:1", "destination"), urnEqual("urn:li:foo:2", "source")));
+
+    assertTrue(sql.contains("FORCE INDEX (" + IDX_SOURCE_DELETED_TS + ")"), sql);
+    assertFalse(sql.contains(IDX_DESTINATION_DELETED_TS), sql);
+  }
+
+  /**
+   * Destination takes precedence in the legacy builder too, so the two builders agree on which hint
+   * a both-pinned query gets.
+   */
+  @Test
+  public void testLegacySqlDestinationWinsWhenBothSidesPinned() {
+    String sql = legacySqlWithRelationshipFilter(daoWithMockedIndexes(true, true),
+        groupFilter(Operator.AND, urnEqual("urn:li:foo:1", "destination"), urnEqual("urn:li:foo:2", "source")));
+
+    assertTrue(sql.contains("FORCE INDEX (" + IDX_DESTINATION_DELETED_TS + ")"), sql);
+    assertFalse(sql.contains(IDX_SOURCE_DELETED_TS), sql);
+  }
+
+  /**
+   * The source join is still appended after the hint, and the hint sits between the table and the
+   * join so the emitted SQL stays valid.
+   */
+  @Test
+  public void testLegacySqlSourceHintPrecedesSourceJoin() {
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipSQL(TEST_RELATIONSHIP_TABLE,
+        leafFilter(urnEqual("urn:li:foo:1", "source")), "metadata_entity_foo", null, null, null,
+        -1, -1, new RelationshipLookUpContext());
+
+    String join = "INNER JOIN metadata_entity_foo st ON st.urn=rt.source";
+    assertTrue(sql.contains(join), sql);
+    assertTrue(sql.contains("FORCE INDEX (" + IDX_SOURCE_DELETED_TS + ")"), sql);
+    assertTrue(sql.indexOf("FORCE INDEX") < sql.indexOf(join), sql);
+  }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3097,6 +3097,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
         .thenReturn(destinationIndexPresent);
     when(mockValidator.indexExists(eq(TEST_RELATIONSHIP_TABLE), eq(IDX_SOURCE_DELETED_TS)))
         .thenReturn(sourceIndexPresent);
+    // A non-urn criterion resolves to a virtual column before it can be rendered. Report every
+    // column on the test table as present so such a filter emits SQL instead of failing resolution.
+    when(mockValidator.columnExists(eq(TEST_RELATIONSHIP_TABLE), anyString())).thenReturn(true);
     EbeanLocalRelationshipQueryDAO dao =
         new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig, mockValidator);
     dao.setSchemaConfig(EbeanLocalDAO.SchemaConfig.NEW_SCHEMA_ONLY);
@@ -3523,5 +3526,26 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertTrue(sql.contains(join), sql);
     assertTrue(sql.contains("FORCE INDEX (" + IDX_SOURCE_DELETED_TS + ")"), sql);
     assertTrue(sql.indexOf("FORCE INDEX") < sql.indexOf(join), sql);
+  }
+
+  /**
+   * A criterion that is not a urn field is skipped while scanning for a urn leaf rather than being
+   * mistaken for one, so a source urn sitting alongside it is still found and hinted.
+   *
+   * <p>This is the shape production actually sends: a caller that passes a lineage type gets a
+   * relationship filter carrying both a source urn and a relationship-field predicate on the
+   * relationship's own type. Note the divergence from the keyset builder, which declines to hint a
+   * multi-criterion group at all -- see {@code testKeysetSqlDestinationWinsWhenBothSidesPinned}.
+   */
+  @Test
+  public void testLegacySqlSkipsNonUrnCriterionWhenLocatingSourceUrn() {
+    LocalRelationshipCriterion relationshipTypeCriterion = EBeanDAOUtils.buildRelationshipFieldCriterion(
+        LocalRelationshipValue.create("TRANSFORMED"), Condition.EQUAL, new RelationshipField().setPath("/type"));
+
+    String sql = legacySqlWithRelationshipFilter(daoWithMockedIndexes(false, true),
+        groupFilter(Operator.AND, relationshipTypeCriterion, urnEqual("urn:li:foo:1", "source")));
+
+    assertTrue(sql.contains("FORCE INDEX (" + IDX_SOURCE_DELETED_TS + ")"), sql);
+    assertFalse(sql.contains(IDX_DESTINATION_DELETED_TS), sql);
   }
 }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3755,6 +3755,23 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
+   * An entity filter names its urn field after the entity, not the relationship column, which is the
+   * shape a caller filtering an asset on urn produces. Rendering it verbatim against rt would emit
+   * rt.urn, a column relationship tables do not have, so the field is renamed to the column that
+   * holds that urn.
+   */
+  @Test
+  public void testKeysetSqlRewritesUrnNamedSourceEntityFilterOntoSourceColumn() {
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, emptyLogicalRelationshipFilter(), null,
+        leafFilter(urnEqual("urn:li:foo:1", null)), null, null, 10, 5, 20);
+
+    assertTrue(sql.contains("rt.source='urn:li:foo:1'"), sql);
+    assertFalse(sql.contains("rt.urn"), sql);
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
+  }
+
+  /**
    * An empty source entity filter with no source entity class is skipped rather than validated. It
    * contributes nothing to the WHERE clause, and the validation that arm runs reads the first
    * criterion without a size check, so an empty logical-expression filter must not reach it.

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -3391,24 +3391,6 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
-   * The source side has only two pinning shapes where the destination has three. With no source entity
-   * class the builder never renders sourceEntityFilter at all (the destination has an `else if` that moves
-   * its filter onto rt; the source has no such branch), so an otherwise hint-eligible source entity filter
-   * must not produce a hint here. Hinting would drive the plan off a predicate absent from the WHERE clause.
-   */
-  @Test
-  public void testKeysetSqlNoSourceHintWhenSourceEntityFilterIsNotRendered() {
-    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
-        TEST_RELATIONSHIP_TABLE, emptyLogicalRelationshipFilter(), null,
-        leafFilter(urnEqual("urn:li:foo:1", "source")), null, null, 10, 5, 20);
-
-    assertHintIndex(sql, null);
-    assertFalse(sql.contains(" st "), sql);
-    // The filter really is absent from the query, which is what makes the hint unsound.
-    assertFalse(sql.contains("urn:li:foo:1"), sql);
-  }
-
-  /**
    * A relationship filter that pins one side inside an AND group is still pinned: every conjunct holds, so
    * the extra predicates only narrow the row set. This is the shape a lineage read takes when the caller
    * also filters on relationship type, and it is the query observed running unhinted in production.
@@ -3733,17 +3715,15 @@ public class EbeanLocalRelationshipQueryDAOTest {
   }
 
   /**
-   * The walk stops descending past {@code MAX_HINT_FILTER_DEPTH} so a pathologically nested filter
-   * cannot turn hint selection into deep recursion. Dropping the hint is the safe outcome: the query
-   * still runs, just without a forced plan.
+   * A urn pinned deep inside a chain of AND groups is still pinned. There is no depth limit on the
+   * walk, because the same tree is recursed again without one when the WHERE clause is built.
    */
   @Test
-  public void testKeysetSqlNoHintWhenFilterNestingExceedsDepthLimit() {
-    // One AND level beyond the limit, with two children per level so buildLogicalGroup's
-    // single-child collapse cannot flatten the tree back under it.
+  public void testKeysetSqlHintsUrnPinnedDeepInsideAndChain() {
     LocalRelationshipCriterion filler = EBeanDAOUtils.buildRelationshipFieldCriterion(
         LocalRelationshipValue.create("COPY"), Condition.EQUAL, new RelationshipField().setPath("/type"));
 
+    // Two children per level so buildLogicalGroup's single-child collapse cannot flatten the tree.
     LogicalExpressionLocalRelationshipCriterion node =
         wrapCriterionAsLogicalExpression(urnEqual("urn:li:foo:1", "source"));
     for (int i = 0; i < 18; i++) {
@@ -3755,6 +3735,57 @@ public class EbeanLocalRelationshipQueryDAOTest {
         new LocalRelationshipFilter().setLogicalExpressionCriteria(node),
         null, null, null, null, 10, 5, 20);
 
-    assertHintIndex(sql, null);
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
+  }
+
+  /**
+   * With no source entity class the source entity filter is rendered against {@code rt} rather than
+   * dropped, so a caller filtering on a non-MG source gets the rows it asked for. It also pins the
+   * source there, so the query is hint-eligible through that filter.
+   */
+  @Test
+  public void testKeysetSqlRendersAndHintsSourceEntityFilterWhenSourceTableIsAbsent() {
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, emptyLogicalRelationshipFilter(), null,
+        leafFilter(urnEqual("urn:li:foo:1", "source")), null, null, 10, 5, 20);
+
+    assertTrue(sql.contains("rt.source='urn:li:foo:1'"), sql);
+    assertFalse(sql.contains(" st "), sql);
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
+  }
+
+  /**
+   * An empty source entity filter with no source entity class is skipped rather than validated. It
+   * contributes nothing to the WHERE clause, and the validation that arm runs reads the first
+   * criterion without a size check, so an empty logical-expression filter must not reach it.
+   */
+  @Test
+  public void testKeysetSqlIgnoresEmptySourceEntityFilterWhenSourceTableIsAbsent() {
+    String sql = daoWithMockedIndexes(false, true).buildFindRelationshipKeysetCurrentSQL(
+        TEST_RELATIONSHIP_TABLE, leafFilter(urnEqual("urn:li:foo:1", "source")), null,
+        emptyLogicalRelationshipFilter(), null, null, 10, 5, 20);
+
+    assertHintIndex(sql, IDX_SOURCE_DELETED_TS);
+    assertTrue(sql.contains("rt.source='urn:li:foo:1'"), sql);
+  }
+
+  /**
+   * The legacy builder's source arm uses the same eligibility rule as the keyset builder, so shapes
+   * that do not pin the source to one value are not hinted there either.
+   */
+  @Test
+  public void testLegacySqlNoSourceHintForShapesThatDoNotPinOneValue() {
+    String notWrapped = legacySqlWithRelationshipFilter(daoWithMockedIndexes(false, true),
+        groupFilter(Operator.NOT, urnEqual("urn:li:foo:1", "source")));
+    assertFalse(notWrapped.contains(IDX_SOURCE_DELETED_TS), notWrapped);
+
+    String multiValueIn = legacySqlWithRelationshipFilter(daoWithMockedIndexes(false, true),
+        leafFilter(urnIn("source", "urn:li:foo:1", "urn:li:foo:2")));
+    assertFalse(multiValueIn.contains(IDX_SOURCE_DELETED_TS), multiValueIn);
+
+    // The eligible shape is still hinted, so the stricter rule did not disable the arm outright.
+    String eligible = legacySqlWithRelationshipFilter(daoWithMockedIndexes(false, true),
+        leafFilter(urnEqual("urn:li:foo:1", "source")));
+    assertTrue(eligible.contains("FORCE INDEX (" + IDX_SOURCE_DELETED_TS + ")"), eligible);
   }
 }


### PR DESCRIPTION
## Summary

Fixes two gaps in index-hint eligibility for keyset relationship scans, both of which leave a query
on a full `PRIMARY` scan:

1. **Source-pinned queries got no hint at all.** Adds `FORCE INDEX (idx_source_deleted_ts)` for
   queries pinning `rt.source` to a single urn, mirroring what #637 did for `rt.destination`.
2. **A urn pinned inside an `AND` group was not recognised.** Eligibility required a bare urn leaf,
   so any filter carrying a second predicate was skipped. This affected the destination side too,
   so #637's hint was silently missing on a common shape.

`LineageAccessorImpl` adds a second criterion whenever the caller passes `lineageType`, and a third
for `actorName`, so a plain lineage read lands in exactly that `AND` shape. Reproduced on
`corp-ltx1`, where it runs until the connection drops:

```
GET /datasets/{key}/lineages?downstream=true&lineageType=DIRECT_COPY

HTTP 500 ... Communications link failure
Query was: SELECT rt.* FROM metadata_relationship_downstreamof rt
  WHERE rt.deleted_ts is NULL
    AND (rt.destination='urn:li:dataset:(...)' AND rt.metadata$type='COPY')
    AND rt.id > 0 AND rt.id <= 516230316
  ORDER BY rt.id ASC LIMIT 1000
```

No `FORCE INDEX`. All three uncovered shapes (`source = X`, `(destination = X AND type = Y)` and
`(source = X AND type = Y)`) were confirmed present on the long-query audit and are closed by this
change.

<img width="1961" height="246" alt="Screenshot 2026-08-28 at 4 48 07 PM" src="https://github.com/user-attachments/assets/15ca7900-6421-4442-9d65-69d26fd8e71c" />

**Why descending an `AND` is sound.** Every conjunct must hold, so one conjunct pinning the urn pins
it for the whole expression; the rest only narrow the row set. `OR`, `NOT` and unspecified operators
are *not* descended into: a row can satisfy an `OR` through its other branch, and a negated predicate
pins nothing, so in both cases the index would no longer cover the query.

Per-leaf rules are unchanged from #637: a urn field of the expected name, `EQUAL` on a scalar or `IN`
on a one-element array. Pinning to exactly one value is what lets the composite index also satisfy
`ORDER BY rt.id ASC`, since InnoDB's id suffix is ordered only within a single leading-column value.

`idx_source_deleted_ts` already exists on the relationship tables, so no migration is added. Each
hint is emitted only when `indexExists` confirms it.

**A dropped filter fixed along the way.** When no source entity class is passed, the source entity
filter was not rendered at all. The destination has an `else if` that moves its filter onto `rt` for
that case; the source had none, so a caller filtering on a non-MG source got back rows it had asked
to exclude. `validateEntityTypeAndFilter` only rejects a blank entity type, so a non-MG type such as
`NON_MG_ASSET` passes validation and then yields a null table name, which is how the filter went
missing. Both builders now give the source the same treatment, and eligibility follows it, so the
source is pinnable through that filter as the destination already was.

The new arm is gated on non-empty criteria rather than non-null, unlike the destination.
`validateEntityFilterOnlyOneUrn` reads `criteria.get(0)` without a size check, so an empty
logical-expression filter would fail there, and an empty filter contributes nothing to the `WHERE`
clause either way. The destination arm predates this and is left alone.

**Deliberate asymmetry.** Only one `FORCE INDEX` can be emitted, so destination wins when both sides
are pinned, keeping every currently hinted query byte-identical.

**Known limitation, unchanged here.** When an entity join is present, neither side considers the
relationship filter as a pinning source. That is pre-existing and symmetric across both sides.
Production lineage reads use the keyset builder.

## Testing Done

```
./gradlew :dao-impl:ebean-dao:compileJava :dao-impl:ebean-dao:compileTestJava   BUILD SUCCESSFUL
./gradlew :dao-impl:ebean-dao:checkstyleMain :dao-impl:ebean-dao:checkstyleTest BUILD SUCCESSFUL
./gradlew :dao-impl:ebean-dao:test    2241 tests, 11 failed, 2070 skipped
```

The 11 failures are pre-existing on this machine: `EmbeddedMariaInstance` will not start, so every
DB-backed class fails at `@BeforeClass init`. Verified identical counts on unmodified
`origin/master` (2241 / 11 / 2070). The new tests could not run locally for that reason and rely on
CI.

The embedded test schema declares neither `idx_source_deleted_ts` nor `idx_destination_deleted_ts`,
so `indexExists` is false throughout the DB-backed suite and no hint is emitted there. Broadening
eligibility to `AND` groups therefore cannot change the SQL those tests assert; the hint tests drive
`indexExists` through a mocked validator instead.

Tests added or updated:

- `relationshipFilterSourceCases`: eligibility matrix over `EQUAL`, single-value `IN`, `NOT`/`OR`
  groups, multi-value `IN`, array-valued `EQUAL`, a wrong field name, and the index-missing case.
- `testKeysetSqlHintsUrnPinnedInsideAndGroup`: the production shape, on both sides.
- `testKeysetSqlHintsUrnPinnedInNestedAndGroup` and
  `testKeysetSqlNoHintWhenUrnIsOnlyPinnedInsideNestedOr`: an `AND` beneath an `AND` pins; an
  `OR` beneath an `AND` does not.
- `testKeysetSqlDestinationWinsWhenBothSidesPinned`: now asserts the destination hint is emitted for
  a both-pinned `AND` group rather than no hint at all.
- `testKeysetSqlSourceEntityFilterJoinAndHint` and
  `testKeysetSqlFallsThroughToSourceWhenDestinationIndexMissing`: join retention and hint ordering.
- `testKeysetSqlRendersAndHintsSourceEntityFilterWhenSourceTableIsAbsent` and
  `testKeysetSqlIgnoresEmptySourceEntityFilterWhenSourceTableIsAbsent`: the dropped-filter fix, and
  that an empty filter is skipped rather than validated.
- `testKeysetSqlHintsUrnPinnedDeepInsideAndChain`: a urn pinned deep in an AND chain is still pinned,
  since the walk has no depth limit.
- `testLegacySqlNoSourceHintForShapesThatDoNotPinOneValue`: the legacy source arm refuses negated and
  multi-value leaves, and still hints the eligible shape.
- Legacy-builder equivalents for the destination-first chain, the source fallback, and a non-urn
  criterion being stepped over while locating a urn leaf.

Verified on `corp-ltx1` with `EXPLAIN ANALYZE`, on the join-free shape metadata-store issues.

Un-hinted, `rt.source` pinned:

```
-> Limit: 1000 row(s)
  -> Sort: rt.id, limit input to 1000 row(s) per chunk
    -> Filter: ((rt.source = '...') and (rt.deleted_ts is null) and (rt.id > 0) and (rt.id <= ...))
      -> Intersect rows sorted by row ID
        -> Index range scan on rt using idx_source_deleted_ts over (source = '...' AND deleted_ts = NULL AND 0 < id <= ...)
```

Hinted:

```
-> Limit: 1000 row(s)
  -> Index range scan on rt using idx_source_deleted_ts over (source = '...' AND deleted_ts = NULL AND 0 < id <= ...),
     with index condition: ((rt.source = '...') and (rt.deleted_ts is null) and (rt.id > 0) and (rt.id <= ...))
```

The intersect does not emit in `rt.id` order, so `ORDER BY rt.id` adds a sort, and a sort has to read
every matching row before `LIMIT` can apply. That is the unbounded per-page work keyset pagination
exists to prevent. The hint removes both the intersect and the sort, leaving a range scan that stops
at 1000.

The `AND` shape this PR adds behaves the same way. Hinted, `metadata$type` becomes a residual filter
over the same range scan:

```
-> Limit: 1000 row(s)
  -> Filter: (rt.metadata$type = 'COPY')
    -> Index range scan on rt using idx_source_deleted_ts over (source = '...' AND deleted_ts = NULL AND 0 < id <= ...),
       with index condition: (...)
```

while un-hinted it goes back through `Intersect rows sorted by row ID` and `Sort: rt.id`.

The joined shape shows the same transition, `index_merge` + `Using filesort` becoming `range` +
`Using index condition`.

**Where the hint helps, and where it does not.** The gain depends on how the pinned urn's rows are
distributed across the id space, not on fan-out alone.

Measured on a deliberately unfavourable subject, a urn holding roughly half the table (index
estimate 41.6M rows against a table estimate of 80.0M), the un-hinted plan is slightly *faster*,
4.31ms against 5.70ms for 1000 rows. With the urn that dominant a sequential `PRIMARY` scan finds
1000 matches after reading only 1349 rows, while the hinted plan pays 1000 secondary-index entries
plus 1000 bookmark lookups back to the primary key. That is the best case for scanning and the worst
case for the hint.

The case this targets is the opposite: a urn whose rows are sparse in id order. There a `PRIMARY`
scan reads far more rows than it returns: the `filtered=1` behaviour #637 was built on, and the
intersect-plus-sort plans shown above. The evidence that this is the shape that matters in production
is that destination-pinned queries disappeared from the long-query audit once #637 reached the
fabric, and that the queries above ran until the connection dropped.

Absolute magnitude on a representative subject is not quantified.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)



