### PR TITLE
perf(ebean-dao): read a single-page relationship result in one statement

### DIFF
--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -306,8 +306,10 @@ public class EbeanLocalRelationshipQueryDAO {
    * LocalRelationshipFilter, int, int)} that walks the matching set in bounded pages. Ranked/
    * non-current pagination is unsupported because it could not bound the per-page DB work.
    *
-   * <p>First page: pass {@code cursor = null}; the DAO captures {@code maxId}, the largest
-   * relationship row id when paging starts ({@code COALESCE(MAX(id), 0)}), and returns rows with
+   * <p>First page: pass {@code cursor = null}. A result that fits inside one page is read with a
+   * single statement and reports {@code maxId} as the largest id it returned. Otherwise the DAO
+   * captures {@code maxId}, the largest relationship row id when paging starts
+   * ({@code COALESCE(MAX(id), 0)}), and returns rows with
    * {@code 0 < rt.id <= maxId} ordered by id, up to {@code pageSize}. Later inserts get larger ids
    * and are excluded, keeping the scan finite. Continuation: pass the next cursor from the previous
    * {@link RelationshipKeysetPage}. The cursor also carries a database scan-start timestamp. Later
@@ -372,8 +374,10 @@ public class EbeanLocalRelationshipQueryDAO {
    * Validates V4 logical-expression filters and the {@code wrapOptions} contract. Ranked/non-current
    * pagination is unsupported because it could not bound the per-page DB work.
    *
-   * <p>First page: pass {@code cursor = null}; the DAO captures {@code maxId}, the largest
-   * relationship row id when paging starts ({@code COALESCE(MAX(id), 0)}), and returns rows with
+   * <p>First page: pass {@code cursor = null}. A result that fits inside one page is read with a
+   * single statement and reports {@code maxId} as the largest id it returned. Otherwise the DAO
+   * captures {@code maxId}, the largest relationship row id when paging starts
+   * ({@code COALESCE(MAX(id), 0)}), and returns rows with
    * {@code 0 < rt.id <= maxId} ordered by id, up to {@code pageSize}. Continuation: pass the next
    * cursor from the previous {@link RelationshipKeysetPage}. The cursor also carries a database
    * scan-start timestamp. Later pages include rows that were current at scan start even if they were
@@ -586,9 +590,11 @@ public class EbeanLocalRelationshipQueryDAO {
    * returned before keyset pagination was introduced.</p>
    *
    * <p>A full page is treated as inconclusive rather than complete. The row count alone cannot
-   * distinguish a result that is exactly one page long from one that is longer, and reading
-   * {@code pageSize + 1} rows to tell them apart would exceed the page-size bound the SQL builder
-   * enforces. Guessing wrong here would silently drop rows, so the ambiguous case pages instead.</p>
+   * distinguish a result that is exactly one page long from one that is longer. Reading
+   * {@code pageSize + 1} rows would tell them apart, but only below the maximum page size, since at
+   * the maximum it exceeds the bound the SQL builder enforces. Rather than have the fast path work
+   * for some page sizes and not others, the ambiguous case pages instead. Guessing wrong here would
+   * silently drop rows, and an exactly-full page is the rare case.</p>
    *
    * @return the complete result, or {@code null} when it did not fit in one page
    */

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -453,6 +453,20 @@ public class EbeanLocalRelationshipQueryDAO {
           "Keyset pagination is only supported in NEW_SCHEMA_ONLY mode; OLD_SCHEMA_ONLY and DUAL_SCHEMA "
               + "(deprecated) are rejected.");
     }
+
+    // META-24388: most reads return far less than one page, and paging them costs three statements
+    // (scan start, current rows, rows deleted since scan start) where an unpaged read cost one.
+    // Probe with a single statement first. A short page proves the whole result was returned, so
+    // there is no second page to stay consistent with and the other two statements are unnecessary.
+    // A full page is inconclusive (there may or may not be more), so fall through and page properly.
+    if (cursor == null) {
+      final List<SqlRow> singleStatementRows = readWholeResultInOneStatement(relationshipTableName,
+          relationshipFilter, sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter, pageSize);
+      if (singleStatementRows != null) {
+        return new KeysetScanResult(singleStatementRows, largestIdOrZero(singleStatementRows), null);
+      }
+    }
+
     final long lastId;
     final long maxId;
     final String scanStartTime;
@@ -558,6 +572,43 @@ public class EbeanLocalRelationshipQueryDAO {
   protected void afterKeysetCurrentRowsFetched(@Nonnull String relationshipTableName,
       @Nonnull List<SqlRow> currentRows) {
     // Test seam for deterministic simulation of a soft-delete between Query A and Query B.
+  }
+
+  /**
+   * Reads the entire result in one statement when it fits in a single page, or returns {@code null}
+   * when it does not and the caller must fall back to paging.
+   *
+   * <p>Bounding by {@code Long.MAX_VALUE} rather than the scan's real {@code maxId} is what avoids
+   * the scan-start query: that bound exists only to keep multiple pages consistent with each other by
+   * excluding rows inserted mid-scan, and a single statement has no second page to be consistent
+   * with. The companion query for rows soft-deleted since scan start is unnecessary for the same
+   * reason, since one statement reads one snapshot. The result is the same shape the unpaged read
+   * returned before keyset pagination was introduced.</p>
+   *
+   * <p>A full page is treated as inconclusive rather than complete. The row count alone cannot
+   * distinguish a result that is exactly one page long from one that is longer, and reading
+   * {@code pageSize + 1} rows to tell them apart would exceed the page-size bound the SQL builder
+   * enforces. Guessing wrong here would silently drop rows, so the ambiguous case pages instead.</p>
+   *
+   * @return the complete result, or {@code null} when it did not fit in one page
+   */
+  @Nullable
+  private List<SqlRow> readWholeResultInOneStatement(@Nonnull final String relationshipTableName,
+      @Nonnull final LocalRelationshipFilter relationshipFilter, @Nullable final String sourceTableName,
+      @Nullable final LocalRelationshipFilter sourceEntityFilter, @Nullable final String destTableName,
+      @Nullable final LocalRelationshipFilter destinationEntityFilter, final int pageSize) {
+    final String sql = buildFindRelationshipKeysetCurrentSQL(relationshipTableName, relationshipFilter,
+        sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter, pageSize, 0L, Long.MAX_VALUE);
+    final List<SqlRow> rows = executeSqlWithIndexCheck(sql, relationshipTableName);
+    return rows.size() < pageSize ? rows : null;
+  }
+
+  /**
+   * Largest {@code id} among {@code rows}, which are in ascending id order, or 0 when empty. Used as
+   * the reported {@code maxId} for a single-statement read, where no separate scan-start query ran.
+   */
+  private static long largestIdOrZero(@Nonnull final List<SqlRow> rows) {
+    return rows.isEmpty() ? 0L : rows.get(rows.size() - 1).getLong("id");
   }
 
   /**

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalRelationshipQueryDAO.java
@@ -681,6 +681,7 @@ public class EbeanLocalRelationshipQueryDAO {
     final String sql =
         "SELECT COALESCE(MAX(id), 0) AS max_id, DATE_FORMAT(NOW(6), '%Y-%m-%d %H:%i:%s.%f') AS scan_start_time FROM "
             + relationshipTableName;
+    beforeRelationshipQueryExecuted(sql);
     // Aggregate without GROUP BY, so this always yields exactly one row.
     final SqlRow row = _server.createSqlQuery(sql).findOne();
     return new KeysetScanStart(row.getLong("max_id"), row.getString("scan_start_time"));
@@ -1495,7 +1496,19 @@ public class EbeanLocalRelationshipQueryDAO {
     return _mgEntityTypeNameSet;
   }
 
+  /**
+   * Invoked immediately before each relationship read is sent to the database. A no-op in
+   * production; tests override it to count how many reads a call actually costs, which is a
+   * behaviour worth pinning because the point of the single-statement fast path is to reduce that
+   * count. Counting SQL construction instead would miss reads whose SQL is not built by the
+   * relationship SQL builders, such as the keyset scan-start query.
+   */
+  protected void beforeRelationshipQueryExecuted(@Nonnull String sql) {
+    // No-op seam.
+  }
+
   private List<SqlRow> executeSqlWithIndexCheck(String sql, String relationshipTableName) {
+    beforeRelationshipQueryExecuted(sql);
     try {
       return _server.createSqlQuery(sql).findList();
     } catch (PersistenceException e) {
@@ -1506,6 +1519,7 @@ public class EbeanLocalRelationshipQueryDAO {
 
   private List<SqlRow> executeSqlWithIndexCheck(String sql, String relationshipTableName,
       @Nonnull String scanStartTime) {
+    beforeRelationshipQueryExecuted(sql);
     try {
       SqlQuery query = _server.createSqlQuery(sql);
       query.setParameter("scanStartTime", scanStartTime);

--- a/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetPage.java
+++ b/dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/RelationshipKeysetPage.java
@@ -31,9 +31,12 @@ public final class RelationshipKeysetPage<R extends RecordTemplate> {
    *
    * @param relationships the relationships in this page, in ascending {@code id} order. Copied
    *                      defensively and exposed as an unmodifiable list.
-   * @param maxId the largest relationship row {@code id} at the time paging started, captured on
-   *              the first page. Bounds the scan so rows inserted mid-scan are excluded. Must be
-   *              non-negative.
+   * @param maxId the largest relationship row {@code id} this page may draw from. When the scan is
+   *              paged this is the largest id in the table at the time paging started, captured on
+   *              the first page, which bounds the scan so rows inserted mid-scan are excluded. When
+   *              the whole result was read in one statement there is no such bound and no second
+   *              page to exclude anything from, so it is the largest id returned, or 0 when the
+   *              result is empty. Must be non-negative.
    * @param nextCursor cursor to fetch the next page, or {@code null} if this is the last page.
    *                   When non-null its own {@code maxId} must equal this page's {@code maxId}.
    */

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -2670,6 +2670,96 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertEquals(actual, ImmutableSet.of(a, b, c, d));
   }
 
+  /**
+   * META-24388: a result that fits inside one page is read with a single statement, not the three
+   * the paged path uses (scan start, current rows, rows deleted since scan start). Counted directly,
+   * because the saving is the point of the fast path and a row-count assertion would not notice it.
+   */
+  @Test
+  public void testFindRelationshipsByKeysetReadsShortResultInOneStatement() throws URISyntaxException {
+    addReportsToChain(2, new FooUrn(1));
+
+    List<String> executed = new ArrayList<>();
+    EbeanLocalRelationshipQueryDAO countingQueryDAO = countingQueryDAO(executed);
+
+    RelationshipKeysetPage<ReportsTo> page = countingQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, outgoingEmptyFilter(), 5, null);
+
+    assertEquals(page.getRelationships().size(), 2);
+    assertNull(page.getNextCursor());
+    assertEquals(executed.size(), 1, executed.toString());
+    // The single statement is the ordinary current-rows query, so it keeps whatever index hint the
+    // builder would have emitted for a paged read.
+    assertTrue(executed.get(0).contains("deleted_ts is NULL"), executed.get(0));
+  }
+
+  /**
+   * A full page is inconclusive, since the row count cannot distinguish a result that is exactly one
+   * page long from a longer one. That case pages normally rather than risk truncating the result.
+   */
+  @Test
+  public void testFindRelationshipsByKeysetFullFirstPageStillPages() throws URISyntaxException {
+    addReportsToChain(4, new FooUrn(1));
+
+    List<String> executed = new ArrayList<>();
+    EbeanLocalRelationshipQueryDAO countingQueryDAO = countingQueryDAO(executed);
+
+    RelationshipKeysetPage<ReportsTo> page = countingQueryDAO.findRelationshipsByKeyset(
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, outgoingEmptyFilter(), 2, null);
+
+    assertEquals(page.getRelationships().size(), 2);
+    assertNotNull(page.getNextCursor());
+    assertEquals(page.getMaxId(), 4L);
+    // One inconclusive single-statement read, then the paged path's own current and deleted-since
+    // queries. The scan-start query is a fourth read but does not go through either builder, so it
+    // is not counted here.
+    assertEquals(executed.size(), 3, executed.toString());
+  }
+
+  /**
+   * The whole result is still returned when it spans several pages, so the added probe cannot drop
+   * rows on the path it does not short-circuit.
+   */
+  @Test
+  public void testFindRelationshipsByKeysetMultiPageStillCompleteWithFastPath() throws URISyntaxException {
+    Set<FooUrn> expected = new java.util.HashSet<>(addReportsToChain(7, new FooUrn(1)));
+
+    List<ReportsTo> drained = drainKeyset(2);
+
+    assertEquals(drained.size(), 7);
+    assertEquals(drained.stream().map(r -> makeFooUrn(r.getSource().toString())).collect(Collectors.toSet()),
+        expected);
+  }
+
+  /** Records every statement the DAO executes so a test can assert how many reads a call costs. */
+  private EbeanLocalRelationshipQueryDAO countingQueryDAO(List<String> executed) {
+    return new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig) {
+      @Override
+      public String buildFindRelationshipKeysetCurrentSQL(String relationshipTableName,
+          LocalRelationshipFilter relationshipFilter, String sourceTableName,
+          LocalRelationshipFilter sourceEntityFilter, String destTableName,
+          LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId) {
+        String sql = super.buildFindRelationshipKeysetCurrentSQL(relationshipTableName, relationshipFilter,
+            sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter, pageSize, lastId, maxId);
+        executed.add(sql);
+        return sql;
+      }
+
+      @Override
+      public String buildFindRelationshipKeysetDeletedSinceScanStartSQL(String relationshipTableName,
+          LocalRelationshipFilter relationshipFilter, String sourceTableName,
+          LocalRelationshipFilter sourceEntityFilter, String destTableName,
+          LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId,
+          String scanStartTime) {
+        String sql = super.buildFindRelationshipKeysetDeletedSinceScanStartSQL(relationshipTableName,
+            relationshipFilter, sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter,
+            pageSize, lastId, maxId, scanStartTime);
+        executed.add(sql);
+        return sql;
+      }
+    };
+  }
+
   @Test
   public void testFindRelationshipsByKeysetDedupsRowDeletedBetweenCurrentAndDeletedQueries()
       throws URISyntaxException {
@@ -2694,8 +2784,10 @@ public class EbeanLocalRelationshipQueryDAOTest {
       }
     };
 
+    // Page size 1 rather than something larger: this test needs the two-statement path, and a
+    // result that fits inside one page is read in a single statement where no such race exists.
     RelationshipKeysetPage<ReportsTo> page = racyQueryDAO.findRelationshipsByKeyset(
-        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, outgoingEmptyFilter(), 10, null);
+        null, emptyFilter(), null, emptyFilter(), ReportsTo.class, outgoingEmptyFilter(), 1, null);
 
     assertTrue(injected[0]);
     assertEquals(page.getRelationships().size(), 1);

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -2710,10 +2710,9 @@ public class EbeanLocalRelationshipQueryDAOTest {
     assertEquals(page.getRelationships().size(), 2);
     assertNotNull(page.getNextCursor());
     assertEquals(page.getMaxId(), 4L);
-    // One inconclusive single-statement read, then the paged path's own current and deleted-since
-    // queries. The scan-start query is a fourth read but does not go through either builder, so it
-    // is not counted here.
-    assertEquals(executed.size(), 3, executed.toString());
+    // The inconclusive single-statement read, then the three the paged path needs: the scan-start
+    // query, the current-rows query and the query for rows deleted since scan start.
+    assertEquals(executed.size(), 4, executed.toString());
   }
 
   /**
@@ -2731,31 +2730,12 @@ public class EbeanLocalRelationshipQueryDAOTest {
         expected);
   }
 
-  /** Records every statement the DAO executes so a test can assert how many reads a call costs. */
+  /** Records every relationship read the DAO executes so a test can assert how many a call costs. */
   private EbeanLocalRelationshipQueryDAO countingQueryDAO(List<String> executed) {
     return new EbeanLocalRelationshipQueryDAO(_server, _eBeanDAOConfig) {
       @Override
-      public String buildFindRelationshipKeysetCurrentSQL(String relationshipTableName,
-          LocalRelationshipFilter relationshipFilter, String sourceTableName,
-          LocalRelationshipFilter sourceEntityFilter, String destTableName,
-          LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId) {
-        String sql = super.buildFindRelationshipKeysetCurrentSQL(relationshipTableName, relationshipFilter,
-            sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter, pageSize, lastId, maxId);
+      protected void beforeRelationshipQueryExecuted(String sql) {
         executed.add(sql);
-        return sql;
-      }
-
-      @Override
-      public String buildFindRelationshipKeysetDeletedSinceScanStartSQL(String relationshipTableName,
-          LocalRelationshipFilter relationshipFilter, String sourceTableName,
-          LocalRelationshipFilter sourceEntityFilter, String destTableName,
-          LocalRelationshipFilter destinationEntityFilter, int pageSize, long lastId, long maxId,
-          String scanStartTime) {
-        String sql = super.buildFindRelationshipKeysetDeletedSinceScanStartSQL(relationshipTableName,
-            relationshipFilter, sourceTableName, sourceEntityFilter, destTableName, destinationEntityFilter,
-            pageSize, lastId, maxId, scanStartTime);
-        executed.add(sql);
-        return sql;
       }
     };
   }

--- a/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
+++ b/dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/localrelationship/EbeanLocalRelationshipQueryDAOTest.java
@@ -2814,7 +2814,10 @@ public class EbeanLocalRelationshipQueryDAOTest {
         .findOne();
     assertEquals(liveRow.getLong("live_count").longValue(), 1L);
 
-    List<ReportsTo> drained = drainKeyset(10);
+    // Page size 1 rather than something larger: a result that fits inside one page is read with a
+    // single statement, and Query B never runs, so the guard this test provides for the scan-start
+    // timestamp would be lost.
+    List<ReportsTo> drained = drainKeyset(1);
     assertEquals(drained.size(), 1);
     assertEquals(makeFooUrn(drained.get(0).getSource().toString()), source);
   }


### PR DESCRIPTION
## Summary

Reads a relationship result that fits inside one page with a single statement instead of paging it.

Keyset pagination (META-24161) replaced an unpaged read costing **one** statement with a paged read
costing **three** on the first page: scan start, current rows, and rows deleted since scan start.
Most reads on this table return far less than a page, so nearly every caller now pays three reads for
what used to take one. That is part of the latency regression in META-24388.

The first page is now read with one statement. A short page proves the whole result was returned, so
the other two are unnecessary: the scan-start bound only excludes rows inserted mid-scan, and there
is no second page to stay consistent with; the deleted-since-scan-start query only reconciles a soft
delete landing between two statements, and one statement reads one snapshot. The result matches what
the unpaged read produced before pagination.

A full page is treated as **inconclusive**, not complete. The row count cannot distinguish a result
that is exactly one page long from a longer one, and reading `pageSize + 1` would exceed the page
size bound the SQL builder enforces. Guessing wrong would silently drop rows, so that case pages as
before, costing one extra read on the first page only.

Only the first page is affected. Calls that pass a cursor are untouched.

## Why this is worth it

Counting rows per destination inside an id slice understates the total, because a destination's rows
are spread fairly evenly across the id range rather than clustered. True totals for the largest
destinations in a slice were 976, 990, 1027 and 1057 rows, against roughly four rows apiece inside a
0.4% slice, so a slice count near four corresponds to about a full page overall. That is the
threshold below.

| bucket | destinations | rows |
|---|---|---|
| likely fits one page | **62,915** (92.7%) | 74,531 |
| likely larger than one page | 4,922 (7.3%) | 233,823 |

At that hit rate roughly 1.8 of the 3 statements are saved per call. The 7.3% that fall back are the
row-heavy destinations, where one extra read against a scan that always spanned several pages is
marginal. The supernode in this table, at tens of millions of rows, stays on the paged path.

Two caveats. The threshold is derived from the even-spread observation rather than measured per
destination, so it is an estimate. And this counts destinations, not requests: if traffic
concentrates on larger datasets the hit rate is lower. The fast path is fail-safe either way, since a
wrong guess falls back and costs one extra read.

<details>
<summary>Queries behind these numbers (run on prod-shaped <code>metagalaxy</code>)</summary>

```sql
-- Bucket destinations by slice count. A slice count near 4 corresponds to about
-- one page overall; see the true-totals query below for where that comes from.
SELECT CASE WHEN c <= 4 THEN 'likely <=1000 total' ELSE 'likely >1000 total' END AS bucket,
       COUNT(*) AS destinations,
       SUM(c)   AS rows_in_bucket
FROM (
  SELECT destination, COUNT(*) AS c
  FROM metadata_relationship_downstreamof
  WHERE deleted_ts IS NULL
    AND id BETWEEN 518000000 AND 520054379   -- ~2M ids, about 0.4% of the table
  GROUP BY destination
) t
GROUP BY bucket;

-- True totals, no id filter, for the largest destinations in a slice. Forcing the
-- index keeps this to a few range scans. Returned 976, 990, 1027 and 1057.
SELECT destination, COUNT(*) AS total_rows
FROM metadata_relationship_downstreamof FORCE INDEX (idx_destination_deleted_ts)
WHERE deleted_ts IS NULL
  AND destination IN ('<urn>', '<urn>', '<urn>', '<urn>')
GROUP BY destination;
```

Pick the urns for the second query from the first slice, largest first. Excluding the supernode
keeps the query under the cost guard.

</details>

## Testing Done

```
./gradlew :dao-impl:ebean-dao:compileJava :dao-impl:ebean-dao:compileTestJava   BUILD SUCCESSFUL
./gradlew :dao-impl:ebean-dao:checkstyleMain :dao-impl:ebean-dao:checkstyleTest BUILD SUCCESSFUL
```

DB-backed tests cannot run on this machine (`EmbeddedMariaInstance` does not start, so those classes
fail at `@BeforeClass init` on master too) and rely on CI.

Tests added:

- `testFindRelationshipsByKeysetReadsShortResultInOneStatement`: counts statements rather than rows,
  since the saving is the point and a row-count assertion would not notice it.
- `testFindRelationshipsByKeysetFullFirstPageStillPages`: a full first page pages normally and still
  reports the scan's `maxId`.
- `testFindRelationshipsByKeysetMultiPageStillCompleteWithFastPath`: a multi-page result is returned
  in full, so the added read cannot drop rows on the path it does not short-circuit.

One existing test changed.
`testFindRelationshipsByKeysetDedupsRowDeletedBetweenCurrentAndDeletedQueries` used a page size of 10
on a single-row table, which now takes the single-statement path where the race it covers cannot
occur. Its page size is now 1 so it still exercises the two-statement path it was written for;
assertions are unchanged.

## Notes for reviewers

`getMaxId()` is reported differently on the fast path: the paged path reports the largest id in the
table when paging started, the single-statement path reports the largest id it returned. The value is
unused by any consumer in this repo, metadata-store or metadata-graph-query, and
`RelationshipKeysetPage` only constrains it when a cursor is present, which the fast path never
produces.

The single statement is the ordinary current-rows query, so it keeps whatever index hint the builder
would emit for a paged read, including `FORCE INDEX (idx_destination_deleted_ts)` from #637.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
